### PR TITLE
feat(recon): safeguarding reconciliation engine — FCA CASS 7 [IL-SAF-01]

### DIFF
--- a/services/recon/recon_engine.py
+++ b/services/recon/recon_engine.py
@@ -1,0 +1,225 @@
+"""
+services/recon/recon_engine.py
+ReconciliationEngine — FCA CASS 7 daily safeguarding recon (IL-SAF-01).
+
+Compares client fund totals against safeguarding account balances.
+Detects discrepancies, flags large values, excludes blocked jurisdictions,
+and records immutable audit trail.
+
+I-01: Decimal ONLY for money.
+I-02: Blocked jurisdictions excluded from recon.
+I-04: Large values (>£50k) flagged for MLRO.
+I-24: Immutable audit trail for every reconciliation.
+I-27: HITL escalation for shortfalls.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Protocol
+from uuid import uuid4
+
+from services.recon.recon_models import (
+    BLOCKED_JURISDICTIONS,
+    LARGE_VALUE_THRESHOLD,
+    RECON_TOLERANCE,
+    AccountBalance,
+    Discrepancy,
+    DiscrepancyType,
+    EscalationLevel,
+    ReconAuditEntry,
+    ReconResult,
+    ReconStatus,
+)
+from services.recon.recon_port import LedgerPort
+
+# ── Audit Port ───────────────────────────────────────────────────────────────
+
+
+class ReconAuditPort(Protocol):
+    """Port for recording immutable recon audit entries (I-24)."""
+
+    def record(self, entry: ReconAuditEntry) -> None: ...
+
+
+class InMemoryReconAuditPort:
+    """In-memory audit trail for tests."""
+
+    def __init__(self) -> None:
+        self._entries: list[ReconAuditEntry] = []
+
+    def record(self, entry: ReconAuditEntry) -> None:
+        self._entries.append(entry)
+
+    @property
+    def entries(self) -> list[ReconAuditEntry]:
+        return list(self._entries)
+
+
+# ── HITL Escalation ──────────────────────────────────────────────────────────
+
+
+class HITLEscalation:
+    """Represents a HITL escalation for discrepancy resolution (I-27)."""
+
+    def __init__(
+        self,
+        recon_id: str,
+        discrepancy: Discrepancy,
+        requires_approval_from: str = "MLRO",
+    ) -> None:
+        self.recon_id = recon_id
+        self.discrepancy = discrepancy
+        self.requires_approval_from = requires_approval_from
+
+
+# ── Reconciliation Engine ────────────────────────────────────────────────────
+
+
+class ReconciliationEngine:
+    """
+    FCA CASS 7 daily safeguarding reconciliation engine.
+
+    Compares total client funds against total safeguarding balances.
+    Excludes blocked jurisdictions (I-02).
+    Flags large values (I-04).
+    Records audit trail (I-24).
+    Escalates discrepancies via HITL (I-27).
+    """
+
+    def __init__(
+        self,
+        ledger: LedgerPort,
+        audit: ReconAuditPort | None = None,
+        tolerance: Decimal | None = None,
+    ) -> None:
+        self._ledger = ledger
+        self._audit: ReconAuditPort = audit or InMemoryReconAuditPort()
+        self._tolerance = tolerance if tolerance is not None else RECON_TOLERANCE
+        self._escalations: list[HITLEscalation] = []
+
+    @property
+    def escalations(self) -> list[HITLEscalation]:
+        """Return pending HITL escalations."""
+        return list(self._escalations)
+
+    def run_daily_recon(self, recon_date: str) -> ReconResult:
+        """
+        Execute daily reconciliation for the given date.
+
+        Returns ReconResult with status BALANCED or DISCREPANCY.
+        Triggers HITL escalation for shortfalls (I-27).
+        """
+        recon_id = f"recon-{uuid4().hex[:12]}"
+
+        # Fetch balances from ledger port.
+        client_balances = self._ledger.get_client_fund_balances(recon_date)
+        safeguarding_balances = self._ledger.get_safeguarding_balances(recon_date)
+
+        # I-02: exclude blocked jurisdictions.
+        excluded: list[str] = []
+        client_balances_filtered: list[AccountBalance] = []
+        for bal in client_balances:
+            if bal.jurisdiction.upper() in BLOCKED_JURISDICTIONS:
+                excluded.append(bal.jurisdiction.upper())
+            else:
+                client_balances_filtered.append(bal)
+
+        safeguarding_filtered: list[AccountBalance] = []
+        for bal in safeguarding_balances:
+            if bal.jurisdiction.upper() in BLOCKED_JURISDICTIONS:
+                excluded.append(bal.jurisdiction.upper())
+            else:
+                safeguarding_filtered.append(bal)
+
+        # I-01: sum with Decimal.
+        client_total = sum(
+            (b.balance for b in client_balances_filtered), Decimal("0")
+        )
+        safeguarding_total = sum(
+            (b.balance for b in safeguarding_filtered), Decimal("0")
+        )
+        difference = client_total - safeguarding_total
+
+        # I-04: flag large values.
+        large_values_flagged = sum(
+            1 for b in client_balances_filtered
+            if b.balance >= LARGE_VALUE_THRESHOLD
+        ) + sum(
+            1 for b in safeguarding_filtered
+            if b.balance >= LARGE_VALUE_THRESHOLD
+        )
+
+        # Detect discrepancies.
+        discrepancies: list[Discrepancy] = []
+        if abs(difference) > self._tolerance:
+            disc_type = (
+                DiscrepancyType.SHORTFALL if difference > Decimal("0")
+                else DiscrepancyType.SURPLUS
+            )
+            escalation = (
+                EscalationLevel.HITL_MLRO if abs(difference) >= LARGE_VALUE_THRESHOLD
+                else EscalationLevel.ALERT
+            )
+            disc = Discrepancy(
+                discrepancy_id=f"disc-{uuid4().hex[:8]}",
+                discrepancy_type=disc_type,
+                expected=client_total,
+                actual=safeguarding_total,
+                difference=abs(difference),
+                account_id="AGGREGATE",
+                description=(
+                    f"Daily recon {recon_date}: client funds {client_total} vs "
+                    f"safeguarding {safeguarding_total}, difference {difference}"
+                ),
+                escalation_level=escalation,
+            )
+            discrepancies.append(disc)
+
+            # I-27: HITL escalation for shortfalls.
+            if disc_type == DiscrepancyType.SHORTFALL:
+                self._escalations.append(
+                    HITLEscalation(
+                        recon_id=recon_id,
+                        discrepancy=disc,
+                        requires_approval_from="MLRO",
+                    )
+                )
+
+        status = (
+            ReconStatus.BALANCED if not discrepancies
+            else ReconStatus.DISCREPANCY
+        )
+
+        result = ReconResult(
+            recon_id=recon_id,
+            recon_date=recon_date,
+            status=status,
+            client_funds_total=client_total,
+            safeguarding_total=safeguarding_total,
+            difference=difference,
+            discrepancies=tuple(discrepancies),
+            large_values_flagged=large_values_flagged,
+            excluded_jurisdictions=tuple(sorted(set(excluded))),
+        )
+
+        # I-24: audit trail.
+        self._record_audit(recon_id, result)
+
+        return result
+
+    def _record_audit(self, recon_id: str, result: ReconResult) -> None:
+        entry = ReconAuditEntry(
+            recon_id=recon_id,
+            action="DAILY_RECON",
+            status=result.status,
+            client_funds_total=result.client_funds_total,
+            safeguarding_total=result.safeguarding_total,
+            actor="SYSTEM",
+            details=(
+                f"discrepancies={len(result.discrepancies)}, "
+                f"large_values={result.large_values_flagged}, "
+                f"excluded={','.join(result.excluded_jurisdictions) or 'none'}"
+            ),
+        )
+        self._audit.record(entry)

--- a/services/recon/recon_models.py
+++ b/services/recon/recon_models.py
@@ -1,0 +1,132 @@
+"""
+services/recon/recon_models.py
+Reconciliation domain models for FCA CASS 7 daily safeguarding recon (IL-SAF-01).
+
+I-01: All monetary values are Decimal — never float.
+I-24: Immutable records via frozen dataclasses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import Enum
+
+
+class ReconStatus(str, Enum):
+    """Status of a reconciliation run."""
+
+    BALANCED = "BALANCED"
+    DISCREPANCY = "DISCREPANCY"
+    ESCALATED = "ESCALATED"
+    RESOLVED = "RESOLVED"
+    PENDING = "PENDING"
+
+
+class DiscrepancyType(str, Enum):
+    """Type of discrepancy found during reconciliation."""
+
+    SHORTFALL = "SHORTFALL"
+    SURPLUS = "SURPLUS"
+    MISSING_ENTRY = "MISSING_ENTRY"
+    AMOUNT_MISMATCH = "AMOUNT_MISMATCH"
+
+
+class EscalationLevel(str, Enum):
+    """Escalation level for discrepancies (I-27)."""
+
+    NONE = "NONE"
+    ALERT = "ALERT"
+    HITL_MLRO = "HITL_MLRO"
+    FCA_NOTIFY = "FCA_NOTIFY"
+
+
+# Tolerance for penny-exact matching (FCA CASS 7).
+RECON_TOLERANCE: Decimal = Decimal("0.01")
+
+# Large value threshold for flagging (I-04).
+LARGE_VALUE_THRESHOLD: Decimal = Decimal("50000")
+
+# Blocked jurisdictions (I-02).
+BLOCKED_JURISDICTIONS: frozenset[str] = frozenset({
+    "RU", "BY", "IR", "KP", "CU", "MM", "AF", "VE", "SY",
+})
+
+
+@dataclass(frozen=True)
+class AccountBalance:
+    """A single account balance snapshot."""
+
+    account_id: str
+    account_name: str
+    balance: Decimal  # I-01
+    currency: str
+    jurisdiction: str = "GB"
+    as_of: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.balance, Decimal):
+            raise TypeError(
+                f"balance must be Decimal, got {type(self.balance).__name__} (I-01)"
+            )
+
+
+@dataclass(frozen=True)
+class Discrepancy:
+    """A discrepancy found during reconciliation (I-24 immutable)."""
+
+    discrepancy_id: str
+    discrepancy_type: DiscrepancyType
+    expected: Decimal  # I-01
+    actual: Decimal    # I-01
+    difference: Decimal  # I-01
+    account_id: str
+    description: str
+    escalation_level: EscalationLevel = EscalationLevel.NONE
+
+    def __post_init__(self) -> None:
+        for fld in ("expected", "actual", "difference"):
+            val = getattr(self, fld)
+            if not isinstance(val, Decimal):
+                raise TypeError(
+                    f"{fld} must be Decimal, got {type(val).__name__} (I-01)"
+                )
+
+
+@dataclass(frozen=True)
+class ReconResult:
+    """Result of a daily reconciliation run (I-24 immutable)."""
+
+    recon_id: str
+    recon_date: str
+    status: ReconStatus
+    client_funds_total: Decimal  # I-01
+    safeguarding_total: Decimal  # I-01
+    difference: Decimal          # I-01
+    discrepancies: tuple[Discrepancy, ...] = ()
+    large_values_flagged: int = 0
+    excluded_jurisdictions: tuple[str, ...] = ()
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def __post_init__(self) -> None:
+        for fld in ("client_funds_total", "safeguarding_total", "difference"):
+            val = getattr(self, fld)
+            if not isinstance(val, Decimal):
+                raise TypeError(
+                    f"{fld} must be Decimal, got {type(val).__name__} (I-01)"
+                )
+
+
+@dataclass(frozen=True)
+class ReconAuditEntry:
+    """Immutable audit record for reconciliation events (I-24)."""
+
+    recon_id: str
+    action: str
+    status: ReconStatus
+    client_funds_total: Decimal  # I-01
+    safeguarding_total: Decimal  # I-01
+    actor: str
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    details: str = ""

