### PR TITLE
feat(pay): payment processing service — auth/capture/settle/refund [IL-PAY-02]

### DIFF
--- a/services/payment/currency_validator.py
+++ b/services/payment/currency_validator.py
@@ -1,0 +1,81 @@
+"""
+services/payment/currency_validator.py
+Multi-currency validation for payment processing (IL-PAY-02).
+
+I-01: All monetary comparisons use Decimal — never float.
+I-02: Blocked jurisdictions checked before currency validation.
+I-04: EDD thresholds enforced per currency.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from services.payment.payment_models import SUPPORTED_CURRENCIES
+
+
+class CurrencyValidationError(ValueError):
+    """Raised when currency validation fails."""
+
+
+class AmountValidationError(ValueError):
+    """Raised when amount validation fails."""
+
+
+# Scheme limits per currency (Decimal, I-01).
+SCHEME_LIMITS: dict[str, Decimal] = {
+    "GBP": Decimal("1000000"),    # FPS scheme limit £1M
+    "EUR": Decimal("100000"),     # SEPA Instant €100k (SEPA CT unlimited)
+    "USD": Decimal("10000000"),   # No hard scheme limit, internal cap $10M
+}
+
+# EDD thresholds per currency (I-04). Amounts >= trigger require HITL.
+EDD_THRESHOLDS: dict[str, Decimal] = {
+    "GBP": Decimal("10000"),
+    "EUR": Decimal("10000"),
+    "USD": Decimal("10000"),
+}
+
+# High-value thresholds requiring MLRO escalation (I-04).
+HIGH_VALUE_THRESHOLDS: dict[str, Decimal] = {
+    "GBP": Decimal("50000"),
+    "EUR": Decimal("50000"),
+    "USD": Decimal("50000"),
+}
+
+
+def validate_currency(currency: str) -> None:
+    """Validate that the currency is supported (GBP, EUR, USD)."""
+    if currency not in SUPPORTED_CURRENCIES:
+        raise CurrencyValidationError(
+            f"Unsupported currency: {currency}. "
+            f"Supported: {', '.join(sorted(SUPPORTED_CURRENCIES))}"
+        )
+
+
+def validate_amount(amount: Decimal, currency: str) -> None:
+    """Validate amount is Decimal, positive, and within scheme limits (I-01)."""
+    if not isinstance(amount, Decimal):
+        raise AmountValidationError(
+            f"Amount must be Decimal, got {type(amount).__name__} (I-01)"
+        )
+    if amount <= Decimal("0"):
+        raise AmountValidationError(f"Amount must be positive, got {amount}")
+    validate_currency(currency)
+    limit = SCHEME_LIMITS.get(currency)
+    if limit is not None and amount > limit:
+        raise AmountValidationError(
+            f"Amount {currency} {amount} exceeds scheme limit of {currency} {limit}"
+        )
+
+
+def requires_edd(amount: Decimal, currency: str) -> bool:
+    """Return True if amount meets or exceeds EDD threshold (I-04)."""
+    threshold = EDD_THRESHOLDS.get(currency, Decimal("10000"))
+    return amount >= threshold
+
+
+def requires_mlro_escalation(amount: Decimal, currency: str) -> bool:
+    """Return True if amount meets or exceeds high-value threshold (I-04)."""
+    threshold = HIGH_VALUE_THRESHOLDS.get(currency, Decimal("50000"))
+    return amount >= threshold

--- a/services/payment/payment_gateway_port.py
+++ b/services/payment/payment_gateway_port.py
@@ -1,0 +1,178 @@
+"""
+services/payment/payment_gateway_port.py
+PaymentGatewayPort Protocol — hexagonal interface for payment gateways (IL-PAY-02).
+
+Adapters: Hyperswitch (production), InMemoryGateway (tests).
+Supports full lifecycle: authorize → capture → settle → refund.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Protocol
+from uuid import uuid4
+
+from services.payment.payment_models import TransactionStatus
+
+
+@dataclass(frozen=True)
+class GatewayResponse:
+    """Immutable response from payment gateway."""
+
+    gateway_reference: str
+    status: TransactionStatus
+    amount: Decimal  # I-01
+    currency: str
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    error_code: str | None = None
+    error_message: str | None = None
+
+
+class PaymentGatewayPort(Protocol):
+    """Hexagonal port for payment gateway adapters (Hyperswitch, Stripe, etc.)."""
+
+    def authorize(
+        self,
+        transaction_id: str,
+        amount: Decimal,
+        currency: str,
+        idempotency_key: str,
+    ) -> GatewayResponse:
+        """Request authorization hold for the given amount."""
+        ...
+
+    def capture(
+        self,
+        transaction_id: str,
+        gateway_reference: str,
+        amount: Decimal,
+    ) -> GatewayResponse:
+        """Capture a previously authorized payment."""
+        ...
+
+    def refund(
+        self,
+        transaction_id: str,
+        gateway_reference: str,
+        amount: Decimal,
+    ) -> GatewayResponse:
+        """Refund a settled payment (partial or full)."""
+        ...
+
+    def get_status(self, gateway_reference: str) -> GatewayResponse:
+        """Query current status of a gateway transaction."""
+        ...
+
+
+class InMemoryGateway:
+    """In-memory stub implementing PaymentGatewayPort for unit tests."""
+
+    def __init__(self) -> None:
+        self._transactions: dict[str, GatewayResponse] = {}
+        self._idempotency_map: dict[str, GatewayResponse] = {}
+        self._fail_next: bool = False
+        self._block_jurisdictions: frozenset[str] = frozenset()
+
+    def set_fail_next(self, fail: bool = True) -> None:
+        """Configure next call to return FAILED status."""
+        self._fail_next = fail
+
+    def authorize(
+        self,
+        transaction_id: str,
+        amount: Decimal,
+        currency: str,
+        idempotency_key: str,
+    ) -> GatewayResponse:
+        # Idempotency: return cached response for duplicate key.
+        if idempotency_key in self._idempotency_map:
+            return self._idempotency_map[idempotency_key]
+
+        if self._fail_next:
+            self._fail_next = False
+            resp = GatewayResponse(
+                gateway_reference=f"gw-{uuid4().hex[:12]}",
+                status=TransactionStatus.FAILED,
+                amount=amount,
+                currency=currency,
+                error_code="DECLINED",
+                error_message="Authorization declined by issuer",
+            )
+            self._idempotency_map[idempotency_key] = resp
+            return resp
+
+        ref = f"gw-{uuid4().hex[:12]}"
+        resp = GatewayResponse(
+            gateway_reference=ref,
+            status=TransactionStatus.AUTHORIZED,
+            amount=amount,
+            currency=currency,
+        )
+        self._transactions[ref] = resp
+        self._idempotency_map[idempotency_key] = resp
+        return resp
+
+    def capture(
+        self,
+        transaction_id: str,
+        gateway_reference: str,
+        amount: Decimal,
+    ) -> GatewayResponse:
+        existing = self._transactions.get(gateway_reference)
+        if existing is None:
+            return GatewayResponse(
+                gateway_reference=gateway_reference,
+                status=TransactionStatus.FAILED,
+                amount=amount,
+                currency="GBP",
+                error_code="NOT_FOUND",
+                error_message="Gateway reference not found",
+            )
+        resp = GatewayResponse(
+            gateway_reference=gateway_reference,
+            status=TransactionStatus.CAPTURED,
+            amount=amount,
+            currency=existing.currency,
+        )
+        self._transactions[gateway_reference] = resp
+        return resp
+
+    def refund(
+        self,
+        transaction_id: str,
+        gateway_reference: str,
+        amount: Decimal,
+    ) -> GatewayResponse:
+        existing = self._transactions.get(gateway_reference)
+        if existing is None:
+            return GatewayResponse(
+                gateway_reference=gateway_reference,
+                status=TransactionStatus.FAILED,
+                amount=amount,
+                currency="GBP",
+                error_code="NOT_FOUND",
+                error_message="Gateway reference not found",
+            )
+        resp = GatewayResponse(
+            gateway_reference=gateway_reference,
+            status=TransactionStatus.REFUNDED,
+            amount=amount,
+            currency=existing.currency,
+        )
+        self._transactions[gateway_reference] = resp
+        return resp
+
+    def get_status(self, gateway_reference: str) -> GatewayResponse:
+        existing = self._transactions.get(gateway_reference)
+        if existing is None:
+            return GatewayResponse(
+                gateway_reference=gateway_reference,
+                status=TransactionStatus.FAILED,
+                amount=Decimal("0"),
+                currency="GBP",
+                error_code="NOT_FOUND",
+                error_message="Gateway reference not found",
+            )
+        return existing

