### PR TITLE
feat(pay): payment authorization guard [IL-PAY-01]

### DIFF
--- a/services/payment/payment_auth_guard.py
+++ b/services/payment/payment_auth_guard.py
@@ -1,0 +1,219 @@
+"""
+services/payment/payment_auth_guard.py
+Payment Authorization Guard (IL-PAY-01).
+
+Wraps PaymentService with pre-flight compliance checks:
+  - Customer lifecycle state must be ACTIVE (LifecycleStatePort)
+  - KYC must be APPROVED (KYCApprovalPort)
+  - Beneficiary jurisdiction must not be blocked (I-02)
+  - Amount must be positive Decimal (I-01)
+  - EDD amounts ≥ threshold require HITL L4 proposal (I-04, I-27)
+
+I-01: all monetary comparisons use Decimal — never float.
+I-02: blocked jurisdictions hard-blocked before any payment submission.
+I-04: EDD threshold £10k individual / £50k corporate triggers HITLProposal.
+I-27: EDD-level payments PROPOSE only — human approves, never auto-submitted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Protocol
+
+from services.aml.aml_thresholds import get_thresholds
+from services.customer_lifecycle.lifecycle_engine import BLOCKED_JURISDICTIONS
+from services.customer_lifecycle.lifecycle_models import CustomerState
+from services.kyc.kyc_port import KYCStatus
+
+# ── Narrow ports ──────────────────────────────────────────────────────────────
+
+
+class LifecycleStatePort(Protocol):
+    """Narrow port: only the customer's current state is needed."""
+
+    def get_state(self, customer_id: str) -> CustomerState: ...
+
+
+class KYCApprovalPort(Protocol):
+    """Narrow port: only the KYC approval status is needed."""
+
+    def get_status(self, customer_id: str) -> KYCStatus: ...
+
+
+# ── In-memory stubs ───────────────────────────────────────────────────────────
+
+
+class InMemoryLifecycleStatePort:
+    """Configurable stub: set state per customer_id."""
+
+    def __init__(self, default: CustomerState = CustomerState.ACTIVE) -> None:
+        self._states: dict[str, CustomerState] = {}
+        self._default = default
+
+    def set_state(self, customer_id: str, state: CustomerState) -> None:
+        self._states[customer_id] = state
+
+    def get_state(self, customer_id: str) -> CustomerState:
+        return self._states.get(customer_id, self._default)
+
+
+class InMemoryKYCApprovalPort:
+    """Configurable stub: set KYC status per customer_id."""
+
+    def __init__(self, default: KYCStatus = KYCStatus.APPROVED) -> None:
+        self._statuses: dict[str, KYCStatus] = {}
+        self._default = default
+
+    def set_status(self, customer_id: str, status: KYCStatus) -> None:
+        self._statuses[customer_id] = status
+
+    def get_status(self, customer_id: str) -> KYCStatus:
+        return self._statuses.get(customer_id, self._default)
+
+
+# ── Result / proposal types ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PaymentAuthApproved:
+    """Payment pre-flight checks passed — safe to submit."""
+
+    customer_id: str
+    amount: str  # Decimal as string (I-01, I-05)
+    currency: str
+    beneficiary_jurisdiction: str
+    authorized_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass
+class HITLProposal:
+    """Payment exceeds EDD threshold — HITL L4 required before submission (I-27)."""
+
+    customer_id: str
+    amount: str  # Decimal as string (I-01, I-05)
+    currency: str
+    beneficiary_jurisdiction: str
+    reason: str
+    requires_approval_from: str = "MLRO"
+    proposed_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+# ── Guard errors ──────────────────────────────────────────────────────────────
+
+
+class CustomerNotActiveError(ValueError):
+    """Raised when the customer lifecycle state is not ACTIVE."""
+
+
+class KYCRequiredError(ValueError):
+    """Raised when the customer's KYC is not APPROVED."""
+
+
+class JurisdictionBlockedError(ValueError):
+    """Raised when the beneficiary jurisdiction is sanctioned (I-02)."""
+
+
+class InvalidPaymentAmountError(ValueError):
+    """Raised when the payment amount is zero or negative (I-01)."""
+
+
+# ── Payment Authorization Guard ───────────────────────────────────────────────
+
+
+class PaymentAuthGuard:
+    """
+    Pre-flight authorization guard for outbound payments (IL-PAY-01).
+
+    I-01: amount comparisons are Decimal — never float.
+    I-02: blocked jurisdictions raise JurisdictionBlockedError immediately.
+    I-04: amounts ≥ EDD threshold return HITLProposal instead of approval.
+    I-27: EDD-level payments are never auto-submitted; human approval required.
+    """
+
+    def __init__(
+        self,
+        lifecycle: LifecycleStatePort | None = None,
+        kyc: KYCApprovalPort | None = None,
+        entity_type: str = "INDIVIDUAL",
+    ) -> None:
+        self._lifecycle: LifecycleStatePort = lifecycle or InMemoryLifecycleStatePort()
+        self._kyc: KYCApprovalPort = kyc or InMemoryKYCApprovalPort()
+        self._entity_type = entity_type
+
+    def authorize(
+        self,
+        customer_id: str,
+        amount: Decimal,  # I-01: Decimal ONLY
+        currency: str,
+        beneficiary_jurisdiction: str,
+    ) -> PaymentAuthApproved | HITLProposal:
+        """Run pre-flight compliance checks for a payment.
+
+        Returns PaymentAuthApproved when all guards pass and amount is below EDD.
+        Returns HITLProposal when amount meets or exceeds EDD threshold (I-04, I-27).
+
+        Raises:
+            InvalidPaymentAmountError: amount ≤ 0.
+            JurisdictionBlockedError: beneficiary jurisdiction is sanctioned (I-02).
+            CustomerNotActiveError: customer lifecycle state is not ACTIVE.
+            KYCRequiredError: customer KYC is not APPROVED.
+        """
+        self._check_amount(amount)
+        self._check_jurisdiction(beneficiary_jurisdiction)
+        self._check_lifecycle(customer_id)
+        self._check_kyc(customer_id)
+
+        thresholds = get_thresholds(self._entity_type)
+        amount_str = str(amount)
+
+        if amount >= thresholds.edd_trigger:  # I-01: Decimal comparison, I-04
+            return HITLProposal(
+                customer_id=customer_id,
+                amount=amount_str,
+                currency=currency,
+                beneficiary_jurisdiction=beneficiary_jurisdiction,
+                reason=(
+                    f"Payment of {currency} {amount} meets EDD threshold "
+                    f"({self._entity_type} ≥ {thresholds.edd_trigger}). "
+                    "MLRO approval required before submission (I-04, I-27)."
+                ),
+            )
+
+        return PaymentAuthApproved(
+            customer_id=customer_id,
+            amount=amount_str,
+            currency=currency,
+            beneficiary_jurisdiction=beneficiary_jurisdiction,
+        )
+
+    # ── Private guard methods ─────────────────────────────────────────────────
+
+    def _check_amount(self, amount: Decimal) -> None:
+        if amount <= Decimal("0"):  # I-01: Decimal comparison
+            raise InvalidPaymentAmountError(
+                f"Payment amount must be positive; got {amount!r} (I-01)."
+            )
+
+    def _check_jurisdiction(self, jurisdiction: str) -> None:
+        if jurisdiction.upper() in BLOCKED_JURISDICTIONS:
+            raise JurisdictionBlockedError(
+                f"Beneficiary jurisdiction {jurisdiction!r} is sanctioned and blocked (I-02)."
+            )
+
+    def _check_lifecycle(self, customer_id: str) -> None:
+        state = self._lifecycle.get_state(customer_id)
+        if state != CustomerState.ACTIVE:
+            raise CustomerNotActiveError(
+                f"Customer {customer_id!r} lifecycle state is {state.value!r}; "
+                "ACTIVE required to initiate payments."
+            )
+
+    def _check_kyc(self, customer_id: str) -> None:
+        status = self._kyc.get_status(customer_id)
+        if status != KYCStatus.APPROVED:
+            raise KYCRequiredError(
+                f"Customer {customer_id!r} KYC status is {status.value!r}; "
+                "APPROVED required to initiate payments."
+            )

