### PR TITLE
feat(ledger): CBS GL — payment posting logic via LedgerPort [IL-CBS-01]

### DIFF
--- a/services/ledger/payment_posting_service.py
+++ b/services/ledger/payment_posting_service.py
@@ -1,0 +1,194 @@
+"""
+services/ledger/payment_posting_service.py
+PaymentPostingService — wires payment events to GL journal entries (IL-CBS-01).
+
+When a payment settles/refunds, auto-posts balanced double-entry journal entries.
+I-01: Decimal ONLY.
+I-02: Blocked jurisdictions → reject.
+I-04: High-value flagged.
+I-24: Immutable audit trail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Protocol
+
+from services.ledger.gl_service import GLService, HighValueHITLProposal
+from services.ledger.ledger_models import (
+    JournalEntry,
+    PostingDirection,
+)
+from services.ledger.posting_models import PaymentEvent
+from services.ledger.posting_rules import (
+    HighValuePostingFlag,
+    PostingRuleEngine,
+)
+
+# ── Audit ────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PostingAuditEntry:
+    """Immutable audit entry for payment postings (I-24)."""
+
+    event_id: str
+    transaction_id: str
+    event_type: str
+    journal_entry_id: str | None
+    amount: Decimal  # I-01
+    currency: str
+    action: str
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    details: str = ""
+
+
+class PostingAuditPort(Protocol):
+    """Port for recording posting audit entries (I-24)."""
+
+    def record(self, entry: PostingAuditEntry) -> None: ...
+
+
+class InMemoryPostingAuditPort:
+    """In-memory audit for tests."""
+
+    def __init__(self) -> None:
+        self._entries: list[PostingAuditEntry] = []
+
+    def record(self, entry: PostingAuditEntry) -> None:
+        self._entries.append(entry)
+
+    @property
+    def entries(self) -> list[PostingAuditEntry]:
+        return list(self._entries)
+
+
+# ── Account Registry ─────────────────────────────────────────────────────────
+
+
+class AccountRegistry:
+    """
+    Maps logical account types to GL account IDs.
+
+    In production, backed by database lookup.
+    For tests, uses in-memory mapping.
+    """
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, dict[str, str]] = {}
+
+    def register(self, account_type: str, currency: str, account_id: str) -> None:
+        key = f"{account_type}:{currency}"
+        self._accounts[key] = {"account_id": account_id, "currency": currency}
+
+    def get_account_id(self, account_type: str, currency: str) -> str | None:
+        key = f"{account_type}:{currency}"
+        entry = self._accounts.get(key)
+        return entry["account_id"] if entry else None
+
+
+# ── Payment Posting Service ──────────────────────────────────────────────────
+
+
+class PaymentPostingService:
+    """
+    Processes payment events into GL journal entries.
+
+    For each payment event (capture, settle, refund):
+    1. Resolve posting rule (debit/credit account types)
+    2. Map account types to GL account IDs
+    3. Post balanced double-entry journal entry
+    4. Record audit trail
+
+    I-01: Decimal amounts.
+    I-02: Blocked jurisdictions rejected.
+    I-04: High-value events flagged.
+    I-24: Immutable audit trail.
+    """
+
+    def __init__(
+        self,
+        gl: GLService,
+        rules: PostingRuleEngine | None = None,
+        registry: AccountRegistry | None = None,
+        audit: PostingAuditPort | None = None,
+    ) -> None:
+        self._gl = gl
+        self._rules = rules or PostingRuleEngine()
+        self._registry = registry or AccountRegistry()
+        self._audit: PostingAuditPort = audit or InMemoryPostingAuditPort()
+        self._high_value_flags: list[HighValuePostingFlag] = []
+
+    @property
+    def high_value_flags(self) -> list[HighValuePostingFlag]:
+        return list(self._high_value_flags)
+
+    def process_event(
+        self,
+        event: PaymentEvent,
+        high_value_approved: bool = False,
+    ) -> JournalEntry | HighValueHITLProposal:
+        """
+        Process a payment event into a GL journal entry.
+
+        Returns JournalEntry if posted.
+        Returns HighValueHITLProposal if high-value and not approved (I-04).
+        Raises JurisdictionBlockedError for blocked jurisdictions (I-02).
+        """
+        # Resolve posting rule (checks I-02).
+        rule = self._rules.resolve(event)
+
+        # Check high value (I-04).
+        hv_flag = self._rules.check_high_value(event)
+        if hv_flag is not None:
+            self._high_value_flags.append(hv_flag)
+
+        # Resolve account IDs.
+        debit_acc = self._registry.get_account_id(rule.debit_account_type, event.currency)
+        credit_acc = self._registry.get_account_id(rule.credit_account_type, event.currency)
+
+        if debit_acc is None or credit_acc is None:
+            raise ValueError(
+                f"Account not found for posting: debit={rule.debit_account_type}, "
+                f"credit={rule.credit_account_type}, currency={event.currency}"
+            )
+
+        description = self._rules.get_description(rule, event)
+
+        # Post journal entry via GLService.
+        result = self._gl.post_journal_entry(
+            description=description,
+            postings=[
+                (debit_acc, PostingDirection.DEBIT, event.amount, event.currency),
+                (credit_acc, PostingDirection.CREDIT, event.amount, event.currency),
+            ],
+            high_value_approved=high_value_approved,
+        )
+
+        # Determine journal entry ID for audit.
+        je_id = result.entry_id if isinstance(result, JournalEntry) else None
+
+        # I-24: audit trail.
+        self._audit.record(
+            PostingAuditEntry(
+                event_id=event.event_id,
+                transaction_id=event.transaction_id,
+                event_type=event.event_type.value,
+                journal_entry_id=je_id,
+                amount=event.amount,
+                currency=event.currency,
+                action="POST_PAYMENT_EVENT",
+                details=f"debit={rule.debit_account_type}, credit={rule.credit_account_type}",
+            )
+        )
+
+        return result
+
+    def get_gl_balance(self, account_type: str, currency: str) -> Decimal:
+        """Get GL balance for a logical account type (I-01)."""
+        acc_id = self._registry.get_account_id(account_type, currency)
+        if acc_id is None:
+            raise ValueError(f"Account not found: {account_type}:{currency}")
+        return self._gl.get_balance(acc_id)

--- a/services/ledger/posting_models.py
+++ b/services/ledger/posting_models.py
@@ -1,0 +1,92 @@
+"""
+services/ledger/posting_models.py
+Models for payment-to-GL posting (IL-CBS-01).
+
+Bridges payment lifecycle events to GL journal entries.
+I-01: All monetary values are Decimal.
+I-24: Immutable records.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import Enum
+
+
+class PaymentEventType(str, Enum):
+    """Payment lifecycle events that trigger GL postings."""
+
+    AUTHORIZED = "AUTHORIZED"
+    CAPTURED = "CAPTURED"
+    SETTLED = "SETTLED"
+    REFUNDED = "REFUNDED"
+    PARTIALLY_REFUNDED = "PARTIALLY_REFUNDED"
+    CHARGEBACK = "CHARGEBACK"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True)
+class PaymentEvent:
+    """A payment lifecycle event to be posted to the GL (I-24 immutable)."""
+
+    event_id: str
+    transaction_id: str
+    event_type: PaymentEventType
+    amount: Decimal  # I-01
+    currency: str
+    customer_id: str
+    beneficiary_jurisdiction: str
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.amount, Decimal):
+            raise TypeError(f"amount must be Decimal, got {type(self.amount).__name__} (I-01)")
+        if self.amount <= Decimal("0"):
+            raise ValueError(f"amount must be positive, got {self.amount}")
+
+
+@dataclass(frozen=True)
+class PostingRule:
+    """Defines how a payment event maps to GL debit/credit postings."""
+
+    event_type: PaymentEventType
+    debit_account_type: str  # e.g. "CUSTOMER_FUNDS", "MERCHANT_RECEIVABLE"
+    credit_account_type: str  # e.g. "SETTLEMENT", "CUSTOMER_FUNDS"
+    description_template: str
+
+
+# Default posting rules per event type.
+DEFAULT_POSTING_RULES: dict[PaymentEventType, PostingRule] = {
+    PaymentEventType.CAPTURED: PostingRule(
+        event_type=PaymentEventType.CAPTURED,
+        debit_account_type="CUSTOMER_FUNDS",
+        credit_account_type="SETTLEMENT_PENDING",
+        description_template="Payment capture: {transaction_id}",
+    ),
+    PaymentEventType.SETTLED: PostingRule(
+        event_type=PaymentEventType.SETTLED,
+        debit_account_type="SETTLEMENT_PENDING",
+        credit_account_type="MERCHANT_PAYABLE",
+        description_template="Payment settlement: {transaction_id}",
+    ),
+    PaymentEventType.REFUNDED: PostingRule(
+        event_type=PaymentEventType.REFUNDED,
+        debit_account_type="MERCHANT_PAYABLE",
+        credit_account_type="CUSTOMER_FUNDS",
+        description_template="Payment refund: {transaction_id}",
+    ),
+    PaymentEventType.PARTIALLY_REFUNDED: PostingRule(
+        event_type=PaymentEventType.PARTIALLY_REFUNDED,
+        debit_account_type="MERCHANT_PAYABLE",
+        credit_account_type="CUSTOMER_FUNDS",
+        description_template="Partial refund: {transaction_id}",
+    ),
+    PaymentEventType.CHARGEBACK: PostingRule(
+        event_type=PaymentEventType.CHARGEBACK,
+        debit_account_type="MERCHANT_PAYABLE",
+        credit_account_type="CUSTOMER_FUNDS",
+        description_template="Chargeback: {transaction_id}",
+    ),
+}