--- a/services/payment/payment_models.py
+++ b/services/payment/payment_models.py
@@ -1,0 +1,116 @@
+"""
+services/payment/payment_models.py
+Payment transaction lifecycle models (IL-PAY-02).
+
+Full payment lifecycle: PENDING → AUTHORIZED → CAPTURED → SETTLED → REFUNDED/FAILED
+Covers S4-01 (initiation), S4-02 (auth), S4-03 (settlement), S4-05 (refund).
+
+I-01: All monetary values are Decimal — never float.
+I-02: Blocked jurisdictions enforced via JurisdictionBlockedError.
+I-24: Immutable audit trail via frozen dataclasses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import Enum
+
+
+class TransactionStatus(str, Enum):
+    """Full payment lifecycle states."""
+
+    PENDING = "PENDING"
+    AUTHORIZED = "AUTHORIZED"
+    CAPTURED = "CAPTURED"
+    SETTLED = "SETTLED"
+    REFUNDED = "REFUNDED"
+    PARTIALLY_REFUNDED = "PARTIALLY_REFUNDED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+    CHARGEBACK = "CHARGEBACK"
+
+
+# Valid transitions for the payment state machine.
+VALID_TRANSITIONS: dict[TransactionStatus, frozenset[TransactionStatus]] = {
+    TransactionStatus.PENDING: frozenset({
+        TransactionStatus.AUTHORIZED,
+        TransactionStatus.FAILED,
+        TransactionStatus.CANCELLED,
+    }),
+    TransactionStatus.AUTHORIZED: frozenset({
+        TransactionStatus.CAPTURED,
+        TransactionStatus.CANCELLED,
+        TransactionStatus.FAILED,
+    }),
+    TransactionStatus.CAPTURED: frozenset({
+        TransactionStatus.SETTLED,
+        TransactionStatus.FAILED,
+    }),
+    TransactionStatus.SETTLED: frozenset({
+        TransactionStatus.REFUNDED,
+        TransactionStatus.PARTIALLY_REFUNDED,
+        TransactionStatus.CHARGEBACK,
+    }),
+    TransactionStatus.PARTIALLY_REFUNDED: frozenset({
+        TransactionStatus.REFUNDED,
+        TransactionStatus.PARTIALLY_REFUNDED,
+        TransactionStatus.CHARGEBACK,
+    }),
+    TransactionStatus.REFUNDED: frozenset(),
+    TransactionStatus.FAILED: frozenset(),
+    TransactionStatus.CANCELLED: frozenset(),
+    TransactionStatus.CHARGEBACK: frozenset(),
+}
+
+SUPPORTED_CURRENCIES: frozenset[str] = frozenset({"GBP", "EUR", "USD"})
+
+
+@dataclass(frozen=True)
+class PaymentTransaction:
+    """Immutable snapshot of a payment at a point in its lifecycle (I-24)."""
+
+    transaction_id: str
+    idempotency_key: str
+    customer_id: str
+    amount: Decimal  # I-01: Decimal ONLY
+    currency: str
+    beneficiary_jurisdiction: str
+    status: TransactionStatus
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    reference: str = ""
+    refunded_amount: Decimal = Decimal("0")  # I-01: Decimal ONLY
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.amount, Decimal):
+            raise TypeError(
+                f"amount must be Decimal, got {type(self.amount).__name__} (I-01)"
+            )
+        if not isinstance(self.refunded_amount, Decimal):
+            raise TypeError(
+                f"refunded_amount must be Decimal, got {type(self.refunded_amount).__name__} (I-01)"
+            )
+        if self.amount <= Decimal("0"):
+            raise ValueError(f"amount must be positive, got {self.amount}")
+        if self.currency not in SUPPORTED_CURRENCIES:
+            raise ValueError(
+                f"unsupported currency: {self.currency} (supported: {', '.join(sorted(SUPPORTED_CURRENCIES))})"
+            )
+
+
+@dataclass(frozen=True)
+class AuditEntry:
+    """Immutable audit record for payment lifecycle events (I-24)."""
+
+    transaction_id: str
+    action: str
+    old_status: TransactionStatus | None
+    new_status: TransactionStatus
+    amount: Decimal  # I-01
+    currency: str
+    actor: str
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    details: str = ""

--- a/services/payment/payment_processing_service.py
+++ b/services/payment/payment_processing_service.py
@@ -1,0 +1,391 @@
+"""
+services/payment/payment_processing_service.py
+Core payment processing service — full lifecycle (IL-PAY-02).
+
+Lifecycle: authorize → capture → settle → refund/chargeback
+Covers S4-01 (initiation), S4-02 (auth), S4-03 (settlement), S4-05 (refund).
+
+I-01: Decimal ONLY for money.
+I-02: Blocked jurisdictions → JurisdictionBlockedError.
+I-04: EDD threshold → HITLProposal (never auto-submitted).
+I-24: Immutable audit trail for every state transition.
+I-27: HITL for high-value payments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from decimal import Decimal
+from typing import Protocol
+from uuid import uuid4
+
+from services.customer_lifecycle.lifecycle_engine import BLOCKED_JURISDICTIONS
+from services.payment.currency_validator import (
+    requires_edd,
+    requires_mlro_escalation,
+    validate_amount,
+    validate_currency,
+)
+from services.payment.payment_gateway_port import GatewayResponse, PaymentGatewayPort
+from services.payment.payment_models import (
+    VALID_TRANSITIONS,
+    AuditEntry,
+    PaymentTransaction,
+    TransactionStatus,
+)
+
+# ── Errors ───────────────────────────────────────────────────────────────────
+
+
+class JurisdictionBlockedError(ValueError):
+    """Raised when beneficiary jurisdiction is sanctioned (I-02)."""
+
+
+class InvalidTransitionError(ValueError):
+    """Raised when a payment state transition is invalid."""
+
+
+class DuplicateIdempotencyKeyError(ValueError):
+    """Raised when an idempotency key has already been used."""
+
+
+class EDDRequiredError(ValueError):
+    """Raised when EDD is required but not yet approved (I-04)."""
+
+
+class RefundExceedsAmountError(ValueError):
+    """Raised when refund amount exceeds the captured/settled amount."""
+
+
+# ── Audit Port ───────────────────────────────────────────────────────────────
+
+
+class AuditPort(Protocol):
+    """Port for recording immutable audit entries (I-24)."""
+
+    def record(self, entry: AuditEntry) -> None: ...
+
+
+class InMemoryAuditPort:
+    """In-memory audit trail for tests."""
+
+    def __init__(self) -> None:
+        self._entries: list[AuditEntry] = []
+
+    def record(self, entry: AuditEntry) -> None:
+        self._entries.append(entry)
+
+    @property
+    def entries(self) -> list[AuditEntry]:
+        return list(self._entries)
+
+
+# ── HITL result types ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class EDDHITLProposal:
+    """Payment requires EDD review — HITL L4 (I-04, I-27)."""
+
+    transaction_id: str
+    customer_id: str
+    amount: str  # Decimal as string (I-01, I-05)
+    currency: str
+    beneficiary_jurisdiction: str
+    reason: str
+    requires_approval_from: str = "MLRO"
+
+
+# ── Payment Processing Service ───────────────────────────────────────────────
+
+
+class PaymentProcessingService:
+    """
+    Core payment processing with full lifecycle management.
+
+    Injected dependencies:
+      - gateway: PaymentGatewayPort (Hyperswitch adapter / InMemory stub)
+      - audit: AuditPort (ClickHouse / InMemory stub)
+
+    All public methods enforce invariants I-01, I-02, I-04, I-24, I-27.
+    """
+
+    def __init__(
+        self,
+        gateway: PaymentGatewayPort,
+        audit: AuditPort | None = None,
+    ) -> None:
+        self._gateway = gateway
+        self._audit: AuditPort = audit or InMemoryAuditPort()
+        self._transactions: dict[str, PaymentTransaction] = {}
+        self._gateway_refs: dict[str, str] = {}  # tx_id → gateway_reference
+        self._idempotency_keys: dict[str, str] = {}  # key → tx_id
+
+    # ── Authorize ────────────────────────────────────────────────────────────
+
+    def authorize(
+        self,
+        customer_id: str,
+        amount: Decimal,
+        currency: str,
+        beneficiary_jurisdiction: str,
+        idempotency_key: str | None = None,
+        edd_approved: bool = False,
+    ) -> PaymentTransaction | EDDHITLProposal:
+        """
+        Authorize a payment. First step in the lifecycle.
+
+        Returns PaymentTransaction if authorized.
+        Returns EDDHITLProposal if EDD threshold met and not pre-approved (I-04).
+        Raises JurisdictionBlockedError if jurisdiction is sanctioned (I-02).
+        """
+        # I-01: validate amount is Decimal and positive.
+        validate_amount(amount, currency)
+        validate_currency(currency)
+
+        # I-02: block sanctioned jurisdictions.
+        jur = beneficiary_jurisdiction.upper()
+        if jur in BLOCKED_JURISDICTIONS:
+            raise JurisdictionBlockedError(
+                f"Beneficiary jurisdiction {beneficiary_jurisdiction!r} is "
+                "sanctioned and blocked (I-02)."
+            )
+
+        # Idempotency: return existing transaction for duplicate key.
+        if idempotency_key and idempotency_key in self._idempotency_keys:
+            existing_tx_id = self._idempotency_keys[idempotency_key]
+            raise DuplicateIdempotencyKeyError(
+                f"Idempotency key {idempotency_key!r} already used for "
+                f"transaction {existing_tx_id}."
+            )
+
+        # I-04: EDD threshold check.
+        if requires_edd(amount, currency) and not edd_approved:
+            tx_id = f"tx-{uuid4().hex[:12]}"
+            reason = (
+                f"Payment of {currency} {amount} meets EDD threshold. "
+                "MLRO approval required (I-04, I-27)."
+            )
+            if requires_mlro_escalation(amount, currency):
+                reason = (
+                    f"High-value payment of {currency} {amount} requires "
+                    "MLRO escalation (I-04, I-27)."
+                )
+            return EDDHITLProposal(
+                transaction_id=tx_id,
+                customer_id=customer_id,
+                amount=str(amount),
+                currency=currency,
+                beneficiary_jurisdiction=beneficiary_jurisdiction,
+                reason=reason,
+            )
+
+        # Generate transaction ID and idempotency key.
+        tx_id = f"tx-{uuid4().hex[:12]}"
+        if idempotency_key is None:
+            idempotency_key = uuid4().hex
+
+        # Submit to gateway.
+        gw_resp: GatewayResponse = self._gateway.authorize(
+            transaction_id=tx_id,
+            amount=amount,
+            currency=currency,
+            idempotency_key=idempotency_key,
+        )
+
+        status = gw_resp.status
+        tx = PaymentTransaction(
+            transaction_id=tx_id,
+            idempotency_key=idempotency_key,
+            customer_id=customer_id,
+            amount=amount,
+            currency=currency,
+            beneficiary_jurisdiction=beneficiary_jurisdiction,
+            status=status,
+            reference=f"PAY-{tx_id}",
+        )
+
+        self._transactions[tx_id] = tx
+        self._gateway_refs[tx_id] = gw_resp.gateway_reference
+        self._idempotency_keys[idempotency_key] = tx_id
+
+        # I-24: audit trail.
+        self._record_audit(
+            tx_id=tx_id,
+            action="AUTHORIZE",
+            old_status=None,
+            new_status=status,
+            amount=amount,
+            currency=currency,
+            actor=customer_id,
+        )
+
+        return tx
+
+    # ── Capture ──────────────────────────────────────────────────────────────
+
+    def capture(self, transaction_id: str) -> PaymentTransaction:
+        """Capture a previously authorized payment."""
+        tx = self._get_transaction(transaction_id)
+        self._validate_transition(tx, TransactionStatus.CAPTURED)
+
+        gw_ref = self._gateway_refs[transaction_id]
+        gw_resp = self._gateway.capture(
+            transaction_id=transaction_id,
+            gateway_reference=gw_ref,
+            amount=tx.amount,
+        )
+
+        new_tx = replace(tx, status=gw_resp.status)
+        self._transactions[transaction_id] = new_tx
+
+        self._record_audit(
+            tx_id=transaction_id,
+            action="CAPTURE",
+            old_status=tx.status,
+            new_status=gw_resp.status,
+            amount=tx.amount,
+            currency=tx.currency,
+            actor="SYSTEM",
+        )
+
+        return new_tx
+
+    # ── Settle ───────────────────────────────────────────────────────────────
+
+    def settle(self, transaction_id: str) -> PaymentTransaction:
+        """Mark a captured payment as settled."""
+        tx = self._get_transaction(transaction_id)
+        self._validate_transition(tx, TransactionStatus.SETTLED)
+
+        new_tx = replace(tx, status=TransactionStatus.SETTLED)
+        self._transactions[transaction_id] = new_tx
+
+        self._record_audit(
+            tx_id=transaction_id,
+            action="SETTLE",
+            old_status=tx.status,
+            new_status=TransactionStatus.SETTLED,
+            amount=tx.amount,
+            currency=tx.currency,
+            actor="SYSTEM",
+        )
+
+        return new_tx
+
+    # ── Refund ───────────────────────────────────────────────────────────────
+
+    def refund(
+        self,
+        transaction_id: str,
+        amount: Decimal | None = None,
+    ) -> PaymentTransaction:
+        """
+        Refund a settled payment (partial or full).
+
+        If amount is None, refund the full remaining amount.
+        Partial refunds track cumulative refunded_amount.
+        """
+        tx = self._get_transaction(transaction_id)
+
+        # Determine refund amount.
+        refund_amount = amount if amount is not None else (tx.amount - tx.refunded_amount)
+
+        if not isinstance(refund_amount, Decimal):
+            raise TypeError(
+                f"Refund amount must be Decimal, got {type(refund_amount).__name__} (I-01)"
+            )
+        if refund_amount <= Decimal("0"):
+            raise ValueError("Refund amount must be positive")
+
+        total_refunded = tx.refunded_amount + refund_amount
+        if total_refunded > tx.amount:
+            raise RefundExceedsAmountError(
+                f"Total refund {total_refunded} would exceed original amount {tx.amount}."
+            )
+
+        # Determine target status.
+        is_full_refund = total_refunded == tx.amount
+        target_status = (
+            TransactionStatus.REFUNDED if is_full_refund
+            else TransactionStatus.PARTIALLY_REFUNDED
+        )
+
+        self._validate_transition(tx, target_status)
+
+        gw_ref = self._gateway_refs[transaction_id]
+        self._gateway.refund(
+            transaction_id=transaction_id,
+            gateway_reference=gw_ref,
+            amount=refund_amount,
+        )
+
+        new_tx = replace(
+            tx,
+            status=target_status,
+            refunded_amount=total_refunded,
+        )
+        self._transactions[transaction_id] = new_tx
+
+        self._record_audit(
+            tx_id=transaction_id,
+            action="REFUND",
+            old_status=tx.status,
+            new_status=target_status,
+            amount=refund_amount,
+            currency=tx.currency,
+            actor="SYSTEM",
+            details=f"refund_amount={refund_amount}, total_refunded={total_refunded}",
+        )
+
+        return new_tx
+
+    # ── Query ────────────────────────────────────────────────────────────────
+
+    def get_transaction(self, transaction_id: str) -> PaymentTransaction | None:
+        """Return transaction by ID, or None if not found."""
+        return self._transactions.get(transaction_id)
+
+    # ── Private helpers ──────────────────────────────────────────────────────
+
+    def _get_transaction(self, transaction_id: str) -> PaymentTransaction:
+        tx = self._transactions.get(transaction_id)
+        if tx is None:
+            raise ValueError(f"Transaction {transaction_id!r} not found.")
+        return tx
+
+    def _validate_transition(
+        self,
+        tx: PaymentTransaction,
+        target: TransactionStatus,
+    ) -> None:
+        allowed = VALID_TRANSITIONS.get(tx.status, frozenset())
+        if target not in allowed:
+            raise InvalidTransitionError(
+                f"Cannot transition from {tx.status.value} to {target.value} "
+                f"for transaction {tx.transaction_id}."
+            )
+
+    def _record_audit(
+        self,
+        *,
+        tx_id: str,
+        action: str,
+        old_status: TransactionStatus | None,
+        new_status: TransactionStatus,
+        amount: Decimal,
+        currency: str,
+        actor: str,
+        details: str = "",
+    ) -> None:
+        entry = AuditEntry(
+            transaction_id=tx_id,
+            action=action,
+            old_status=old_status,
+            new_status=new_status,
+            amount=amount,
+            currency=currency,
+            actor=actor,
+            details=details,
+        )
+        self._audit.record(entry)