--- a/services/recon/recon_port.py
+++ b/services/recon/recon_port.py
@@ -1,0 +1,84 @@
+"""
+services/recon/recon_port.py
+LedgerPort Protocol for safeguarding reconciliation (IL-SAF-01).
+
+Hexagonal port: adapters fetch balances from Midaz, bank APIs, etc.
+InMemoryLedgerPort for unit tests.
+
+I-01: All monetary values are Decimal.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Protocol
+
+from services.recon.recon_models import AccountBalance
+
+
+class LedgerPort(Protocol):
+    """Port for fetching account balances from the ledger (Midaz adapter)."""
+
+    def get_client_fund_balances(self, as_of_date: str) -> list[AccountBalance]:
+        """Return all client fund account balances as of a given date."""
+        ...
+
+    def get_safeguarding_balances(self, as_of_date: str) -> list[AccountBalance]:
+        """Return all safeguarding account balances as of a given date."""
+        ...
+
+
+class InMemoryLedgerPort:
+    """Configurable in-memory stub for testing."""
+
+    def __init__(self) -> None:
+        self._client_funds: list[AccountBalance] = []
+        self._safeguarding: list[AccountBalance] = []
+
+    def set_client_funds(self, balances: list[AccountBalance]) -> None:
+        self._client_funds = list(balances)
+
+    def set_safeguarding(self, balances: list[AccountBalance]) -> None:
+        self._safeguarding = list(balances)
+
+    def add_client_fund(
+        self,
+        account_id: str,
+        balance: Decimal,
+        currency: str = "GBP",
+        jurisdiction: str = "GB",
+        account_name: str = "",
+    ) -> None:
+        self._client_funds.append(
+            AccountBalance(
+                account_id=account_id,
+                account_name=account_name or f"Client-{account_id}",
+                balance=balance,
+                currency=currency,
+                jurisdiction=jurisdiction,
+            )
+        )
+
+    def add_safeguarding(
+        self,
+        account_id: str,
+        balance: Decimal,
+        currency: str = "GBP",
+        jurisdiction: str = "GB",
+        account_name: str = "",
+    ) -> None:
+        self._safeguarding.append(
+            AccountBalance(
+                account_id=account_id,
+                account_name=account_name or f"Safeguarding-{account_id}",
+                balance=balance,
+                currency=currency,
+                jurisdiction=jurisdiction,
+            )
+        )
+
+    def get_client_fund_balances(self, as_of_date: str) -> list[AccountBalance]:
+        return list(self._client_funds)
+
+    def get_safeguarding_balances(self, as_of_date: str) -> list[AccountBalance]:
+        return list(self._safeguarding)

--- a/services/recon/recon_report.py
+++ b/services/recon/recon_report.py
@@ -1,0 +1,86 @@
+"""
+services/recon/recon_report.py
+Daily reconciliation report generator (IL-SAF-01).
+
+Generates structured JSON report from ReconResult for FCA CASS 7 compliance.
+
+I-01: All monetary values are Decimal, serialized as strings.
+I-24: Reports are immutable once generated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+import json
+
+from services.recon.recon_models import ReconResult, ReconStatus
+
+
+@dataclass(frozen=True)
+class ReconReport:
+    """Immutable daily reconciliation report (I-24)."""
+
+    report_id: str
+    recon_id: str
+    recon_date: str
+    status: str
+    client_funds_total: str  # Decimal as string (I-01, I-05)
+    safeguarding_total: str
+    difference: str
+    discrepancy_count: int
+    large_values_flagged: int
+    excluded_jurisdictions: tuple[str, ...]
+    generated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    report_format: str = "JSON"
+
+
+class ReconReportGenerator:
+    """Generates daily reconciliation reports from ReconResult."""
+
+    def __init__(self) -> None:
+        self._reports: list[ReconReport] = []
+
+    def generate(self, result: ReconResult) -> ReconReport:
+        """Generate a structured report from a reconciliation result."""
+        report = ReconReport(
+            report_id=f"rpt-{result.recon_id}",
+            recon_id=result.recon_id,
+            recon_date=result.recon_date,
+            status=result.status.value,
+            client_funds_total=str(result.client_funds_total),
+            safeguarding_total=str(result.safeguarding_total),
+            difference=str(result.difference),
+            discrepancy_count=len(result.discrepancies),
+            large_values_flagged=result.large_values_flagged,
+            excluded_jurisdictions=result.excluded_jurisdictions,
+        )
+        self._reports.append(report)
+        return report
+
+    def to_json(self, report: ReconReport) -> str:
+        """Serialize report to JSON string."""
+        data = {
+            "report_id": report.report_id,
+            "recon_id": report.recon_id,
+            "recon_date": report.recon_date,
+            "status": report.status,
+            "client_funds_total": report.client_funds_total,
+            "safeguarding_total": report.safeguarding_total,
+            "difference": report.difference,
+            "discrepancy_count": report.discrepancy_count,
+            "large_values_flagged": report.large_values_flagged,
+            "excluded_jurisdictions": list(report.excluded_jurisdictions),
+            "generated_at": report.generated_at,
+            "report_format": report.report_format,
+            "fca_compliance": {
+                "regulation": "FCA CASS 7",
+                "requirement": "Daily safeguarding reconciliation",
+                "balanced": report.status == ReconStatus.BALANCED.value,
+            },
+        }
+        return json.dumps(data, indent=2)
+
+    @property
+    def reports(self) -> list[ReconReport]:
+        return list(self._reports)

