### PR TITLE
docs(governance): IL-PROT-01 branch protection policy and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,25 @@
+# CODEOWNERS — banxe-emi-stack
+# IL-PROT-01 (Sprint 42) | Effective: 2026-04-27
+#
+# All pull requests require review from the code owner of the
+# modified path. GitHub enforces this when "Require review from
+# CODEOWNERS" is enabled in branch protection settings.
+#
+# Syntax: <pattern> <@owner> [<@owner2> ...]
+# Patterns follow .gitignore rules; last matching pattern wins.
+
+# Default owner for everything not matched below
+*                                @mmber
+
+# Compliance-critical service paths (FCA CASS 15 / PS22/9)
+/services/complaints/            @mmber
+/services/fatca_crs/             @mmber
+/services/customer_lifecycle/    @mmber
+/services/client_statements/     @mmber
+
+# CI/CD workflows — changes require extra scrutiny
+/.github/workflows/              @mmber
+
+# Claude Code configuration — policy files
+/.claude/                        @mmber
+/CLAUDE.md                       @mmber

--- a/docs/governance/branch-protection.md
+++ b/docs/governance/branch-protection.md
@@ -1,0 +1,95 @@
+# Branch Protection Policy — banxe-emi-stack
+
+**IL:** IL-PROT-01 (Sprint 42)
+**Effective:** 2026-04-27
+**Configured via:** GitHub UI (Settings → Branches → Branch protection rules)
+
+> This document is the canonical description of branch protection rules.
+> The authoritative enforcement is in GitHub's branch protection settings.
+> `gh api` is never used to configure these rules — all changes via GitHub UI only.
+
+---
+
+## Scope
+
+| Branch | Protected |
+|--------|-----------|
+| `main` | ✅ Yes |
+| `feat/*`, `fix/*`, `chore/*` | No (feature branches are ephemeral) |
+
+---
+
+## Required Pull Request Reviews
+
+| Setting | Value |
+|---------|-------|
+| Minimum approvals required | 1 |
+| Dismiss stale reviews on new push | Yes |
+| Require review from CODEOWNERS | Yes (see `.github/CODEOWNERS`) |
+| Restrict who can dismiss reviews | No additional restriction |
+
+---
+
+## Required Status Checks
+
+All of the following checks must pass before merge is allowed:
+
+| Check name | Workflow | Notes |
+|------------|----------|-------|
+| `Ruff lint + format` | `quality-gate.yml` | Python lint + format |
+| `Biome lint + format (Frontend)` | `quality-gate.yml` | Frontend lint |
+| `Semgrep (banxe-rules)` | `quality-gate.yml` | SAST / custom rules |
+| `Gitleaks - Secrets Scan` | `quality-gate.yml` | Secrets detection |
+| `Pytest (coverage >= 80%)` | `quality-gate.yml` | Test suite + coverage |
+| `Vitest (frontend)` | `quality-gate.yml` | Frontend tests |
+| `CodeRabbit` | External | AI code review |
+
+> **Note:** `claude-review` workflow was removed in IL-REVW-01 (PR #13, commit `dd027cb`).
+> It does not appear in required checks.
+
+---
+
+## Branch Restrictions
+
+| Setting | Value |
+|---------|-------|
+| Allow force pushes | ❌ No |
+| Allow branch deletions | ❌ No |
+| Require linear history (squash-only) | ✅ Yes |
+| Include administrators | ✅ Yes (admins not exempt) |
+
+---
+
+## CODEOWNERS
+
+Defined in `.github/CODEOWNERS`. All paths owned by `@mmber`.
+Critical paths with explicit ownership:
+
+| Path | Owner |
+|------|-------|
+| `*` (all files) | `@mmber` |
+| `/services/complaints/` | `@mmber` |
+| `/services/fatca_crs/` | `@mmber` |
+| `/services/customer_lifecycle/` | `@mmber` |
+| `/services/client_statements/` | `@mmber` |
+| `/.github/workflows/` | `@mmber` |
+| `/.claude/` | `@mmber` |
+| `/CLAUDE.md` | `@mmber` |
+
+---
+
+## Rationale
+
+- Linear history ensures a clean, bisectable `git log` on `main`.
+- Admin inclusion prevents privileged bypass of required checks.
+- CODEOWNERS ensures the primary maintainer reviews all changes,
+  especially in compliance-critical service paths.
+- No `gh secret set` / `gh api` for protection rules — all changes
+  are human-initiated via GitHub UI to maintain audit trail.
+
+## Related
+
+- IL-PROT-01: `banxe-architecture/instruction-ledger/sprint-42/IL-PROT-01-branch-protection-main.md`
+- IL-REVW-01: removal of `claude-review` workflow (PR #13)
+- IL-SEC-01: secrets posture review (Sprint 42)
+- `.github/CODEOWNERS` (this repo)


### PR DESCRIPTION
## Summary

Closes #9

Adds canonical branch protection documentation and CODEOWNERS for `banxe-emi-stack`.

IL file: [`instruction-ledger/sprint-42/IL-PROT-01-branch-protection-main.md`](https://github.com/CarmiBanxe/banxe-architecture/blob/feat/sprint-42-bootstrap/instruction-ledger/sprint-42/IL-PROT-01-branch-protection-main.md)

Cross-link: CarmiBanxe/banxe-architecture (same branch, companion PR)

## Changes

**`docs/governance/branch-protection.md`** (new)
- Protected branch: `main` only
- Required reviews: 1, dismiss stale on new push, require CODEOWNERS
- Required status checks: Ruff, Biome, Semgrep, Gitleaks, Pytest, Vitest, CodeRabbit
- Restrictions: no force-push, no branch deletion, linear history (squash-only)
- Admins included in restrictions (no bypass)
- Note: `claude-review` removed in IL-REVW-01 — not in required checks

**`.github/CODEOWNERS`** (new)
- Default owner: `@mmber` for all paths (`*`)
- Explicit entries for compliance-critical services: `complaints/`, `fatca_crs/`, `customer_lifecycle/`, `client_statements/`
- Explicit entries for: `.github/workflows/`, `.claude/`, `CLAUDE.md`

## Rationale

Branch protection settings are configured via GitHub UI only — no `gh api` calls.
This document is the canonical reference; the UI settings are the enforcement layer.
Linear history keeps `git log` on `main` bisectable.
Admin inclusion prevents privileged bypass of required checks.

## Test plan

- [x] Pre-commit auditor: ✅ PASS (both commits)
- [x] Pytest: ✅ PASS (no Python files changed)
- [x] Semgrep: ✅ PASS
- [x] Code-guardian: ✅ APPROVE (all paths in CODEOWNERS verified to exist)
- [x] Workflow job names verified against `quality-gate.yml`
- [ ] CI checks (running after PR creation)
- [ ] Branch protection configured in GitHub UI by owner after merge

## Risks

- Low: doc-only change, no source code, no migrations
- Branch protection UI settings must be applied manually after merge — tracked in issue #9 checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