--- a/tests/test_payment_processing_service.py
+++ b/tests/test_payment_processing_service.py
@@ -1,0 +1,602 @@
+"""
+tests/test_payment_processing_service.py
+Tests for PaymentProcessingService (IL-PAY-02).
+
+Acceptance criteria:
+- test_payment_authorize_success (Decimal amounts, I-01)
+- test_payment_authorize_blocked_jurisdiction (I-02)
+- test_payment_capture_after_auth
+- test_payment_refund_after_capture (partial + full)
+- test_payment_duplicate_idempotency_key
+- test_payment_amount_exceeds_threshold_requires_edd (I-04)
+- test_payment_audit_trail_recorded (I-24)
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from services.payment.currency_validator import (
+    AmountValidationError,
+    CurrencyValidationError,
+    requires_edd,
+    requires_mlro_escalation,
+    validate_amount,
+    validate_currency,
+)
+from services.payment.payment_gateway_port import InMemoryGateway
+from services.payment.payment_models import (
+    SUPPORTED_CURRENCIES,
+    VALID_TRANSITIONS,
+    PaymentTransaction,
+    TransactionStatus,
+)
+from services.payment.payment_processing_service import (
+    DuplicateIdempotencyKeyError,
+    EDDHITLProposal,
+    InMemoryAuditPort,
+    InvalidTransitionError,
+    JurisdictionBlockedError,
+    PaymentProcessingService,
+    RefundExceedsAmountError,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def gateway():
+    return InMemoryGateway()
+
+
+@pytest.fixture
+def audit():
+    return InMemoryAuditPort()
+
+
+@pytest.fixture
+def service(gateway, audit):
+    return PaymentProcessingService(gateway=gateway, audit=audit)
+
+
+# ── Authorization Tests ──────────────────────────────────────────────────────
+
+
+class TestAuthorize:
+    def test_payment_authorize_success(self, service):
+        """AC: authorize with Decimal amount returns AUTHORIZED transaction (I-01)."""
+        result = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        assert isinstance(result, PaymentTransaction)
+        assert result.status == TransactionStatus.AUTHORIZED
+        assert isinstance(result.amount, Decimal)
+        assert result.amount == Decimal("100.00")
+        assert result.currency == "GBP"
+        assert result.customer_id == "cust-001"
+
+    def test_payment_authorize_eur(self, service):
+        """Authorize EUR payment."""
+        result = service.authorize(
+            customer_id="cust-002",
+            amount=Decimal("250.50"),
+            currency="EUR",
+            beneficiary_jurisdiction="DE",
+        )
+        assert isinstance(result, PaymentTransaction)
+        assert result.status == TransactionStatus.AUTHORIZED
+        assert result.currency == "EUR"
+
+    def test_payment_authorize_usd(self, service):
+        """Authorize USD payment."""
+        result = service.authorize(
+            customer_id="cust-003",
+            amount=Decimal("500.00"),
+            currency="USD",
+            beneficiary_jurisdiction="US",
+        )
+        assert isinstance(result, PaymentTransaction)
+        assert result.currency == "USD"
+
+    def test_payment_authorize_blocked_jurisdiction_ru(self, service):
+        """AC: RU jurisdiction raises JurisdictionBlockedError (I-02)."""
+        with pytest.raises(JurisdictionBlockedError, match="sanctioned"):
+            service.authorize(
+                customer_id="cust-001",
+                amount=Decimal("100.00"),
+                currency="GBP",
+                beneficiary_jurisdiction="RU",
+            )
+
+    def test_payment_authorize_blocked_jurisdiction_ir(self, service):
+        """AC: IR jurisdiction blocked (I-02)."""
+        with pytest.raises(JurisdictionBlockedError):
+            service.authorize(
+                customer_id="cust-001",
+                amount=Decimal("100.00"),
+                currency="GBP",
+                beneficiary_jurisdiction="IR",
+            )
+
+    def test_payment_authorize_blocked_jurisdiction_kp(self, service):
+        """AC: KP jurisdiction blocked (I-02)."""
+        with pytest.raises(JurisdictionBlockedError):
+            service.authorize(
+                customer_id="cust-001",
+                amount=Decimal("100.00"),
+                currency="GBP",
+                beneficiary_jurisdiction="KP",
+            )
+
+    def test_payment_authorize_blocked_jurisdiction_case_insensitive(self, service):
+        """Jurisdiction check is case-insensitive."""
+        with pytest.raises(JurisdictionBlockedError):
+            service.authorize(
+                customer_id="cust-001",
+                amount=Decimal("100.00"),
+                currency="GBP",
+                beneficiary_jurisdiction="ru",
+            )
+
+    def test_payment_authorize_zero_amount(self, service):
+        """Zero amount raises AmountValidationError."""
+        with pytest.raises(AmountValidationError):
+            service.authorize(
+                customer_id="cust-001",
+                amount=Decimal("0"),
+                currency="GBP",
+                beneficiary_jurisdiction="GB",
+            )
+
+    def test_payment_authorize_negative_amount(self, service):
+        """Negative amount raises AmountValidationError."""
+        with pytest.raises(AmountValidationError):
+            service.authorize(
+                customer_id="cust-001",
+                amount=Decimal("-50.00"),
+                currency="GBP",
+                beneficiary_jurisdiction="GB",
+            )
+
+    def test_payment_authorize_unsupported_currency(self, service):
+        """Unsupported currency raises CurrencyValidationError."""
+        with pytest.raises(CurrencyValidationError):
+            service.authorize(
+                customer_id="cust-001",
+                amount=Decimal("100.00"),
+                currency="JPY",
+                beneficiary_jurisdiction="JP",
+            )
+
+    def test_payment_authorize_gateway_failure(self, service, gateway):
+        """Gateway failure returns FAILED transaction."""
+        gateway.set_fail_next(True)
+        result = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        assert isinstance(result, PaymentTransaction)
+        assert result.status == TransactionStatus.FAILED
+
+
+# ── Idempotency Tests ────────────────────────────────────────────────────────
+
+
+class TestIdempotency:
+    def test_payment_duplicate_idempotency_key(self, service):
+        """AC: duplicate idempotency key raises DuplicateIdempotencyKeyError."""
+        service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+            idempotency_key="key-001",
+        )
+        with pytest.raises(DuplicateIdempotencyKeyError, match="key-001"):
+            service.authorize(
+                customer_id="cust-001",
+                amount=Decimal("100.00"),
+                currency="GBP",
+                beneficiary_jurisdiction="GB",
+                idempotency_key="key-001",
+            )
+
+    def test_different_idempotency_keys_ok(self, service):
+        """Different idempotency keys create separate transactions."""
+        r1 = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+            idempotency_key="key-a",
+        )
+        r2 = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+            idempotency_key="key-b",
+        )
+        assert r1.transaction_id != r2.transaction_id
+
+
+# ── EDD Threshold Tests ─────────────────────────────────────────────────────
+
+
+class TestEDDThreshold:
+    def test_payment_amount_exceeds_threshold_requires_edd(self, service):
+        """AC: amount >= £10k returns EDDHITLProposal (I-04, I-27)."""
+        result = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("10000"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        assert isinstance(result, EDDHITLProposal)
+        assert result.requires_approval_from == "MLRO"
+        assert result.amount == "10000"
+        assert result.currency == "GBP"
+
+    def test_payment_amount_above_threshold(self, service):
+        """Amount above threshold returns EDDHITLProposal."""
+        result = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("15000.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        assert isinstance(result, EDDHITLProposal)
+
+    def test_payment_below_threshold_authorized(self, service):
+        """Amount below threshold authorizes normally."""
+        result = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("9999.99"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        assert isinstance(result, PaymentTransaction)
+        assert result.status == TransactionStatus.AUTHORIZED
+
+    def test_edd_approved_bypasses_threshold(self, service):
+        """Pre-approved EDD allows authorization above threshold."""
+        result = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("15000.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+            edd_approved=True,
+        )
+        assert isinstance(result, PaymentTransaction)
+        assert result.status == TransactionStatus.AUTHORIZED
+
+    def test_high_value_mlro_escalation(self, service):
+        """High-value (>£50k) produces MLRO escalation message."""
+        result = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("55000.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        assert isinstance(result, EDDHITLProposal)
+        assert "MLRO escalation" in result.reason
+
+
+# ── Capture Tests ────────────────────────────────────────────────────────────
+
+
+class TestCapture:
+    def test_payment_capture_after_auth(self, service):
+        """AC: capture after authorization succeeds."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        captured = service.capture(tx.transaction_id)
+        assert captured.status == TransactionStatus.CAPTURED
+        assert captured.amount == Decimal("100.00")
+
+    def test_capture_without_auth_fails(self, service):
+        """Capture without prior authorization raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            service.capture("tx-nonexistent")
+
+    def test_capture_already_captured_fails(self, service):
+        """Capture of already-captured transaction raises InvalidTransitionError."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        service.capture(tx.transaction_id)
+        with pytest.raises(InvalidTransitionError):
+            service.capture(tx.transaction_id)
+
+
+# ── Settle Tests ─────────────────────────────────────────────────────────────
+
+
+class TestSettle:
+    def test_settle_after_capture(self, service):
+        """Settle after capture succeeds."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        service.capture(tx.transaction_id)
+        settled = service.settle(tx.transaction_id)
+        assert settled.status == TransactionStatus.SETTLED
+
+    def test_settle_without_capture_fails(self, service):
+        """Settle without capture raises InvalidTransitionError."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        with pytest.raises(InvalidTransitionError):
+            service.settle(tx.transaction_id)
+
+
+# ── Refund Tests ─────────────────────────────────────────────────────────────
+
+
+class TestRefund:
+    def _settled_tx(self, service):
+        """Helper: create an authorized → captured → settled transaction."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("200.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        service.capture(tx.transaction_id)
+        service.settle(tx.transaction_id)
+        return tx
+
+    def test_payment_full_refund_after_settle(self, service):
+        """AC: full refund after settlement succeeds."""
+        tx = self._settled_tx(service)
+        refunded = service.refund(tx.transaction_id)
+        assert refunded.status == TransactionStatus.REFUNDED
+        assert refunded.refunded_amount == Decimal("200.00")
+
+    def test_payment_partial_refund(self, service):
+        """AC: partial refund returns PARTIALLY_REFUNDED."""
+        tx = self._settled_tx(service)
+        refunded = service.refund(tx.transaction_id, amount=Decimal("50.00"))
+        assert refunded.status == TransactionStatus.PARTIALLY_REFUNDED
+        assert refunded.refunded_amount == Decimal("50.00")
+
+    def test_payment_multiple_partial_refunds(self, service):
+        """Multiple partial refunds accumulate."""
+        tx = self._settled_tx(service)
+        r1 = service.refund(tx.transaction_id, amount=Decimal("50.00"))
+        assert r1.refunded_amount == Decimal("50.00")
+        r2 = service.refund(tx.transaction_id, amount=Decimal("50.00"))
+        assert r2.refunded_amount == Decimal("100.00")
+
+    def test_partial_then_full_refund(self, service):
+        """Partial refund followed by remaining amount gives REFUNDED."""
+        tx = self._settled_tx(service)
+        service.refund(tx.transaction_id, amount=Decimal("100.00"))
+        r2 = service.refund(tx.transaction_id, amount=Decimal("100.00"))
+        assert r2.status == TransactionStatus.REFUNDED
+        assert r2.refunded_amount == Decimal("200.00")
+
+    def test_refund_exceeds_amount(self, service):
+        """Refund exceeding original amount raises RefundExceedsAmountError."""
+        tx = self._settled_tx(service)
+        with pytest.raises(RefundExceedsAmountError):
+            service.refund(tx.transaction_id, amount=Decimal("201.00"))
+
+    def test_refund_before_settle_fails(self, service):
+        """Refund before settlement raises InvalidTransitionError."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        service.capture(tx.transaction_id)
+        with pytest.raises(InvalidTransitionError):
+            service.refund(tx.transaction_id)
+
+
+# ── Audit Trail Tests ────────────────────────────────────────────────────────
+
+
+class TestAuditTrail:
+    def test_payment_audit_trail_recorded(self, service, audit):
+        """AC: audit entry recorded for every state transition (I-24)."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        assert len(audit.entries) == 1
+        entry = audit.entries[0]
+        assert entry.transaction_id == tx.transaction_id
+        assert entry.action == "AUTHORIZE"
+        assert entry.new_status == TransactionStatus.AUTHORIZED
+        assert entry.old_status is None
+        assert isinstance(entry.amount, Decimal)
+
+    def test_full_lifecycle_audit_trail(self, service, audit):
+        """Full lifecycle: authorize → capture → settle → refund produces 4 entries."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        service.capture(tx.transaction_id)
+        service.settle(tx.transaction_id)
+        service.refund(tx.transaction_id)
+        assert len(audit.entries) == 4
+        actions = [e.action for e in audit.entries]
+        assert actions == ["AUTHORIZE", "CAPTURE", "SETTLE", "REFUND"]
+
+    def test_audit_entry_immutable(self, audit):
+        """Audit entries are frozen dataclasses (I-24)."""
+        from services.payment.payment_models import AuditEntry
+
+        entry = AuditEntry(
+            transaction_id="tx-001",
+            action="TEST",
+            old_status=None,
+            new_status=TransactionStatus.AUTHORIZED,
+            amount=Decimal("100"),
+            currency="GBP",
+            actor="test",
+        )
+        with pytest.raises(AttributeError):
+            entry.action = "MODIFIED"  # type: ignore[misc]
+
+    def test_audit_records_refund_details(self, service, audit):
+        """Refund audit entry includes refund amount details."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("200.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        service.capture(tx.transaction_id)
+        service.settle(tx.transaction_id)
+        service.refund(tx.transaction_id, amount=Decimal("75.00"))
+        refund_entry = audit.entries[-1]
+        assert refund_entry.action == "REFUND"
+        assert "75.00" in refund_entry.details
+
+
+# ── Transaction Query Tests ──────────────────────────────────────────────────
+
+
+class TestQuery:
+    def test_get_transaction(self, service):
+        """get_transaction returns stored transaction."""
+        tx = service.authorize(
+            customer_id="cust-001",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+        )
+        found = service.get_transaction(tx.transaction_id)
+        assert found is not None
+        assert found.transaction_id == tx.transaction_id
+
+    def test_get_transaction_not_found(self, service):
+        """get_transaction returns None for unknown ID."""
+        assert service.get_transaction("tx-nonexistent") is None
+
+
+# ── Currency Validator Tests ─────────────────────────────────────────────────
+
+
+class TestCurrencyValidator:
+    def test_validate_supported_currencies(self):
+        """All supported currencies pass validation."""
+        for cur in SUPPORTED_CURRENCIES:
+            validate_currency(cur)
+
+    def test_validate_unsupported_currency(self):
+        with pytest.raises(CurrencyValidationError):
+            validate_currency("CHF")
+
+    def test_validate_amount_decimal(self):
+        validate_amount(Decimal("100.00"), "GBP")
+
+    def test_validate_amount_not_decimal(self):
+        with pytest.raises(AmountValidationError, match="Decimal"):
+            validate_amount(100.0, "GBP")  # type: ignore[arg-type]
+
+    def test_validate_amount_exceeds_scheme_limit(self):
+        with pytest.raises(AmountValidationError, match="exceeds scheme limit"):
+            validate_amount(Decimal("1000001"), "GBP")
+
+    def test_requires_edd_at_threshold(self):
+        assert requires_edd(Decimal("10000"), "GBP") is True
+
+    def test_requires_edd_below_threshold(self):
+        assert requires_edd(Decimal("9999.99"), "GBP") is False
+
+    def test_requires_mlro_at_threshold(self):
+        assert requires_mlro_escalation(Decimal("50000"), "GBP") is True
+
+    def test_requires_mlro_below_threshold(self):
+        assert requires_mlro_escalation(Decimal("49999.99"), "GBP") is False
+
+
+# ── Model Tests ──────────────────────────────────────────────────────────────
+
+
+class TestModels:
+    def test_payment_transaction_decimal_only(self):
+        """PaymentTransaction rejects non-Decimal amount (I-01)."""
+        with pytest.raises(TypeError, match="Decimal"):
+            PaymentTransaction(
+                transaction_id="tx-001",
+                idempotency_key="key-001",
+                customer_id="cust-001",
+                amount=100.0,  # type: ignore[arg-type]
+                currency="GBP",
+                beneficiary_jurisdiction="GB",
+                status=TransactionStatus.PENDING,
+            )
+
+    def test_payment_transaction_positive_amount(self):
+        """PaymentTransaction rejects non-positive amount."""
+        with pytest.raises(ValueError, match="positive"):
+            PaymentTransaction(
+                transaction_id="tx-001",
+                idempotency_key="key-001",
+                customer_id="cust-001",
+                amount=Decimal("-10"),
+                currency="GBP",
+                beneficiary_jurisdiction="GB",
+                status=TransactionStatus.PENDING,
+            )
+
+    def test_payment_transaction_unsupported_currency(self):
+        """PaymentTransaction rejects unsupported currency."""
+        with pytest.raises(ValueError, match="unsupported currency"):
+            PaymentTransaction(
+                transaction_id="tx-001",
+                idempotency_key="key-001",
+                customer_id="cust-001",
+                amount=Decimal("100"),
+                currency="XYZ",
+                beneficiary_jurisdiction="GB",
+                status=TransactionStatus.PENDING,
+            )
+
+    def test_payment_transaction_frozen(self):
+        """PaymentTransaction is immutable (frozen=True)."""
+        tx = PaymentTransaction(
+            transaction_id="tx-001",
+            idempotency_key="key-001",
+            customer_id="cust-001",
+            amount=Decimal("100"),
+            currency="GBP",
+            beneficiary_jurisdiction="GB",
+            status=TransactionStatus.PENDING,
+        )
+        with pytest.raises(AttributeError):
+            tx.amount = Decimal("200")  # type: ignore[misc]
+
+    def test_valid_transitions_complete(self):
+        """Every TransactionStatus has an entry in VALID_TRANSITIONS."""
+        for status in TransactionStatus:
+            assert status in VALID_TRANSITIONS


### PR DESCRIPTION
## Summary
- Full payment lifecycle: authorize -> capture -> settle -> refund/chargeback
- PaymentProcessingService with Protocol DI (PaymentGatewayPort)
- TransactionStatus state machine with VALID_TRANSITIONS enforcement
- CurrencyValidator: GBP/EUR/USD with scheme limits
- InMemoryGateway + InMemoryAuditPort stubs for testing

## Invariants enforced
- I-01: Decimal ONLY for money (no float)
- I-02: RU/BY/IR/KP/CU/MM/AF/VE/SY jurisdiction blocking
- I-04: EDD threshold (>=10k GBP) -> EDDHITLProposal
- I-24: Immutable audit trail for every state transition
- I-27: HITL for high-value payments (>=50k -> MLRO)

## Files
- services/payment/payment_models.py
- services/payment/payment_processing_service.py
- services/payment/payment_gateway_port.py
- services/payment/currency_validator.py
- tests/test_payment_processing_service.py

## Test plan
- [x] 49 tests passing
- [x] Coverage: 89-100% on all new files
- [x] Ruff clean

Closes #21

Generated with Claude Code