### PR TITLE
feat(ledger): financial accounts GL — double-entry bookkeeping [IL-FIN-01]

### DIFF
--- a/services/ledger/gl_service.py
+++ b/services/ledger/gl_service.py
@@ -1,0 +1,277 @@
+"""
+services/ledger/gl_service.py
+GLService — double-entry bookkeeping service (IL-FIN-01).
+
+Covers S16 (Financial Accounts) and GAP D-gl (Midaz GL).
+
+I-01: Decimal ONLY for money.
+I-02: Blocked jurisdictions → account rejected.
+I-04: High-value postings flagged for MLRO.
+I-24: Immutable audit trail for every GL operation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Protocol
+from uuid import uuid4
+
+from services.ledger.ledger_models import (
+    BLOCKED_JURISDICTIONS,
+    HIGH_VALUE_THRESHOLD,
+    SUPPORTED_CURRENCIES,
+    Account,
+    AccountType,
+    GLAuditEntry,
+    JournalEntry,
+    Posting,
+    PostingDirection,
+    PostingStatus,
+)
+from services.ledger.ledger_port import LedgerPort
+
+# ── Errors ───────────────────────────────────────────────────────────────────
+
+
+class JurisdictionBlockedError(ValueError):
+    """Raised when account jurisdiction is sanctioned (I-02)."""
+
+
+class UnbalancedEntryError(ValueError):
+    """Raised when journal entry debits != credits."""
+
+
+class HighValuePostingError(ValueError):
+    """Raised when posting exceeds high-value threshold without approval (I-04)."""
+
+
+# ── Audit Port ───────────────────────────────────────────────────────────────
+
+
+class GLAuditPort(Protocol):
+    """Port for recording GL audit entries (I-24)."""
+
+    def record(self, entry: GLAuditEntry) -> None: ...
+
+
+class InMemoryGLAuditPort:
+    """In-memory audit trail for tests."""
+
+    def __init__(self) -> None:
+        self._entries: list[GLAuditEntry] = []
+
+    def record(self, entry: GLAuditEntry) -> None:
+        self._entries.append(entry)
+
+    @property
+    def entries(self) -> list[GLAuditEntry]:
+        return list(self._entries)
+
+
+# ── HITL Proposal ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class HighValueHITLProposal:
+    """High-value posting requires MLRO approval (I-04, I-27)."""
+
+    entry_id: str
+    total_amount: str  # Decimal as string
+    currency: str
+    reason: str
+    requires_approval_from: str = "MLRO"
+
+
+# ── GL Service ───────────────────────────────────────────────────────────────
+
+
+class GLService:
+    """
+    General Ledger service with double-entry bookkeeping.
+
+    Enforces:
+    - Double-entry balance (debits == credits per currency)
+    - Jurisdiction blocking (I-02)
+    - High-value flagging (I-04)
+    - Immutable audit trail (I-24)
+    """
+
+    def __init__(
+        self,
+        ledger: LedgerPort,
+        audit: GLAuditPort | None = None,
+    ) -> None:
+        self._ledger = ledger
+        self._audit: GLAuditPort = audit or InMemoryGLAuditPort()
+
+    # ── Account Operations ───────────────────────────────────────────────────
+
+    def create_account(
+        self,
+        name: str,
+        account_type: AccountType,
+        currency: str,
+        jurisdiction: str = "GB",
+    ) -> Account:
+        """Create a new GL account. Rejects blocked jurisdictions (I-02)."""
+        # I-02: block sanctioned jurisdictions.
+        if jurisdiction.upper() in BLOCKED_JURISDICTIONS:
+            raise JurisdictionBlockedError(
+                f"Account jurisdiction {jurisdiction!r} is sanctioned (I-02)."
+            )
+
+        if currency not in SUPPORTED_CURRENCIES:
+            raise ValueError(
+                f"Unsupported currency: {currency} "
+                f"(supported: {', '.join(sorted(SUPPORTED_CURRENCIES))})"
+            )
+
+        account = Account(
+            account_id=f"acc-{uuid4().hex[:12]}",
+            name=name,
+            account_type=account_type,
+            currency=currency,
+            jurisdiction=jurisdiction.upper(),
+        )
+        created = self._ledger.create_account(account)
+
+        self._record_audit(
+            entry_id=created.account_id,
+            action="CREATE_ACCOUNT",
+            status=PostingStatus.POSTED,
+            total_amount=Decimal("0"),
+            currency=currency,
+            actor="SYSTEM",
+            details=f"type={account_type.value}, jurisdiction={jurisdiction.upper()}",
+        )
+
+        return created
+
+    def get_account(self, account_id: str) -> Account | None:
+        """Fetch account by ID."""
+        return self._ledger.get_account(account_id)
+
+    def get_balance(self, account_id: str) -> Decimal:
+        """Return current balance for account (I-01: Decimal)."""
+        return self._ledger.get_account_balance(account_id)
+
+    # ── Journal Entry Operations ─────────────────────────────────────────────
+
+    def post_journal_entry(
+        self,
+        description: str,
+        postings: list[tuple[str, PostingDirection, Decimal, str]],
+        high_value_approved: bool = False,
+    ) -> JournalEntry | HighValueHITLProposal:
+        """
+        Post a double-entry journal entry.
+
+        Each posting tuple: (account_id, direction, amount, currency).
+
+        Returns JournalEntry if posted.
+        Returns HighValueHITLProposal if total > threshold and not approved (I-04).
+        Raises UnbalancedEntryError if debits != credits.
+        """
+        entry_id = f"je-{uuid4().hex[:12]}"
+
+        # Build Posting objects.
+        posting_objs: list[Posting] = []
+        for i, (acc_id, direction, amount, currency) in enumerate(postings):
+            if not isinstance(amount, Decimal):
+                raise TypeError(
+                    f"Amount must be Decimal, got {type(amount).__name__} (I-01)"
+                )
+            posting_objs.append(
+                Posting(
+                    posting_id=f"{entry_id}-p{i}",
+                    account_id=acc_id,
+                    direction=direction,
+                    amount=amount,
+                    currency=currency,
+                )
+            )
+
+        # Validate double-entry balance per currency.
+        self._validate_balance(posting_objs)
+
+        # I-04: check high-value threshold.
+        total_debit = sum(
+            (p.amount for p in posting_objs if p.direction == PostingDirection.DEBIT),
+            Decimal("0"),
+        )
+        currencies = {p.currency for p in posting_objs}
+        primary_currency = next(iter(currencies))
+
+        if total_debit >= HIGH_VALUE_THRESHOLD and not high_value_approved:
+            return HighValueHITLProposal(
+                entry_id=entry_id,
+                total_amount=str(total_debit),
+                currency=primary_currency,
+                reason=(
+                    f"Journal entry total {primary_currency} {total_debit} "
+                    f"exceeds high-value threshold {HIGH_VALUE_THRESHOLD}. "
+                    "MLRO approval required (I-04, I-27)."
+                ),
+            )
+
+        entry = JournalEntry(
+            entry_id=entry_id,
+            description=description,
+            postings=tuple(posting_objs),
+        )
+
+        posted = self._ledger.post_journal_entry(entry)
+
+        self._record_audit(
+            entry_id=entry_id,
+            action="POST_JOURNAL_ENTRY",
+            status=posted.status,
+            total_amount=total_debit,
+            currency=primary_currency,
+            actor="SYSTEM",
+            details=f"postings={len(posting_objs)}, description={description}",
+        )
+
+        return posted
+
+    # ── Private helpers ──────────────────────────────────────────────────────
+
+    def _validate_balance(self, postings: list[Posting]) -> None:
+        """Validate that debits == credits per currency."""
+        # Group by currency.
+        by_currency: dict[str, dict[str, Decimal]] = {}
+        for p in postings:
+            if p.currency not in by_currency:
+                by_currency[p.currency] = {"DEBIT": Decimal("0"), "CREDIT": Decimal("0")}
+            by_currency[p.currency][p.direction.value] += p.amount
+
+        for currency, totals in by_currency.items():
+            if totals["DEBIT"] != totals["CREDIT"]:
+                raise UnbalancedEntryError(
+                    f"Unbalanced entry for {currency}: "
+                    f"debits={totals['DEBIT']}, credits={totals['CREDIT']}. "
+                    "Double-entry requires debits == credits."
+                )
+
+    def _record_audit(
+        self,
+        *,
+        entry_id: str,
+        action: str,
+        status: PostingStatus,
+        total_amount: Decimal,
+        currency: str,
+        actor: str,
+        details: str = "",
+    ) -> None:
+        entry = GLAuditEntry(
+            entry_id=entry_id,
+            action=action,
+            status=status,
+            total_amount=total_amount,
+            currency=currency,
+            actor=actor,
+            details=details,
+        )
+        self._audit.record(entry)

--- a/services/ledger/inmemory_ledger.py
+++ b/services/ledger/inmemory_ledger.py
@@ -1,0 +1,75 @@
+"""
+services/ledger/inmemory_ledger.py
+InMemoryLedger — test stub implementing LedgerPort (IL-FIN-01).
+
+I-01: All monetary values are Decimal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+
+from services.ledger.ledger_models import (
+    Account,
+    JournalEntry,
+    PostingDirection,
+    PostingStatus,
+)
+
+
+class InMemoryLedger:
+    """In-memory GL implementing LedgerPort for unit tests."""
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, Account] = {}
+        self._entries: dict[str, JournalEntry] = {}
+
+    def create_account(self, account: Account) -> Account:
+        if account.account_id in self._accounts:
+            raise ValueError(f"Account {account.account_id!r} already exists")
+        self._accounts[account.account_id] = account
+        return account
+
+    def get_account(self, account_id: str) -> Account | None:
+        return self._accounts.get(account_id)
+
+    def post_journal_entry(self, entry: JournalEntry) -> JournalEntry:
+        if entry.entry_id in self._entries:
+            raise ValueError(f"Journal entry {entry.entry_id!r} already exists")
+        # Verify all accounts exist.
+        for posting in entry.postings:
+            if posting.account_id not in self._accounts:
+                raise ValueError(
+                    f"Account {posting.account_id!r} not found for posting"
+                )
+        posted = replace(entry, status=PostingStatus.POSTED)
+        self._entries[entry.entry_id] = posted
+        return posted
+
+    def get_journal_entry(self, entry_id: str) -> JournalEntry | None:
+        return self._entries.get(entry_id)
+
+    def get_account_balance(self, account_id: str) -> Decimal:
+        """Compute balance from posted journal entries (I-01: Decimal)."""
+        if account_id not in self._accounts:
+            raise ValueError(f"Account {account_id!r} not found")
+        balance = Decimal("0")
+        for entry in self._entries.values():
+            if entry.status != PostingStatus.POSTED:
+                continue
+            for posting in entry.postings:
+                if posting.account_id == account_id:
+                    if posting.direction == PostingDirection.DEBIT:
+                        balance += posting.amount
+                    else:
+                        balance -= posting.amount
+        return balance
+
+    @property
+    def accounts(self) -> dict[str, Account]:
+        return dict(self._accounts)
+
+    @property
+    def entries(self) -> dict[str, JournalEntry]:
+        return dict(self._entries)