--- a/services/ledger/posting_rules.py
+++ b/services/ledger/posting_rules.py
@@ -1,0 +1,87 @@
+"""
+services/ledger/posting_rules.py
+PostingRuleEngine — debit/credit mapping per payment event type (IL-CBS-01).
+
+I-01: Decimal amounts.
+I-02: Blocked jurisdictions → reject posting.
+I-04: High-value postings flagged.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from services.ledger.posting_models import (
+    DEFAULT_POSTING_RULES,
+    PaymentEvent,
+    PaymentEventType,
+    PostingRule,
+)
+
+BLOCKED_JURISDICTIONS: frozenset[str] = frozenset(
+    {"RU", "BY", "IR", "KP", "CU", "MM", "AF", "VE", "SY"}
+)
+
+HIGH_VALUE_THRESHOLD: Decimal = Decimal("10000")
+
+
+class JurisdictionBlockedError(ValueError):
+    """Posting blocked for sanctioned jurisdiction (I-02)."""
+
+
+class NoPostingRuleError(ValueError):
+    """No posting rule defined for this event type."""
+
+
+class HighValuePostingFlag:
+    """Flag indicating a high-value posting (I-04)."""
+
+    def __init__(self, event: PaymentEvent, threshold: Decimal) -> None:
+        self.event = event
+        self.threshold = threshold
+        self.reason = (
+            f"Payment {event.transaction_id} amount {event.currency} {event.amount} "
+            f"exceeds threshold {threshold} (I-04)"
+        )
+
+
+class PostingRuleEngine:
+    """
+    Resolves payment events to posting rules.
+
+    I-02: Rejects events from blocked jurisdictions.
+    I-04: Flags high-value events.
+    """
+
+    def __init__(
+        self,
+        rules: dict[PaymentEventType, PostingRule] | None = None,
+    ) -> None:
+        self._rules = rules or dict(DEFAULT_POSTING_RULES)
+
+    def resolve(self, event: PaymentEvent) -> PostingRule:
+        """
+        Resolve a payment event to its posting rule.
+
+        Raises JurisdictionBlockedError for blocked jurisdictions (I-02).
+        Raises NoPostingRuleError if no rule exists for the event type.
+        """
+        if event.beneficiary_jurisdiction.upper() in BLOCKED_JURISDICTIONS:
+            raise JurisdictionBlockedError(
+                f"Posting blocked for jurisdiction {event.beneficiary_jurisdiction!r} (I-02)"
+            )
+
+        rule = self._rules.get(event.event_type)
+        if rule is None:
+            raise NoPostingRuleError(f"No posting rule for event type {event.event_type.value}")
+        return rule
+
+    def check_high_value(self, event: PaymentEvent) -> HighValuePostingFlag | None:
+        """Return flag if event amount exceeds threshold (I-04)."""
+        if event.amount >= HIGH_VALUE_THRESHOLD:
+            return HighValuePostingFlag(event, HIGH_VALUE_THRESHOLD)
+        return None
+
+    def get_description(self, rule: PostingRule, event: PaymentEvent) -> str:
+        """Generate posting description from rule template."""
+        return rule.description_template.format(transaction_id=event.transaction_id)

--- a/tests/test_payment_posting_service.py
+++ b/tests/test_payment_posting_service.py
@@ -1,0 +1,373 @@
+"""
+tests/test_payment_posting_service.py
+Tests for PaymentPostingService (IL-CBS-01).
+
+Acceptance criteria:
+- test_payment_capture_posts_debit_credit (Decimal, I-01)
+- test_payment_refund_reversal_posts
+- test_payment_settlement_recon
+- test_posting_blocked_jurisdiction (I-02)
+- test_posting_high_value_flagged (I-04)
+- test_posting_audit_trail (I-24)
+- test_posting_double_entry_always_balanced
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from services.ledger.gl_service import GLService, HighValueHITLProposal, InMemoryGLAuditPort
+from services.ledger.inmemory_ledger import InMemoryLedger
+from services.ledger.ledger_models import AccountType, JournalEntry, PostingDirection, PostingStatus
+from services.ledger.payment_posting_service import (
+    AccountRegistry,
+    InMemoryPostingAuditPort,
+    PaymentPostingService,
+)
+from services.ledger.posting_models import (
+    DEFAULT_POSTING_RULES,
+    PaymentEvent,
+    PaymentEventType,
+)
+from services.ledger.posting_rules import (
+    JurisdictionBlockedError,
+    NoPostingRuleError,
+    PostingRuleEngine,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ledger():
+    return InMemoryLedger()
+
+
+@pytest.fixture
+def gl_audit():
+    return InMemoryGLAuditPort()
+
+
+@pytest.fixture
+def gl(ledger, gl_audit):
+    return GLService(ledger=ledger, audit=gl_audit)
+
+
+@pytest.fixture
+def posting_audit():
+    return InMemoryPostingAuditPort()
+
+
+@pytest.fixture
+def registry(gl):
+    """Create GL accounts and register them."""
+    reg = AccountRegistry()
+    # Create accounts in GL.
+    cf = gl.create_account("Customer Funds", AccountType.LIABILITY, "GBP")
+    sp = gl.create_account("Settlement Pending", AccountType.LIABILITY, "GBP")
+    mp = gl.create_account("Merchant Payable", AccountType.LIABILITY, "GBP")
+    # Register logical types.
+    reg.register("CUSTOMER_FUNDS", "GBP", cf.account_id)
+    reg.register("SETTLEMENT_PENDING", "GBP", sp.account_id)
+    reg.register("MERCHANT_PAYABLE", "GBP", mp.account_id)
+    return reg
+
+
+@pytest.fixture
+def service(gl, registry, posting_audit):
+    return PaymentPostingService(gl=gl, registry=registry, audit=posting_audit)
+
+
+def _event(
+    event_type: PaymentEventType = PaymentEventType.CAPTURED,
+    amount: Decimal = Decimal("500.00"),
+    currency: str = "GBP",
+    jurisdiction: str = "GB",
+    tx_id: str = "tx-001",
+) -> PaymentEvent:
+    return PaymentEvent(
+        event_id=f"evt-{tx_id}",
+        transaction_id=tx_id,
+        event_type=event_type,
+        amount=amount,
+        currency=currency,
+        customer_id="cust-001",
+        beneficiary_jurisdiction=jurisdiction,
+    )
+
+
+# ── Capture Posting Tests ────────────────────────────────────────────────────
+
+
+class TestCapturePosting:
+    def test_payment_capture_posts_debit_credit(self, service):
+        """AC: capture → debit customer funds, credit settlement pending (Decimal, I-01)."""
+        result = service.process_event(_event(PaymentEventType.CAPTURED))
+        assert isinstance(result, JournalEntry)
+        assert result.status == PostingStatus.POSTED
+        assert len(result.postings) == 2
+        debit = [p for p in result.postings if p.direction == PostingDirection.DEBIT]
+        credit = [p for p in result.postings if p.direction == PostingDirection.CREDIT]
+        assert len(debit) == 1
+        assert len(credit) == 1
+        assert debit[0].amount == Decimal("500.00")
+        assert credit[0].amount == Decimal("500.00")
+
+    def test_capture_description(self, service):
+        """Capture posting has correct description."""
+        result = service.process_event(_event(PaymentEventType.CAPTURED, tx_id="tx-abc"))
+        assert "tx-abc" in result.description
+
+
+# ── Settlement Tests ─────────────────────────────────────────────────────────
+
+
+class TestSettlement:
+    def test_payment_settlement_posts(self, service):
+        """Settlement → debit settlement pending, credit merchant payable."""
+        result = service.process_event(_event(PaymentEventType.SETTLED))
+        assert isinstance(result, JournalEntry)
+        assert result.status == PostingStatus.POSTED
+
+    def test_payment_settlement_recon(self, service):
+        """AC: settled amount matches GL totals — balanced."""
+        service.process_event(_event(PaymentEventType.CAPTURED, amount=Decimal("1000.00")))
+        service.process_event(_event(PaymentEventType.SETTLED, amount=Decimal("1000.00")))
+
+        cf_balance = service.get_gl_balance("CUSTOMER_FUNDS", "GBP")
+        sp_balance = service.get_gl_balance("SETTLEMENT_PENDING", "GBP")
+        mp_balance = service.get_gl_balance("MERCHANT_PAYABLE", "GBP")
+
+        # Customer funds debited 1000 (capture).
+        assert cf_balance == Decimal("1000.00")
+        # Settlement pending: +1000 (capture credit) -1000 (settle debit) = 0.
+        assert sp_balance == Decimal("0")
+        # Merchant payable: -1000 (settle credit).
+        assert mp_balance == Decimal("-1000.00")
+
+
+# ── Refund Tests ─────────────────────────────────────────────────────────────
+
+
+class TestRefund:
+    def test_payment_refund_reversal_posts(self, service):
+        """AC: refund → reverse entries (debit merchant, credit customer)."""
+        service.process_event(_event(PaymentEventType.CAPTURED, amount=Decimal("200.00")))
+        service.process_event(_event(PaymentEventType.SETTLED, amount=Decimal("200.00")))
+        result = service.process_event(_event(PaymentEventType.REFUNDED, amount=Decimal("200.00")))
+
+        assert isinstance(result, JournalEntry)
+        assert result.status == PostingStatus.POSTED
+
+    def test_partial_refund(self, service):
+        """Partial refund posts correctly."""
+        service.process_event(_event(PaymentEventType.CAPTURED, amount=Decimal("500.00")))
+        service.process_event(_event(PaymentEventType.SETTLED, amount=Decimal("500.00")))
+        result = service.process_event(
+            _event(PaymentEventType.PARTIALLY_REFUNDED, amount=Decimal("100.00"))
+        )
+        assert isinstance(result, JournalEntry)
+
+    def test_refund_balances_correct(self, service):
+        """After full refund, customer funds net to zero."""
+        service.process_event(_event(PaymentEventType.CAPTURED, amount=Decimal("300.00")))
+        service.process_event(_event(PaymentEventType.SETTLED, amount=Decimal("300.00")))
+        service.process_event(_event(PaymentEventType.REFUNDED, amount=Decimal("300.00")))
+
+        cf = service.get_gl_balance("CUSTOMER_FUNDS", "GBP")
+        mp = service.get_gl_balance("MERCHANT_PAYABLE", "GBP")
+        # Capture debit +300, refund credit -300 = 0.
+        assert cf == Decimal("0")
+        # Settle credit -300, refund debit +300 = 0.
+        assert mp == Decimal("0")
+
+
+# ── Double Entry Balance Tests ───────────────────────────────────────────────
+
+
+class TestDoubleEntry:
+    def test_posting_double_entry_always_balanced(self, service, ledger):
+        """AC: sum(debits) == sum(credits) always."""
+        service.process_event(_event(PaymentEventType.CAPTURED, amount=Decimal("1000.00")))
+        service.process_event(_event(PaymentEventType.SETTLED, amount=Decimal("1000.00")))
+        service.process_event(_event(PaymentEventType.REFUNDED, amount=Decimal("500.00")))
+
+        total_debit = Decimal("0")
+        total_credit = Decimal("0")
+        for entry in ledger.entries.values():
+            for posting in entry.postings:
+                if posting.direction == PostingDirection.DEBIT:
+                    total_debit += posting.amount
+                else:
+                    total_credit += posting.amount
+
+        assert total_debit == total_credit
+
+    def test_chargeback_posts_balanced(self, service, ledger):
+        """Chargeback posting is balanced."""
+        service.process_event(_event(PaymentEventType.CAPTURED, amount=Decimal("200.00")))
+        service.process_event(_event(PaymentEventType.SETTLED, amount=Decimal("200.00")))
+        service.process_event(_event(PaymentEventType.CHARGEBACK, amount=Decimal("200.00")))
+
+        total_debit = Decimal("0")
+        total_credit = Decimal("0")
+        for entry in ledger.entries.values():
+            for posting in entry.postings:
+                if posting.direction == PostingDirection.DEBIT:
+                    total_debit += posting.amount
+                else:
+                    total_credit += posting.amount
+        assert total_debit == total_credit
+
+
+# ── Jurisdiction Blocking Tests ──────────────────────────────────────────────
+
+
+class TestJurisdiction:
+    def test_posting_blocked_jurisdiction(self, service):
+        """AC: blocked jurisdiction → JurisdictionBlockedError (I-02)."""
+        with pytest.raises(JurisdictionBlockedError, match="I-02"):
+            service.process_event(_event(jurisdiction="RU"))
+
+    def test_posting_blocked_ir(self, service):
+        with pytest.raises(JurisdictionBlockedError):
+            service.process_event(_event(jurisdiction="IR"))
+
+    def test_posting_blocked_case_insensitive(self, service):
+        with pytest.raises(JurisdictionBlockedError):
+            service.process_event(_event(jurisdiction="kp"))
+
+
+# ── High Value Tests ─────────────────────────────────────────────────────────
+
+
+class TestHighValue:
+    def test_posting_high_value_flagged(self, service):
+        """AC: >£10k → flag (I-04)."""
+        service.process_event(
+            _event(amount=Decimal("15000.00")),
+            high_value_approved=True,
+        )
+        assert len(service.high_value_flags) == 1
+        assert service.high_value_flags[0].event.amount == Decimal("15000.00")
+
+    def test_high_value_without_approval_hitl(self, service):
+        """High value without approval → HighValueHITLProposal from GLService."""
+        # GLService threshold is £50k, posting_rules threshold is £10k.
+        # Event with £50k+ triggers GLService HITL.
+        result = service.process_event(_event(amount=Decimal("55000.00")))
+        assert isinstance(result, HighValueHITLProposal)
+
+    def test_below_threshold_posts_normally(self, service):
+        """Below threshold posts without flag."""
+        service.process_event(_event(amount=Decimal("9999.99")))
+        assert len(service.high_value_flags) == 0
+
+
+# ── Audit Trail Tests ────────────────────────────────────────────────────────
+
+
+class TestAuditTrail:
+    def test_posting_audit_trail(self, service, posting_audit):
+        """AC: every posting logged (I-24)."""
+        service.process_event(_event())
+        assert len(posting_audit.entries) == 1
+        entry = posting_audit.entries[0]
+        assert entry.transaction_id == "tx-001"
+        assert entry.event_type == "CAPTURED"
+        assert entry.action == "POST_PAYMENT_EVENT"
+        assert isinstance(entry.amount, Decimal)
+
+    def test_multiple_events_multiple_entries(self, service, posting_audit):
+        """Each event produces an audit entry."""
+        service.process_event(_event(PaymentEventType.CAPTURED))
+        service.process_event(_event(PaymentEventType.SETTLED))
+        assert len(posting_audit.entries) == 2
+
+    def test_audit_includes_account_details(self, service, posting_audit):
+        """Audit entry includes debit/credit account types."""
+        service.process_event(_event(PaymentEventType.CAPTURED))
+        entry = posting_audit.entries[0]
+        assert "CUSTOMER_FUNDS" in entry.details
+        assert "SETTLEMENT_PENDING" in entry.details
+
+    def test_audit_entry_immutable(self):
+        """PostingAuditEntry is frozen (I-24)."""
+        from services.ledger.payment_posting_service import PostingAuditEntry
+
+        entry = PostingAuditEntry(
+            event_id="e-001",
+            transaction_id="tx-001",
+            event_type="CAPTURED",
+            journal_entry_id="je-001",
+            amount=Decimal("100"),
+            currency="GBP",
+            action="TEST",
+        )
+        with pytest.raises(AttributeError):
+            entry.action = "MODIFIED"  # type: ignore[misc]
+
+
+# ── Posting Rules Tests ──────────────────────────────────────────────────────
+
+
+class TestPostingRules:
+    def test_default_rules_exist(self):
+        """Default rules cover CAPTURED, SETTLED, REFUNDED, PARTIALLY_REFUNDED, CHARGEBACK."""
+        expected = {
+            PaymentEventType.CAPTURED,
+            PaymentEventType.SETTLED,
+            PaymentEventType.REFUNDED,
+            PaymentEventType.PARTIALLY_REFUNDED,
+            PaymentEventType.CHARGEBACK,
+        }
+        assert set(DEFAULT_POSTING_RULES.keys()) == expected
+
+    def test_no_rule_for_authorized(self):
+        """AUTHORIZED has no posting rule (no GL impact)."""
+        engine = PostingRuleEngine()
+        with pytest.raises(NoPostingRuleError):
+            engine.resolve(_event(PaymentEventType.AUTHORIZED))
+
+    def test_no_rule_for_failed(self):
+        """FAILED has no posting rule."""
+        engine = PostingRuleEngine()
+        with pytest.raises(NoPostingRuleError):
+            engine.resolve(_event(PaymentEventType.FAILED))
+
+
+# ── Model Tests ──────────────────────────────────────────────────────────────
+
+
+class TestModels:
+    def test_payment_event_decimal_only(self):
+        """PaymentEvent rejects non-Decimal (I-01)."""
+        with pytest.raises(TypeError, match="Decimal"):
+            PaymentEvent(
+                event_id="e-001",
+                transaction_id="tx-001",
+                event_type=PaymentEventType.CAPTURED,
+                amount=100.0,  # type: ignore[arg-type]
+                currency="GBP",
+                customer_id="c-001",
+                beneficiary_jurisdiction="GB",
+            )
+
+    def test_payment_event_positive_amount(self):
+        """PaymentEvent rejects zero/negative amount."""
+        with pytest.raises(ValueError, match="positive"):
+            PaymentEvent(
+                event_id="e-001",
+                transaction_id="tx-001",
+                event_type=PaymentEventType.CAPTURED,
+                amount=Decimal("0"),
+                currency="GBP",
+                customer_id="c-001",
+                beneficiary_jurisdiction="GB",
+            )
+
+    def test_payment_event_frozen(self):
+        """PaymentEvent is immutable (I-24)."""
+        event = _event()
+        with pytest.raises(AttributeError):
+            event.amount = Decimal("999")  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- PaymentPostingService: wires payment events to GL journal entries
- PostingRuleEngine: debit/credit mapping per event type
- AccountRegistry: logical account types to GL IDs
- Double-entry always balanced (capture/settle/refund/chargeback)
- High-value flagging (>=10k, I-04)
- Jurisdiction blocking (I-02)

## Files
- services/ledger/payment_posting_service.py
- services/ledger/posting_rules.py
- services/ledger/posting_models.py
- tests/test_payment_posting_service.py — 25 tests

## Test plan
- [x] 25 tests passing
- [x] Coverage: 97-100%
- [x] Ruff lint + format clean

Closes #31

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment event processing and General Ledger posting with automatic debit/credit journal entry generation.
  * Implemented jurisdiction-based compliance blocking for restricted regions.
  * Introduced high-value payment approval workflow requiring manual authorization before GL posting.
  * Added immutable audit trail logging for all payment transactions to support regulatory compliance.
  * Implemented GL balance verification and double-entry accounting reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->