--- a/tests/test_recon_engine.py
+++ b/tests/test_recon_engine.py
@@ -1,0 +1,446 @@
+"""
+tests/test_recon_engine.py
+Tests for ReconciliationEngine — FCA CASS 7 daily recon (IL-SAF-01).
+
+Acceptance criteria:
+- test_daily_recon_balanced (Decimal, I-01)
+- test_daily_recon_discrepancy_detected (I-27 HITL)
+- test_recon_audit_trail (I-24)
+- test_recon_blocked_jurisdiction_excluded (I-02)
+- test_recon_report_generated
+- test_recon_large_value_flagged (>£50k, I-04)
+"""
+
+from decimal import Decimal
+import json
+
+import pytest
+
+from services.recon.recon_engine import (
+    HITLEscalation,
+    InMemoryReconAuditPort,
+    ReconciliationEngine,
+)
+from services.recon.recon_models import (
+    BLOCKED_JURISDICTIONS,
+    LARGE_VALUE_THRESHOLD,
+    RECON_TOLERANCE,
+    AccountBalance,
+    Discrepancy,
+    DiscrepancyType,
+    EscalationLevel,
+    ReconAuditEntry,
+    ReconResult,
+    ReconStatus,
+)
+from services.recon.recon_port import InMemoryLedgerPort
+from services.recon.recon_report import ReconReport, ReconReportGenerator
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ledger():
+    return InMemoryLedgerPort()
+
+
+@pytest.fixture
+def audit():
+    return InMemoryReconAuditPort()
+
+
+@pytest.fixture
+def engine(ledger, audit):
+    return ReconciliationEngine(ledger=ledger, audit=audit)
+
+
+@pytest.fixture
+def report_gen():
+    return ReconReportGenerator()
+
+
+# ── Daily Recon Balanced Tests ───────────────────────────────────────────────
+
+
+class TestDailyReconBalanced:
+    def test_daily_recon_balanced(self, engine, ledger):
+        """AC: client funds == safeguarding → BALANCED (Decimal, I-01)."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("100000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+
+        assert result.status == ReconStatus.BALANCED
+        assert isinstance(result.client_funds_total, Decimal)
+        assert isinstance(result.safeguarding_total, Decimal)
+        assert result.client_funds_total == Decimal("100000.00")
+        assert result.safeguarding_total == Decimal("100000.00")
+        assert result.difference == Decimal("0")
+        assert len(result.discrepancies) == 0
+
+    def test_balanced_within_tolerance(self, engine, ledger):
+        """Difference within tolerance (£0.01) is still BALANCED."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("100000.01"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.status == ReconStatus.BALANCED
+
+    def test_balanced_multiple_accounts(self, engine, ledger):
+        """Multiple accounts summed correctly."""
+        ledger.add_client_fund("cf-001", Decimal("50000.00"))
+        ledger.add_client_fund("cf-002", Decimal("50000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("70000.00"))
+        ledger.add_safeguarding("sg-002", Decimal("30000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.status == ReconStatus.BALANCED
+        assert result.client_funds_total == Decimal("100000.00")
+        assert result.safeguarding_total == Decimal("100000.00")
+
+    def test_empty_accounts_balanced(self, engine):
+        """No accounts → BALANCED (both zero)."""
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.status == ReconStatus.BALANCED
+        assert result.client_funds_total == Decimal("0")
+        assert result.safeguarding_total == Decimal("0")
+
+
+# ── Discrepancy Detection Tests ──────────────────────────────────────────────
+
+
+class TestDiscrepancyDetection:
+    def test_daily_recon_discrepancy_detected_shortfall(self, engine, ledger):
+        """AC: shortfall detected → DISCREPANCY + HITL escalation (I-27)."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("95000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+
+        assert result.status == ReconStatus.DISCREPANCY
+        assert len(result.discrepancies) == 1
+        disc = result.discrepancies[0]
+        assert disc.discrepancy_type == DiscrepancyType.SHORTFALL
+        assert disc.difference == Decimal("5000.00")
+        assert disc.escalation_level == EscalationLevel.ALERT
+
+    def test_discrepancy_surplus(self, engine, ledger):
+        """Surplus (safeguarding > client) also flagged."""
+        ledger.add_client_fund("cf-001", Decimal("90000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("95000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.status == ReconStatus.DISCREPANCY
+        disc = result.discrepancies[0]
+        assert disc.discrepancy_type == DiscrepancyType.SURPLUS
+
+    def test_shortfall_triggers_hitl_escalation(self, engine, ledger):
+        """AC: shortfall triggers HITL escalation with MLRO approval (I-27)."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("95000.00"))
+
+        engine.run_daily_recon("2026-04-28")
+
+        assert len(engine.escalations) == 1
+        esc = engine.escalations[0]
+        assert isinstance(esc, HITLEscalation)
+        assert esc.requires_approval_from == "MLRO"
+
+    def test_surplus_no_hitl_escalation(self, engine, ledger):
+        """Surplus does NOT trigger HITL escalation."""
+        ledger.add_client_fund("cf-001", Decimal("90000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("95000.00"))
+
+        engine.run_daily_recon("2026-04-28")
+        assert len(engine.escalations) == 0
+
+    def test_large_discrepancy_mlro_escalation(self, engine, ledger):
+        """Large shortfall (>£50k) escalates to HITL_MLRO level."""
+        ledger.add_client_fund("cf-001", Decimal("200000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("100000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        disc = result.discrepancies[0]
+        assert disc.escalation_level == EscalationLevel.HITL_MLRO
+
+    def test_exact_tolerance_boundary(self, engine, ledger):
+        """Difference exactly at tolerance → BALANCED."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("99999.99"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.status == ReconStatus.BALANCED
+
+    def test_just_above_tolerance(self, engine, ledger):
+        """Difference just above tolerance → DISCREPANCY."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("99999.98"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.status == ReconStatus.DISCREPANCY
+
+
+# ── Audit Trail Tests ────────────────────────────────────────────────────────
+
+
+class TestAuditTrail:
+    def test_recon_audit_trail(self, engine, ledger, audit):
+        """AC: immutable audit entry recorded per reconciliation (I-24)."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("100000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+
+        assert len(audit.entries) == 1
+        entry = audit.entries[0]
+        assert entry.recon_id == result.recon_id
+        assert entry.action == "DAILY_RECON"
+        assert entry.status == ReconStatus.BALANCED
+        assert isinstance(entry.client_funds_total, Decimal)
+        assert isinstance(entry.safeguarding_total, Decimal)
+        assert entry.actor == "SYSTEM"
+
+    def test_audit_entry_immutable(self):
+        """ReconAuditEntry is frozen (I-24)."""
+        entry = ReconAuditEntry(
+            recon_id="r-001",
+            action="TEST",
+            status=ReconStatus.BALANCED,
+            client_funds_total=Decimal("100"),
+            safeguarding_total=Decimal("100"),
+            actor="test",
+        )
+        with pytest.raises(AttributeError):
+            entry.action = "MODIFIED"  # type: ignore[misc]
+
+    def test_multiple_recons_produce_multiple_audit_entries(
+        self, engine, ledger, audit
+    ):
+        """Each recon run produces its own audit entry."""
+        ledger.add_client_fund("cf-001", Decimal("100.00"))
+        ledger.add_safeguarding("sg-001", Decimal("100.00"))
+
+        engine.run_daily_recon("2026-04-28")
+        engine.run_daily_recon("2026-04-29")
+
+        assert len(audit.entries) == 2
+
+    def test_audit_records_discrepancy_details(self, engine, ledger, audit):
+        """Audit entry includes discrepancy count in details."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("90000.00"))
+
+        engine.run_daily_recon("2026-04-28")
+        entry = audit.entries[0]
+        assert "discrepancies=1" in entry.details
+
+
+# ── Blocked Jurisdiction Tests ─────────────────────────────────────��─────────
+
+
+class TestBlockedJurisdictions:
+    def test_recon_blocked_jurisdiction_excluded(self, engine, ledger):
+        """AC: blocked jurisdiction accounts excluded from recon (I-02)."""
+        ledger.add_client_fund("cf-gb", Decimal("100000.00"), jurisdiction="GB")
+        ledger.add_client_fund("cf-ru", Decimal("50000.00"), jurisdiction="RU")
+        ledger.add_safeguarding("sg-001", Decimal("100000.00"), jurisdiction="GB")
+
+        result = engine.run_daily_recon("2026-04-28")
+
+        assert result.status == ReconStatus.BALANCED
+        assert result.client_funds_total == Decimal("100000.00")  # RU excluded
+        assert "RU" in result.excluded_jurisdictions
+
+    def test_multiple_blocked_jurisdictions(self, engine, ledger):
+        """Multiple blocked jurisdictions excluded."""
+        ledger.add_client_fund("cf-gb", Decimal("100.00"), jurisdiction="GB")
+        ledger.add_client_fund("cf-ir", Decimal("200.00"), jurisdiction="IR")
+        ledger.add_client_fund("cf-kp", Decimal("300.00"), jurisdiction="KP")
+        ledger.add_safeguarding("sg-001", Decimal("100.00"), jurisdiction="GB")
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.status == ReconStatus.BALANCED
+        assert "IR" in result.excluded_jurisdictions
+        assert "KP" in result.excluded_jurisdictions
+
+    def test_blocked_jurisdiction_case_insensitive(self, engine, ledger):
+        """Jurisdiction check is case-insensitive."""
+        ledger.add_client_fund("cf-gb", Decimal("100.00"), jurisdiction="GB")
+        ledger.add_client_fund("cf-ru", Decimal("500.00"), jurisdiction="ru")
+        ledger.add_safeguarding("sg-001", Decimal("100.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.client_funds_total == Decimal("100.00")
+
+    def test_all_blocked_countries(self):
+        """Verify all I-02 blocked countries are in the set."""
+        expected = {"RU", "BY", "IR", "KP", "CU", "MM", "AF", "VE", "SY"}
+        assert expected == BLOCKED_JURISDICTIONS
+
+
+# ── Large Value Tests ────────────────────────────────────────────────────────
+
+
+class TestLargeValues:
+    def test_recon_large_value_flagged(self, engine, ledger):
+        """AC: accounts with balance >= £50k flagged (I-04)."""
+        ledger.add_client_fund("cf-001", Decimal("60000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("60000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.large_values_flagged == 2  # Both flagged
+
+    def test_below_large_value_not_flagged(self, engine, ledger):
+        """Accounts below £50k threshold not flagged."""
+        ledger.add_client_fund("cf-001", Decimal("49999.99"))
+        ledger.add_safeguarding("sg-001", Decimal("49999.99"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.large_values_flagged == 0
+
+    def test_exactly_at_threshold_flagged(self, engine, ledger):
+        """Account exactly at £50k is flagged."""
+        ledger.add_client_fund("cf-001", Decimal("50000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("50000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.large_values_flagged == 2
+
+    def test_mixed_large_and_small(self, engine, ledger):
+        """Only large accounts flagged, small ones not."""
+        ledger.add_client_fund("cf-001", Decimal("60000.00"))
+        ledger.add_client_fund("cf-002", Decimal("1000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("61000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        assert result.large_values_flagged == 2  # cf-001 + sg-001
+
+
+# ── Report Generator Tests ───────────────────────────────────────────────────
+
+
+class TestReconReport:
+    def test_recon_report_generated(self, engine, ledger, report_gen):
+        """AC: daily report generated from ReconResult."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("100000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        report = report_gen.generate(result)
+
+        assert isinstance(report, ReconReport)
+        assert report.recon_id == result.recon_id
+        assert report.status == "BALANCED"
+        assert report.client_funds_total == "100000.00"
+        assert report.safeguarding_total == "100000.00"
+        assert report.report_format == "JSON"
+
+    def test_report_to_json(self, engine, ledger, report_gen):
+        """Report serializable to valid JSON."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("100000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        report = report_gen.generate(result)
+        json_str = report_gen.to_json(report)
+
+        data = json.loads(json_str)
+        assert data["status"] == "BALANCED"
+        assert data["fca_compliance"]["regulation"] == "FCA CASS 7"
+        assert data["fca_compliance"]["balanced"] is True
+
+    def test_report_discrepancy_json(self, engine, ledger, report_gen):
+        """Discrepancy report has balanced=False."""
+        ledger.add_client_fund("cf-001", Decimal("100000.00"))
+        ledger.add_safeguarding("sg-001", Decimal("90000.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        report = report_gen.generate(result)
+        json_str = report_gen.to_json(report)
+
+        data = json.loads(json_str)
+        assert data["fca_compliance"]["balanced"] is False
+        assert data["discrepancy_count"] == 1
+
+    def test_report_immutable(self, engine, ledger, report_gen):
+        """ReconReport is frozen."""
+        ledger.add_client_fund("cf-001", Decimal("100.00"))
+        ledger.add_safeguarding("sg-001", Decimal("100.00"))
+
+        result = engine.run_daily_recon("2026-04-28")
+        report = report_gen.generate(result)
+        with pytest.raises(AttributeError):
+            report.status = "MODIFIED"  # type: ignore[misc]
+
+    def test_reports_stored(self, engine, ledger, report_gen):
+        """Generator stores all generated reports."""
+        ledger.add_client_fund("cf-001", Decimal("100.00"))
+        ledger.add_safeguarding("sg-001", Decimal("100.00"))
+
+        r1 = engine.run_daily_recon("2026-04-28")
+        r2 = engine.run_daily_recon("2026-04-29")
+        report_gen.generate(r1)
+        report_gen.generate(r2)
+
+        assert len(report_gen.reports) == 2
+
+
+# ─�� Model Tests ──────────────────────────────────────────────────────────────
+
+
+class TestModels:
+    def test_account_balance_decimal_only(self):
+        """AccountBalance rejects non-Decimal (I-01)."""
+        with pytest.raises(TypeError, match="Decimal"):
+            AccountBalance(
+                account_id="a-001",
+                account_name="Test",
+                balance=100.0,  # type: ignore[arg-type]
+                currency="GBP",
+            )
+
+    def test_discrepancy_decimal_only(self):
+        """Discrepancy rejects non-Decimal fields (I-01)."""
+        with pytest.raises(TypeError, match="Decimal"):
+            Discrepancy(
+                discrepancy_id="d-001",
+                discrepancy_type=DiscrepancyType.SHORTFALL,
+                expected=100.0,  # type: ignore[arg-type]
+                actual=Decimal("90"),
+                difference=Decimal("10"),
+                account_id="a-001",
+                description="test",
+            )
+
+    def test_recon_result_decimal_only(self):
+        """ReconResult rejects non-Decimal fields (I-01)."""
+        with pytest.raises(TypeError, match="Decimal"):
+            ReconResult(
+                recon_id="r-001",
+                recon_date="2026-04-28",
+                status=ReconStatus.BALANCED,
+                client_funds_total=100.0,  # type: ignore[arg-type]
+                safeguarding_total=Decimal("100"),
+                difference=Decimal("0"),
+            )
+
+    def test_recon_result_frozen(self):
+        """ReconResult is immutable (I-24)."""
+        result = ReconResult(
+            recon_id="r-001",
+            recon_date="2026-04-28",
+            status=ReconStatus.BALANCED,
+            client_funds_total=Decimal("100"),
+            safeguarding_total=Decimal("100"),
+            difference=Decimal("0"),
+        )
+        with pytest.raises(AttributeError):
+            result.status = ReconStatus.DISCREPANCY  # type: ignore[misc]
+
+    def test_recon_tolerance_value(self):
+        """RECON_TOLERANCE is £0.01."""
+        assert Decimal("0.01") == RECON_TOLERANCE
+
+    def test_large_value_threshold(self):
+        """LARGE_VALUE_THRESHOLD is £50,000."""
+        assert Decimal("50000") == LARGE_VALUE_THRESHOLD


### PR DESCRIPTION
## Summary
- ReconciliationEngine: daily client funds vs safeguarding balance comparison
- Discrepancy detection with SHORTFALL/SURPLUS classification
- HITL escalation for shortfalls (MLRO approval required, I-27)
- Blocked jurisdiction exclusion (I-02)
- Large value flagging (>=50k GBP, I-04)
- ReconReportGenerator for daily JSON reports (FCA CASS 7)
- Immutable audit trail for every recon run (I-24)

## Files
- services/recon/recon_engine.py — ReconciliationEngine
- services/recon/recon_models.py — ReconResult, Discrepancy, ReconStatus
- services/recon/recon_port.py — LedgerPort Protocol + InMemoryLedgerPort
- services/recon/recon_report.py — ReconReportGenerator
- tests/test_recon_engine.py — 34 tests

## Test plan
- [x] 34 tests passing
- [x] Coverage: 91-100% on all new files
- [x] Ruff clean

Closes #23

Generated with Claude Code