--- a/services/ledger/ledger_models.py
+++ b/services/ledger/ledger_models.py
@@ -1,0 +1,127 @@
+"""
+services/ledger/ledger_models.py
+General Ledger domain models (IL-FIN-01).
+
+Double-entry bookkeeping: every JournalEntry has balanced debit/credit postings.
+
+I-01: All monetary values are Decimal — never float.
+I-24: Immutable records via frozen dataclasses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import Enum
+
+
+class PostingStatus(str, Enum):
+    """Status of a journal entry posting."""
+
+    PENDING = "PENDING"
+    POSTED = "POSTED"
+    REVERSED = "REVERSED"
+    FAILED = "FAILED"
+
+
+class AccountType(str, Enum):
+    """Chart of accounts classification."""
+
+    ASSET = "ASSET"
+    LIABILITY = "LIABILITY"
+    EQUITY = "EQUITY"
+    REVENUE = "REVENUE"
+    EXPENSE = "EXPENSE"
+
+
+class PostingDirection(str, Enum):
+    """Debit or credit."""
+
+    DEBIT = "DEBIT"
+    CREDIT = "CREDIT"
+
+
+SUPPORTED_CURRENCIES: frozenset[str] = frozenset({"GBP", "EUR", "USD"})
+
+BLOCKED_JURISDICTIONS: frozenset[str] = frozenset({
+    "RU", "BY", "IR", "KP", "CU", "MM", "AF", "VE", "SY",
+})
+
+# I-04: high-value posting threshold.
+HIGH_VALUE_THRESHOLD: Decimal = Decimal("50000")
+
+
+@dataclass(frozen=True)
+class Account:
+    """A General Ledger account (I-24 immutable)."""
+
+    account_id: str
+    name: str
+    account_type: AccountType
+    currency: str
+    jurisdiction: str = "GB"
+    is_active: bool = True
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def __post_init__(self) -> None:
+        if self.currency not in SUPPORTED_CURRENCIES:
+            raise ValueError(
+                f"Unsupported currency: {self.currency} "
+                f"(supported: {', '.join(sorted(SUPPORTED_CURRENCIES))})"
+            )
+
+
+@dataclass(frozen=True)
+class Posting:
+    """A single debit or credit within a journal entry (I-24 immutable)."""
+
+    posting_id: str
+    account_id: str
+    direction: PostingDirection
+    amount: Decimal  # I-01
+    currency: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.amount, Decimal):
+            raise TypeError(
+                f"amount must be Decimal, got {type(self.amount).__name__} (I-01)"
+            )
+        if self.amount <= Decimal("0"):
+            raise ValueError(f"amount must be positive, got {self.amount}")
+        if self.currency not in SUPPORTED_CURRENCIES:
+            raise ValueError(f"Unsupported currency: {self.currency}")
+
+
+@dataclass(frozen=True)
+class JournalEntry:
+    """
+    A double-entry journal entry (I-24 immutable).
+
+    Invariant: sum of debits == sum of credits for the same currency.
+    """
+
+    entry_id: str
+    description: str
+    postings: tuple[Posting, ...]
+    status: PostingStatus = PostingStatus.PENDING
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if len(self.postings) < 2:
+            raise ValueError("Journal entry must have at least 2 postings")
+
+
+@dataclass(frozen=True)
+class GLAuditEntry:
+    """Immutable audit record for GL operations (I-24)."""
+
+    entry_id: str
+    action: str
+    status: PostingStatus
+    total_amount: Decimal  # I-01
+    currency: str
+    actor: str
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    details: str = ""

--- a/services/ledger/ledger_port.py
+++ b/services/ledger/ledger_port.py
@@ -1,0 +1,37 @@
+"""
+services/ledger/ledger_port.py
+LedgerPort Protocol for General Ledger operations (IL-FIN-01).
+
+Hexagonal port: adapters interact with Midaz GL / InMemory stub.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Protocol
+
+from services.ledger.ledger_models import Account, JournalEntry
+
+
+class LedgerPort(Protocol):
+    """Port for General Ledger operations."""
+
+    def create_account(self, account: Account) -> Account:
+        """Create a new GL account."""
+        ...
+
+    def get_account(self, account_id: str) -> Account | None:
+        """Fetch account by ID."""
+        ...
+
+    def post_journal_entry(self, entry: JournalEntry) -> JournalEntry:
+        """Post a journal entry to the GL."""
+        ...
+
+    def get_journal_entry(self, entry_id: str) -> JournalEntry | None:
+        """Fetch a journal entry by ID."""
+        ...
+
+    def get_account_balance(self, account_id: str) -> Decimal:
+        """Return current balance for account (Decimal, I-01)."""
+        ...