--- a/tests/test_payment_auth_guard.py
+++ b/tests/test_payment_auth_guard.py
@@ -1,0 +1,267 @@
+"""Tests for Payment Authorization Guard (IL-PAY-01)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.customer_lifecycle.lifecycle_models import CustomerState
+from services.kyc.kyc_port import KYCStatus
+from services.payment.payment_auth_guard import (
+    CustomerNotActiveError,
+    HITLProposal,
+    InMemoryKYCApprovalPort,
+    InMemoryLifecycleStatePort,
+    InvalidPaymentAmountError,
+    JurisdictionBlockedError,
+    KYCRequiredError,
+    PaymentAuthApproved,
+    PaymentAuthGuard,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _guard(
+    state: CustomerState = CustomerState.ACTIVE,
+    kyc_status: KYCStatus = KYCStatus.APPROVED,
+    entity_type: str = "INDIVIDUAL",
+) -> PaymentAuthGuard:
+    lc = InMemoryLifecycleStatePort(default=state)
+    kyc = InMemoryKYCApprovalPort(default=kyc_status)
+    return PaymentAuthGuard(lifecycle=lc, kyc=kyc, entity_type=entity_type)
+
+
+def _authorize(
+    guard: PaymentAuthGuard,
+    amount: str = "500",
+    currency: str = "GBP",
+    jurisdiction: str = "GB",
+    customer_id: str = "C-001",
+) -> PaymentAuthApproved | HITLProposal:
+    return guard.authorize(
+        customer_id=customer_id,
+        amount=Decimal(amount),
+        currency=currency,
+        beneficiary_jurisdiction=jurisdiction,
+    )
+
+
+# ── Happy-path: PaymentAuthApproved ──────────────────────────────────────────
+
+
+class TestPaymentAuthApproved:
+    def test_active_kyc_approved_below_edd_returns_approved(self) -> None:
+        guard = _guard()
+        result = _authorize(guard, amount="500")
+        assert isinstance(result, PaymentAuthApproved)
+
+    def test_approved_fields(self) -> None:
+        guard = _guard()
+        result = _authorize(guard, amount="999.99", currency="EUR", jurisdiction="FR")
+        assert isinstance(result, PaymentAuthApproved)
+        assert result.customer_id == "C-001"
+        assert result.currency == "EUR"
+        assert result.beneficiary_jurisdiction == "FR"
+        assert result.amount == "999.99"
+
+    def test_amount_stored_as_string(self) -> None:
+        """I-01, I-05: amount in result is a plain string, not float."""
+        guard = _guard()
+        result = _authorize(guard, amount="1234.56")
+        assert isinstance(result, PaymentAuthApproved)
+        assert isinstance(result.amount, str)
+        assert Decimal(result.amount) == Decimal("1234.56")
+
+    def test_authorized_at_is_set(self) -> None:
+        guard = _guard()
+        result = _authorize(guard)
+        assert isinstance(result, PaymentAuthApproved)
+        assert result.authorized_at  # non-empty ISO timestamp
+
+    def test_exactly_one_below_edd_threshold_approved(self) -> None:
+        """£9999.99 is below INDIVIDUAL EDD threshold of £10k."""
+        guard = _guard()
+        result = _authorize(guard, amount="9999.99")
+        assert isinstance(result, PaymentAuthApproved)
+
+    def test_per_customer_state_override(self) -> None:
+        lc = InMemoryLifecycleStatePort(default=CustomerState.SUSPENDED)
+        lc.set_state("C-OK", CustomerState.ACTIVE)
+        kyc = InMemoryKYCApprovalPort()
+        guard = PaymentAuthGuard(lifecycle=lc, kyc=kyc)
+        result = guard.authorize("C-OK", Decimal("100"), "GBP", "GB")
+        assert isinstance(result, PaymentAuthApproved)
+
+
+# ── EDD threshold: HITLProposal (I-04, I-27) ─────────────────────────────────
+
+
+class TestHITLProposal:
+    def test_at_edd_threshold_returns_hitl(self) -> None:
+        """£10,000 exactly meets INDIVIDUAL EDD threshold → HITLProposal."""
+        guard = _guard()
+        result = _authorize(guard, amount="10000")
+        assert isinstance(result, HITLProposal)
+
+    def test_above_edd_threshold_returns_hitl(self) -> None:
+        guard = _guard()
+        result = _authorize(guard, amount="50000")
+        assert isinstance(result, HITLProposal)
+
+    def test_hitl_fields(self) -> None:
+        guard = _guard()
+        result = _authorize(guard, amount="10000", currency="GBP", jurisdiction="DE")
+        assert isinstance(result, HITLProposal)
+        assert result.customer_id == "C-001"
+        assert result.amount == "10000"
+        assert result.currency == "GBP"
+        assert result.beneficiary_jurisdiction == "DE"
+        assert result.requires_approval_from == "MLRO"
+
+    def test_hitl_reason_mentions_edd(self) -> None:
+        guard = _guard()
+        result = _authorize(guard, amount="15000")
+        assert isinstance(result, HITLProposal)
+        assert "EDD" in result.reason or "edd" in result.reason.lower()
+
+    def test_hitl_amount_is_string(self) -> None:
+        """I-01: amount stored as Decimal string in HITLProposal."""
+        guard = _guard()
+        result = _authorize(guard, amount="10000")
+        assert isinstance(result, HITLProposal)
+        assert isinstance(result.amount, str)
+        assert Decimal(result.amount) == Decimal("10000")
+
+    def test_corporate_edd_threshold_is_50k(self) -> None:
+        """COMPANY EDD threshold is £50k (I-04) — £49,999.99 approved."""
+        guard = _guard(entity_type="COMPANY")
+        result = _authorize(guard, amount="49999.99")
+        assert isinstance(result, PaymentAuthApproved)
+
+    def test_corporate_at_50k_hitl(self) -> None:
+        guard = _guard(entity_type="COMPANY")
+        result = _authorize(guard, amount="50000")
+        assert isinstance(result, HITLProposal)
+
+
+# ── Guard failures ────────────────────────────────────────────────────────────
+
+
+class TestInvalidAmount:
+    def test_zero_amount_raises(self) -> None:
+        guard = _guard()
+        with pytest.raises(InvalidPaymentAmountError):
+            guard.authorize("C-001", Decimal("0"), "GBP", "GB")
+
+    def test_negative_amount_raises(self) -> None:
+        guard = _guard()
+        with pytest.raises(InvalidPaymentAmountError):
+            guard.authorize("C-001", Decimal("-100"), "GBP", "GB")
+
+    def test_amount_check_runs_before_jurisdiction(self) -> None:
+        """Amount guard is first — blocked jurisdiction not reached yet."""
+        guard = _guard()
+        with pytest.raises(InvalidPaymentAmountError):
+            guard.authorize("C-001", Decimal("0"), "GBP", "RU")
+
+
+class TestJurisdictionBlocked:
+    @pytest.mark.parametrize("country", ["RU", "BY", "IR", "KP", "CU", "MM", "AF", "VE", "SY"])
+    def test_all_blocked_jurisdictions_raise(self, country: str) -> None:
+        guard = _guard()
+        with pytest.raises(JurisdictionBlockedError):
+            _authorize(guard, jurisdiction=country)
+
+    def test_jurisdiction_checked_case_insensitive(self) -> None:
+        guard = _guard()
+        with pytest.raises(JurisdictionBlockedError):
+            _authorize(guard, jurisdiction="ru")
+
+    def test_gb_jurisdiction_allowed(self) -> None:
+        guard = _guard()
+        result = _authorize(guard, jurisdiction="GB")
+        assert isinstance(result, PaymentAuthApproved)
+
+    def test_jurisdiction_check_before_lifecycle(self) -> None:
+        """Jurisdiction guard runs before lifecycle — blocked even for suspended customer."""
+        guard = _guard(state=CustomerState.SUSPENDED)
+        with pytest.raises(JurisdictionBlockedError):
+            _authorize(guard, jurisdiction="RU")
+
+
+class TestCustomerNotActive:
+    @pytest.mark.parametrize(
+        "state",
+        [
+            CustomerState.PROSPECT,
+            CustomerState.ONBOARDING,
+            CustomerState.KYC_PENDING,
+            CustomerState.SUSPENDED,
+            CustomerState.CLOSED,
+            CustomerState.OFFBOARDED,
+        ],
+    )
+    def test_non_active_states_raise(self, state: CustomerState) -> None:
+        guard = _guard(state=state)
+        with pytest.raises(CustomerNotActiveError):
+            _authorize(guard)
+
+    def test_error_message_contains_state(self) -> None:
+        guard = _guard(state=CustomerState.SUSPENDED)
+        with pytest.raises(CustomerNotActiveError, match="suspended"):
+            _authorize(guard)
+
+    def test_lifecycle_check_before_kyc(self) -> None:
+        """Lifecycle guard runs before KYC — suspended customer with bad KYC gets lifecycle error."""
+        guard = _guard(state=CustomerState.SUSPENDED, kyc_status=KYCStatus.PENDING)
+        with pytest.raises(CustomerNotActiveError):
+            _authorize(guard)
+
+
+class TestKYCRequired:
+    @pytest.mark.parametrize(
+        "status",
+        [KYCStatus.PENDING, KYCStatus.REJECTED, KYCStatus.EXPIRED],
+    )
+    def test_non_approved_kyc_raises(self, status: KYCStatus) -> None:
+        guard = _guard(kyc_status=status)
+        with pytest.raises(KYCRequiredError):
+            _authorize(guard)
+
+    def test_error_message_contains_status(self) -> None:
+        guard = _guard(kyc_status=KYCStatus.PENDING)
+        with pytest.raises(KYCRequiredError, match="PENDING"):
+            _authorize(guard)
+
+
+# ── Stub isolation ────────────────────────────────────────────────────────────
+
+
+class TestStubs:
+    def test_inmemory_lifecycle_default_active(self) -> None:
+        port = InMemoryLifecycleStatePort()
+        assert port.get_state("any") == CustomerState.ACTIVE
+
+    def test_inmemory_lifecycle_set_and_get(self) -> None:
+        port = InMemoryLifecycleStatePort()
+        port.set_state("C-X", CustomerState.SUSPENDED)
+        assert port.get_state("C-X") == CustomerState.SUSPENDED
+        assert port.get_state("C-Y") == CustomerState.ACTIVE  # default unchanged
+
+    def test_inmemory_kyc_default_approved(self) -> None:
+        port = InMemoryKYCApprovalPort()
+        assert port.get_status("any") == KYCStatus.APPROVED
+
+    def test_inmemory_kyc_set_and_get(self) -> None:
+        port = InMemoryKYCApprovalPort()
+        port.set_status("C-X", KYCStatus.PENDING)
+        assert port.get_status("C-X") == KYCStatus.PENDING
+        assert port.get_status("C-Y") == KYCStatus.APPROVED
+
+    def test_no_ports_injected_uses_defaults(self) -> None:
+        """Default guard (no args) approves ACTIVE+APPROVED customer below EDD."""
+        guard = PaymentAuthGuard()
+        result = guard.authorize("C-001", Decimal("100"), "GBP", "GB")
+        assert isinstance(result, PaymentAuthApproved)


### PR DESCRIPTION
## Summary

- **`services/payment/payment_auth_guard.py`** — `PaymentAuthGuard` with Protocol DI ports (`LifecycleStatePort`, `KYCApprovalPort`), InMemory stubs, guard errors, and result types (`PaymentAuthApproved`, `HITLProposal`)
- Guard order: amount → jurisdiction (I-02) → lifecycle → KYC → EDD threshold (I-04, I-27)
- 45 tests across 7 classes; all gates green (ruff, bandit, semgrep, pytest)

## Invariants enforced

| ID | Rule |
|----|------|
| I-01 | `Decimal` only; amounts serialised as strings in results |
| I-02 | 9 blocked jurisdictions hard-blocked before any lifecycle check |
| I-04 | EDD threshold £10k INDIVIDUAL / £50k COMPANY → `HITLProposal` |
| I-27 | EDD-level payments propose only — `requires_approval_from="MLRO"` |

## Test plan

- [x] Happy path: ACTIVE + APPROVED + below EDD → `PaymentAuthApproved`
- [x] EDD boundary: ≥£10k INDIVIDUAL / ≥£50k COMPANY → `HITLProposal`
- [x] Guard order: amount first, then jurisdiction, then lifecycle, then KYC
- [x] All 9 blocked jurisdictions + case-insensitive match
- [x] All 6 non-ACTIVE lifecycle states raise `CustomerNotActiveError`
- [x] PENDING/REJECTED/EXPIRED KYC raises `KYCRequiredError`
- [x] InMemory stub isolation (default states, per-customer override, no-args guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented payment authorization system with automatic compliance checks: jurisdiction validation, customer lifecycle verification, and KYC approval confirmation
  * Transactions exceeding Enhanced Due Diligence (EDD) thresholds now require human review and approval before processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->