--- a/tests/test_gl_service.py
+++ b/tests/test_gl_service.py
@@ -1,0 +1,433 @@
+"""
+tests/test_gl_service.py
+Tests for GLService — double-entry bookkeeping (IL-FIN-01).
+
+Acceptance criteria:
+- test_double_entry_debit_credit_balanced (Decimal, I-01)
+- test_journal_entry_immutable (I-24)
+- test_multi_currency_posting (GBP/EUR/USD)
+- test_blocked_jurisdiction_account_rejected (I-02)
+- test_high_value_posting_flagged (I-04)
+- test_gl_audit_trail_complete (I-24)
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from services.ledger.gl_service import (
+    GLService,
+    HighValueHITLProposal,
+    InMemoryGLAuditPort,
+    JurisdictionBlockedError,
+    UnbalancedEntryError,
+)
+from services.ledger.inmemory_ledger import InMemoryLedger
+from services.ledger.ledger_models import (
+    BLOCKED_JURISDICTIONS,
+    HIGH_VALUE_THRESHOLD,
+    SUPPORTED_CURRENCIES,
+    Account,
+    AccountType,
+    GLAuditEntry,
+    JournalEntry,
+    Posting,
+    PostingDirection,
+    PostingStatus,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ledger():
+    return InMemoryLedger()
+
+
+@pytest.fixture
+def audit():
+    return InMemoryGLAuditPort()
+
+
+@pytest.fixture
+def service(ledger, audit):
+    return GLService(ledger=ledger, audit=audit)
+
+
+def _create_two_accounts(service, currency="GBP"):
+    """Helper: create a debit and credit account."""
+    cash = service.create_account("Cash", AccountType.ASSET, currency)
+    revenue = service.create_account("Revenue", AccountType.REVENUE, currency)
+    return cash, revenue
+
+
+# ── Double-Entry Balance Tests ───────────────────────────────────────────────
+
+
+class TestDoubleEntry:
+    def test_double_entry_debit_credit_balanced(self, service):
+        """AC: balanced journal entry posts successfully (Decimal, I-01)."""
+        cash, revenue = _create_two_accounts(service)
+        result = service.post_journal_entry(
+            description="Sale revenue",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("500.00"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("500.00"), "GBP"),
+            ],
+        )
+        assert isinstance(result, JournalEntry)
+        assert result.status == PostingStatus.POSTED
+        assert len(result.postings) == 2
+
+    def test_unbalanced_entry_rejected(self, service):
+        """Unbalanced journal entry raises UnbalancedEntryError."""
+        cash, revenue = _create_two_accounts(service)
+        with pytest.raises(UnbalancedEntryError, match="Unbalanced"):
+            service.post_journal_entry(
+                description="Bad entry",
+                postings=[
+                    (cash.account_id, PostingDirection.DEBIT, Decimal("500.00"), "GBP"),
+                    (revenue.account_id, PostingDirection.CREDIT, Decimal("499.99"), "GBP"),
+                ],
+            )
+
+    def test_balance_updated_after_posting(self, service):
+        """Account balances reflect posted entries."""
+        cash, revenue = _create_two_accounts(service)
+        service.post_journal_entry(
+            description="Sale",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("1000.00"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("1000.00"), "GBP"),
+            ],
+        )
+        assert service.get_balance(cash.account_id) == Decimal("1000.00")
+        assert service.get_balance(revenue.account_id) == Decimal("-1000.00")
+
+    def test_multiple_postings_accumulate(self, service):
+        """Multiple journal entries accumulate balances."""
+        cash, revenue = _create_two_accounts(service)
+        for i in range(3):
+            service.post_journal_entry(
+                description=f"Sale {i}",
+                postings=[
+                    (cash.account_id, PostingDirection.DEBIT, Decimal("100.00"), "GBP"),
+                    (revenue.account_id, PostingDirection.CREDIT, Decimal("100.00"), "GBP"),
+                ],
+            )
+        assert service.get_balance(cash.account_id) == Decimal("300.00")
+
+    def test_three_leg_entry(self, service):
+        """Three-posting entry (split) must still balance."""
+        cash = service.create_account("Cash", AccountType.ASSET, "GBP")
+        tax = service.create_account("Tax", AccountType.LIABILITY, "GBP")
+        revenue = service.create_account("Revenue", AccountType.REVENUE, "GBP")
+
+        result = service.post_journal_entry(
+            description="Sale with tax",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("120.00"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("100.00"), "GBP"),
+                (tax.account_id, PostingDirection.CREDIT, Decimal("20.00"), "GBP"),
+            ],
+        )
+        assert isinstance(result, JournalEntry)
+        assert result.status == PostingStatus.POSTED
+
+
+# ── Immutability Tests ───────────────────────────────────────────────────────
+
+
+class TestImmutability:
+    def test_journal_entry_immutable(self, service):
+        """AC: JournalEntry is frozen (I-24)."""
+        cash, revenue = _create_two_accounts(service)
+        result = service.post_journal_entry(
+            description="Test",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("100.00"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("100.00"), "GBP"),
+            ],
+        )
+        with pytest.raises(AttributeError):
+            result.status = PostingStatus.REVERSED  # type: ignore[misc]
+
+    def test_account_immutable(self, service):
+        """Account is frozen (I-24)."""
+        account = service.create_account("Cash", AccountType.ASSET, "GBP")
+        with pytest.raises(AttributeError):
+            account.name = "Modified"  # type: ignore[misc]
+
+    def test_posting_immutable(self):
+        """Posting is frozen (I-24)."""
+        posting = Posting(
+            posting_id="p-001",
+            account_id="acc-001",
+            direction=PostingDirection.DEBIT,
+            amount=Decimal("100"),
+            currency="GBP",
+        )
+        with pytest.raises(AttributeError):
+            posting.amount = Decimal("200")  # type: ignore[misc]
+
+    def test_gl_audit_entry_immutable(self):
+        """GLAuditEntry is frozen (I-24)."""
+        entry = GLAuditEntry(
+            entry_id="je-001",
+            action="TEST",
+            status=PostingStatus.POSTED,
+            total_amount=Decimal("100"),
+            currency="GBP",
+            actor="test",
+        )
+        with pytest.raises(AttributeError):
+            entry.action = "MODIFIED"  # type: ignore[misc]
+
+
+# ── Multi-Currency Tests ─────────────────────────────────────────────────────
+
+
+class TestMultiCurrency:
+    def test_multi_currency_posting_gbp(self, service):
+        """AC: GBP posting works."""
+        cash, revenue = _create_two_accounts(service, "GBP")
+        result = service.post_journal_entry(
+            description="GBP sale",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("100.00"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("100.00"), "GBP"),
+            ],
+        )
+        assert isinstance(result, JournalEntry)
+
+    def test_multi_currency_posting_eur(self, service):
+        """AC: EUR posting works."""
+        cash, revenue = _create_two_accounts(service, "EUR")
+        result = service.post_journal_entry(
+            description="EUR sale",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("250.50"), "EUR"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("250.50"), "EUR"),
+            ],
+        )
+        assert isinstance(result, JournalEntry)
+
+    def test_multi_currency_posting_usd(self, service):
+        """AC: USD posting works."""
+        cash, revenue = _create_two_accounts(service, "USD")
+        result = service.post_journal_entry(
+            description="USD sale",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("500.00"), "USD"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("500.00"), "USD"),
+            ],
+        )
+        assert isinstance(result, JournalEntry)
+
+    def test_unsupported_currency_rejected(self, service):
+        """Unsupported currency raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported currency"):
+            service.create_account("Cash", AccountType.ASSET, "CHF")
+
+    def test_supported_currencies_set(self):
+        """Verify supported currencies include GBP, EUR, USD."""
+        assert frozenset({"GBP", "EUR", "USD"}) == SUPPORTED_CURRENCIES
+
+
+# ── Jurisdiction Blocking Tests ──────────────────────────────────────────────
+
+
+class TestJurisdictionBlocking:
+    def test_blocked_jurisdiction_account_rejected_ru(self, service):
+        """AC: RU jurisdiction account rejected (I-02)."""
+        with pytest.raises(JurisdictionBlockedError, match="sanctioned"):
+            service.create_account("Bad Account", AccountType.ASSET, "GBP", "RU")
+
+    def test_blocked_jurisdiction_ir(self, service):
+        """IR jurisdiction blocked (I-02)."""
+        with pytest.raises(JurisdictionBlockedError):
+            service.create_account("Bad", AccountType.ASSET, "GBP", "IR")
+
+    def test_blocked_jurisdiction_kp(self, service):
+        """KP jurisdiction blocked (I-02)."""
+        with pytest.raises(JurisdictionBlockedError):
+            service.create_account("Bad", AccountType.ASSET, "GBP", "KP")
+
+    def test_blocked_jurisdiction_case_insensitive(self, service):
+        """Jurisdiction check is case-insensitive."""
+        with pytest.raises(JurisdictionBlockedError):
+            service.create_account("Bad", AccountType.ASSET, "GBP", "ru")
+
+    def test_all_blocked_jurisdictions(self):
+        """Verify all I-02 blocked countries."""
+        expected = {"RU", "BY", "IR", "KP", "CU", "MM", "AF", "VE", "SY"}
+        assert expected == BLOCKED_JURISDICTIONS
+
+    def test_gb_jurisdiction_allowed(self, service):
+        """GB jurisdiction is allowed."""
+        account = service.create_account("Cash", AccountType.ASSET, "GBP", "GB")
+        assert account.jurisdiction == "GB"
+
+
+# ── High-Value Posting Tests ─────────────────────────────────────────────────
+
+
+class TestHighValue:
+    def test_high_value_posting_flagged(self, service):
+        """AC: posting >= £50k returns HighValueHITLProposal (I-04)."""
+        cash, revenue = _create_two_accounts(service)
+        result = service.post_journal_entry(
+            description="Large sale",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("50000.00"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("50000.00"), "GBP"),
+            ],
+        )
+        assert isinstance(result, HighValueHITLProposal)
+        assert result.requires_approval_from == "MLRO"
+        assert result.total_amount == "50000.00"
+
+    def test_below_threshold_posts_normally(self, service):
+        """Posting below threshold posts without HITL."""
+        cash, revenue = _create_two_accounts(service)
+        result = service.post_journal_entry(
+            description="Normal sale",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("49999.99"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("49999.99"), "GBP"),
+            ],
+        )
+        assert isinstance(result, JournalEntry)
+
+    def test_high_value_approved_posts(self, service):
+        """Pre-approved high-value posting succeeds."""
+        cash, revenue = _create_two_accounts(service)
+        result = service.post_journal_entry(
+            description="Approved large sale",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("100000.00"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("100000.00"), "GBP"),
+            ],
+            high_value_approved=True,
+        )
+        assert isinstance(result, JournalEntry)
+        assert result.status == PostingStatus.POSTED
+
+    def test_high_value_threshold(self):
+        """HIGH_VALUE_THRESHOLD is £50,000."""
+        assert Decimal("50000") == HIGH_VALUE_THRESHOLD
+
+
+# ── Audit Trail Tests ────────────────────────────────────────────────────────
+
+
+class TestAuditTrail:
+    def test_gl_audit_trail_complete_account_creation(self, service, audit):
+        """AC: audit entry for account creation (I-24)."""
+        service.create_account("Cash", AccountType.ASSET, "GBP")
+        assert len(audit.entries) == 1
+        entry = audit.entries[0]
+        assert entry.action == "CREATE_ACCOUNT"
+        assert entry.status == PostingStatus.POSTED
+        assert isinstance(entry.total_amount, Decimal)
+
+    def test_gl_audit_trail_journal_entry(self, service, audit):
+        """AC: audit entry for journal entry posting (I-24)."""
+        cash, revenue = _create_two_accounts(service)
+        service.post_journal_entry(
+            description="Sale",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("100.00"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("100.00"), "GBP"),
+            ],
+        )
+        # 2 account creations + 1 journal entry = 3 audit entries
+        assert len(audit.entries) == 3
+        je_entry = audit.entries[-1]
+        assert je_entry.action == "POST_JOURNAL_ENTRY"
+        assert je_entry.total_amount == Decimal("100.00")
+
+    def test_audit_includes_details(self, service, audit):
+        """Audit entry includes posting details."""
+        cash, revenue = _create_two_accounts(service)
+        service.post_journal_entry(
+            description="Test sale",
+            postings=[
+                (cash.account_id, PostingDirection.DEBIT, Decimal("100.00"), "GBP"),
+                (revenue.account_id, PostingDirection.CREDIT, Decimal("100.00"), "GBP"),
+            ],
+        )
+        je_entry = audit.entries[-1]
+        assert "postings=2" in je_entry.details
+        assert "Test sale" in je_entry.details
+
+
+# ── Model Validation Tests ───────────────────────────────────────────────────
+
+
+class TestModels:
+    def test_posting_decimal_only(self):
+        """Posting rejects non-Decimal amount (I-01)."""
+        with pytest.raises(TypeError, match="Decimal"):
+            Posting(
+                posting_id="p-001",
+                account_id="acc-001",
+                direction=PostingDirection.DEBIT,
+                amount=100.0,  # type: ignore[arg-type]
+                currency="GBP",
+            )
+
+    def test_posting_positive_amount(self):
+        """Posting rejects non-positive amount."""
+        with pytest.raises(ValueError, match="positive"):
+            Posting(
+                posting_id="p-001",
+                account_id="acc-001",
+                direction=PostingDirection.DEBIT,
+                amount=Decimal("-10"),
+                currency="GBP",
+            )
+
+    def test_journal_entry_min_postings(self):
+        """JournalEntry requires at least 2 postings."""
+        with pytest.raises(ValueError, match="at least 2"):
+            JournalEntry(
+                entry_id="je-001",
+                description="Bad",
+                postings=(
+                    Posting("p-001", "acc-001", PostingDirection.DEBIT, Decimal("100"), "GBP"),
+                ),
+            )
+
+    def test_account_unsupported_currency(self):
+        """Account rejects unsupported currency."""
+        with pytest.raises(ValueError, match="Unsupported currency"):
+            Account(
+                account_id="acc-001",
+                name="Bad",
+                account_type=AccountType.ASSET,
+                currency="JPY",
+            )
+
+    def test_get_account(self, service):
+        """get_account returns created account."""
+        account = service.create_account("Cash", AccountType.ASSET, "GBP")
+        found = service.get_account(account.account_id)
+        assert found is not None
+        assert found.account_id == account.account_id
+
+    def test_get_account_not_found(self, service):
+        """get_account returns None for unknown ID."""
+        assert service.get_account("nonexistent") is None
+
+    def test_non_decimal_amount_rejected(self, service):
+        """Non-Decimal amount in posting rejected (I-01)."""
+        cash, revenue = _create_two_accounts(service)
+        with pytest.raises(TypeError, match="Decimal"):
+            service.post_journal_entry(
+                description="Bad",
+                postings=[
+                    (cash.account_id, PostingDirection.DEBIT, 100.0, "GBP"),  # type: ignore[list-item]
+                    (revenue.account_id, PostingDirection.CREDIT, Decimal("100"), "GBP"),
+                ],
+            )


### PR DESCRIPTION
## Summary
- GLService: double-entry bookkeeping with balanced debit/credit validation
- LedgerPort Protocol + InMemoryLedger stub
- Account, JournalEntry, Posting domain models (frozen, I-24)
- Multi-currency: GBP, EUR, USD
- High-value posting HITL (>=50k, I-04)
- Jurisdiction blocking for account creation (I-02)
- Immutable audit trail for all GL operations (I-24)

## Files
- services/ledger/gl_service.py — GLService
- services/ledger/ledger_models.py — Account, JournalEntry, Posting, PostingStatus
- services/ledger/ledger_port.py — LedgerPort Protocol
- services/ledger/inmemory_ledger.py — InMemoryLedger
- tests/test_gl_service.py — 34 tests

## Test plan
- [x] 34 tests passing
- [x] Coverage: 82-100% on all new files
- [x] Ruff clean

Closes #25

Generated with Claude Code