### PR TITLE
feat(governance): SMCR compliance framework — roles, certs, conduct [IL-GOV-01]

### DIFF
--- a/services/compliance_automation/smcr_framework.py
+++ b/services/compliance_automation/smcr_framework.py
@@ -1,0 +1,361 @@
+"""
+services/compliance_automation/smcr_framework.py
+SMCRFramework — FCA Senior Managers & Certification Regime (IL-GOV-01).
+
+Manages SMF role registry, certification tracking, conduct rules enforcement,
+breach reporting, and FCA reporting data export.
+
+I-24: Immutable audit trail.
+I-27: Conduct rule breaches → HITL escalation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+from uuid import uuid4
+
+from services.compliance_automation.smcr_models import (
+    INDIVIDUAL_CONDUCT_RULES,
+    SENIOR_MANAGER_CONDUCT_RULES,
+    BreachReport,
+    BreachSeverity,
+    BreachStatus,
+    CertificationStatus,
+    CertifiedPerson,
+    ConductRule,
+    ConductRuleTier,
+    SeniorManager,
+    SMCRAuditEntry,
+    SMFRole,
+)
+from services.compliance_automation.smcr_registry import InMemorySMCRRegistry, SMCRRegistryPort
+
+# ── Audit Port ───────────────────────────────────────────────────────────────
+
+
+class SMCRAuditPort(Protocol):
+    """Port for recording SMCR audit entries (I-24)."""
+
+    def record(self, entry: SMCRAuditEntry) -> None: ...
+
+
+class InMemorySMCRAuditPort:
+    """In-memory audit for tests."""
+
+    def __init__(self) -> None:
+        self._entries: list[SMCRAuditEntry] = []
+
+    def record(self, entry: SMCRAuditEntry) -> None:
+        self._entries.append(entry)
+
+    @property
+    def entries(self) -> list[SMCRAuditEntry]:
+        return list(self._entries)
+
+
+# ── HITL Proposal ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class BreachHITLProposal:
+    """Conduct rule breach requires HITL escalation (I-27)."""
+
+    breach_id: str
+    person_id: str
+    rule_id: str
+    severity: str
+    reason: str
+    requires_approval_from: str = "COMPLIANCE_OFFICER"
+
+
+# ── Certification Alert ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CertificationAlert:
+    """Alert for certification due/expired."""
+
+    person_id: str
+    name: str
+    status: str
+    expires_at: str
+    message: str
+
+
+# ── SMCR Framework ───────────────────────────────────────────────────────────
+
+
+class SMCRFramework:
+    """
+    FCA SMCR compliance framework.
+
+    Manages:
+    - SMF role registration and responsibility mapping
+    - Annual certification tracking
+    - Conduct rules enforcement
+    - Breach reporting with HITL escalation (I-27)
+    - FCA reporting data export
+
+    I-24: All operations logged to audit trail.
+    I-27: Breaches escalated via HITL.
+    """
+
+    def __init__(
+        self,
+        registry: SMCRRegistryPort | None = None,
+        audit: SMCRAuditPort | None = None,
+    ) -> None:
+        self._registry: SMCRRegistryPort = registry or InMemorySMCRRegistry()
+        self._audit: SMCRAuditPort = audit or InMemorySMCRAuditPort()
+
+    # ── SMF Role Management ──────────────────────────────────────────────────
+
+    def register_smf(
+        self,
+        person_id: str,
+        name: str,
+        role: SMFRole,
+        fca_reference: str,
+        statement_of_responsibilities: str,
+    ) -> SeniorManager:
+        """Register a Senior Management Function holder."""
+        manager = SeniorManager(
+            person_id=person_id,
+            name=name,
+            role=role,
+            fca_reference=fca_reference,
+            appointed_at=datetime.now(UTC).isoformat(),
+            statement_of_responsibilities=statement_of_responsibilities,
+        )
+        registered = self._registry.register_senior_manager(manager)
+
+        self._record_audit(
+            action="REGISTER_SMF",
+            entity_type="SENIOR_MANAGER",
+            entity_id=person_id,
+            actor="SYSTEM",
+            details=f"role={role.value}, fca_ref={fca_reference}",
+        )
+
+        return registered
+
+    def get_smf(self, person_id: str) -> SeniorManager | None:
+        return self._registry.get_senior_manager(person_id)
+
+    def list_smfs(self) -> list[SeniorManager]:
+        return self._registry.list_senior_managers()
+
+    def get_responsibility_map(self) -> dict[str, dict[str, str]]:
+        """Return responsibility map: person_id → {role, name, SoR}."""
+        managers = self._registry.list_senior_managers()
+        return {
+            m.person_id: {
+                "role": m.role.value,
+                "name": m.name,
+                "statement_of_responsibilities": m.statement_of_responsibilities,
+                "fca_reference": m.fca_reference,
+            }
+            for m in managers
+            if m.is_active
+        }
+
+    # ── Certification Management ─────────────────────────────────────────────
+
+    def register_certified_person(
+        self,
+        person_id: str,
+        name: str,
+        function_title: str,
+        certified_by: str,
+        expires_at: str,
+    ) -> CertifiedPerson:
+        """Register a certified person with annual certification."""
+        person = CertifiedPerson(
+            person_id=person_id,
+            name=name,
+            function_title=function_title,
+            certification_status=CertificationStatus.CERTIFIED,
+            certified_at=datetime.now(UTC).isoformat(),
+            expires_at=expires_at,
+            certified_by=certified_by,
+        )
+        registered = self._registry.register_certified_person(person)
+
+        self._record_audit(
+            action="REGISTER_CERTIFIED",
+            entity_type="CERTIFIED_PERSON",
+            entity_id=person_id,
+            actor=certified_by,
+            details=f"function={function_title}, expires={expires_at}",
+        )
+
+        return registered
+
+    def check_certifications(self, as_of_date: str) -> list[CertificationAlert]:
+        """Check for expired or due certifications. Returns alerts."""
+        alerts: list[CertificationAlert] = []
+        for person in self._registry.list_certified_persons():
+            if person.certification_status == CertificationStatus.REVOKED:
+                continue
+            if person.expires_at <= as_of_date:
+                alerts.append(
+                    CertificationAlert(
+                        person_id=person.person_id,
+                        name=person.name,
+                        status="EXPIRED" if person.expires_at < as_of_date else "DUE",
+                        expires_at=person.expires_at,
+                        message=(
+                            f"Certification for {person.name} ({person.function_title}) "
+                            f"{'expired' if person.expires_at < as_of_date else 'due'} "
+                            f"on {person.expires_at}. Annual renewal required."
+                        ),
+                    )
+                )
+
+        if alerts:
+            self._record_audit(
+                action="CERTIFICATION_CHECK",
+                entity_type="CERTIFIED_PERSON",
+                entity_id="BATCH",
+                actor="SYSTEM",
+                details=f"alerts={len(alerts)}, as_of={as_of_date}",
+            )
+
+        return alerts
+
+    # ── Conduct Rules ────────────────────────────────────────────────────────
+
+    def get_conduct_rules(self, tier: ConductRuleTier | None = None) -> list[ConductRule]:
+        """Return conduct rules, optionally filtered by tier."""
+        all_rules = list(INDIVIDUAL_CONDUCT_RULES) + list(SENIOR_MANAGER_CONDUCT_RULES)
+        if tier is not None:
+            return [r for r in all_rules if r.tier == tier]
+        return all_rules
+
+    # ── Breach Reporting ─────────────────────────────────────────────────────
+
+    def report_breach(
+        self,
+        person_id: str,
+        rule_id: str,
+        severity: BreachSeverity,
+        description: str,
+        reported_by: str,
+    ) -> BreachReport | BreachHITLProposal:
+        """
+        Report a conduct rule breach.
+
+        Returns BreachReport for MINOR breaches.
+        Returns BreachHITLProposal for MAJOR/CRITICAL breaches (I-27).
+        """
+        breach_id = f"breach-{uuid4().hex[:8]}"
+        report = BreachReport(
+            breach_id=breach_id,
+            person_id=person_id,
+            rule_id=rule_id,
+            severity=severity,
+            status=BreachStatus.OPEN,
+            description=description,
+            reported_by=reported_by,
+        )
+        self._registry.file_breach(report)
+
+        self._record_audit(
+            action="REPORT_BREACH",
+            entity_type="BREACH",
+            entity_id=breach_id,
+            actor=reported_by,
+            details=f"person={person_id}, rule={rule_id}, severity={severity.value}",
+        )
+
+        # I-27: HITL escalation for MAJOR/CRITICAL.
+        if severity in (BreachSeverity.MAJOR, BreachSeverity.CRITICAL):
+            return BreachHITLProposal(
+                breach_id=breach_id,
+                person_id=person_id,
+                rule_id=rule_id,
+                severity=severity.value,
+                reason=(
+                    f"{severity.value} conduct rule breach ({rule_id}) by {person_id}. "
+                    "Compliance officer review and potential FCA notification required (I-27)."
+                ),
+            )
+
+        return report
+
+    def list_breaches(self, status: str | None = None) -> list[BreachReport]:
+        return self._registry.list_breaches(status)
+
+    # ── FCA Reporting ────────────────────────────────────────────────────────
+
+    def export_fca_reporting_data(self) -> dict:
+        """Export SMCR data in FCA RegData-ready format."""
+        managers = self._registry.list_senior_managers()
+        certified = self._registry.list_certified_persons()
+        breaches = self._registry.list_breaches()
+
+        self._record_audit(
+            action="EXPORT_FCA_DATA",
+            entity_type="SMCR",
+            entity_id="EXPORT",
+            actor="SYSTEM",
+            details=f"managers={len(managers)}, certified={len(certified)}, breaches={len(breaches)}",
+        )
+
+        return {
+            "senior_managers": [
+                {
+                    "person_id": m.person_id,
+                    "name": m.name,
+                    "role": m.role.value,
+                    "fca_reference": m.fca_reference,
+                    "appointed_at": m.appointed_at,
+                    "is_active": m.is_active,
+                }
+                for m in managers
+            ],
+            "certified_persons": [
+                {
+                    "person_id": p.person_id,
+                    "name": p.name,
+                    "function_title": p.function_title,
+                    "status": p.certification_status.value,
+                    "certified_at": p.certified_at,
+                    "expires_at": p.expires_at,
+                }
+                for p in certified
+            ],
+            "breaches": [
+                {
+                    "breach_id": b.breach_id,
+                    "person_id": b.person_id,
+                    "rule_id": b.rule_id,
+                    "severity": b.severity.value,
+                    "status": b.status.value,
+                }
+                for b in breaches
+            ],
+            "exported_at": datetime.now(UTC).isoformat(),
+        }
+
+    # ── Private ──────────────────────────────────────────────────────────────
+
+    def _record_audit(
+        self,
+        *,
+        action: str,
+        entity_type: str,
+        entity_id: str,
+        actor: str,
+        details: str,
+    ) -> None:
+        entry = SMCRAuditEntry(
+            action=action,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            actor=actor,
+            details=details,
+        )
+        self._audit.record(entry)

--- a/services/compliance_automation/smcr_models.py
+++ b/services/compliance_automation/smcr_models.py
@@ -1,0 +1,188 @@
+"""
+services/compliance_automation/smcr_models.py
+SMCR (Senior Managers & Certification Regime) domain models (IL-GOV-01).
+
+FCA SMCR requires EMI firms to:
+- Register Senior Management Functions (SMFs)
+- Certify relevant staff annually
+- Enforce Conduct Rules
+- Report breaches to FCA
+
+I-24: Immutable records via frozen dataclasses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+
+
+class SMFRole(str, Enum):
+    """FCA Senior Management Functions relevant to EMI."""
+
+    SMF1 = "SMF1"  # Chief Executive
+    SMF3 = "SMF3"  # Executive Director
+    SMF9 = "SMF9"  # Chair
+    SMF16 = "SMF16"  # Compliance Oversight
+    SMF17 = "SMF17"  # Money Laundering Reporting Officer (MLRO)
+    SMF24 = "SMF24"  # Chief Operations
+    SMF27 = "SMF27"  # Partner
+    SMF29 = "SMF29"  # Limited Scope (small firms)
+
+
+class CertificationStatus(str, Enum):
+    """Annual certification status."""
+
+    CERTIFIED = "CERTIFIED"
+    PENDING = "PENDING"
+    EXPIRED = "EXPIRED"
+    REVOKED = "REVOKED"
+
+
+class ConductRuleTier(str, Enum):
+    """FCA Conduct Rules tiers."""
+
+    TIER_1 = "TIER_1"  # Individual Conduct Rules (all staff)
+    TIER_2 = "TIER_2"  # Senior Manager Conduct Rules (SMFs only)
+
+
+class BreachSeverity(str, Enum):
+    """Severity of a conduct rule breach."""
+
+    CRITICAL = "CRITICAL"
+    MAJOR = "MAJOR"
+    MINOR = "MINOR"
+
+
+class BreachStatus(str, Enum):
+    """Status of a breach report."""
+
+    OPEN = "OPEN"
+    INVESTIGATING = "INVESTIGATING"
+    REPORTED_TO_FCA = "REPORTED_TO_FCA"
+    RESOLVED = "RESOLVED"
+    CLOSED = "CLOSED"
+
+
+@dataclass(frozen=True)
+class SeniorManager:
+    """Registered Senior Management Function holder (I-24 immutable)."""
+
+    person_id: str
+    name: str
+    role: SMFRole
+    fca_reference: str  # FCA Individual Reference Number (IRN)
+    appointed_at: str
+    statement_of_responsibilities: str  # SoR document reference
+    is_active: bool = True
+    registered_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass(frozen=True)
+class CertifiedPerson:
+    """Certified person under SMCR Certification Regime (I-24 immutable)."""
+
+    person_id: str
+    name: str
+    function_title: str
+    certification_status: CertificationStatus
+    certified_at: str
+    expires_at: str  # Annual renewal required
+    certified_by: str  # Person ID of certifying senior manager
+    registered_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass(frozen=True)
+class ConductRule:
+    """FCA Conduct Rule definition (I-24 immutable)."""
+
+    rule_id: str
+    tier: ConductRuleTier
+    title: str
+    description: str
+
+
+@dataclass(frozen=True)
+class BreachReport:
+    """Conduct rule breach report (I-24 immutable)."""
+
+    breach_id: str
+    person_id: str
+    rule_id: str
+    severity: BreachSeverity
+    status: BreachStatus
+    description: str
+    reported_by: str
+    reported_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    fca_notified: bool = False
+
+
+@dataclass(frozen=True)
+class SMCRAuditEntry:
+    """Immutable audit entry for SMCR operations (I-24)."""
+
+    action: str
+    entity_type: str  # "SENIOR_MANAGER", "CERTIFIED_PERSON", "BREACH"
+    entity_id: str
+    actor: str
+    details: str
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+# FCA Individual Conduct Rules (Tier 1 — all SMCR staff).
+INDIVIDUAL_CONDUCT_RULES: tuple[ConductRule, ...] = (
+    ConductRule("ICR-1", ConductRuleTier.TIER_1, "Integrity", "Act with integrity"),
+    ConductRule(
+        "ICR-2",
+        ConductRuleTier.TIER_1,
+        "Due skill, care and diligence",
+        "Act with due skill, care and diligence",
+    ),
+    ConductRule(
+        "ICR-3",
+        ConductRuleTier.TIER_1,
+        "Open and cooperative",
+        "Be open and cooperative with regulators",
+    ),
+    ConductRule(
+        "ICR-4",
+        ConductRuleTier.TIER_1,
+        "Proper standards of market conduct",
+        "Pay due regard to proper standards of market conduct",
+    ),
+    ConductRule(
+        "ICR-5",
+        ConductRuleTier.TIER_1,
+        "Responsible behaviour",
+        "Act in a way that promotes the integrity of the UK financial system",
+    ),
+)
+
+# Senior Manager Conduct Rules (Tier 2 — SMFs only).
+SENIOR_MANAGER_CONDUCT_RULES: tuple[ConductRule, ...] = (
+    ConductRule(
+        "SMCR-1",
+        ConductRuleTier.TIER_2,
+        "Reasonable steps (business)",
+        "Take reasonable steps to ensure business is controlled effectively",
+    ),
+    ConductRule(
+        "SMCR-2",
+        ConductRuleTier.TIER_2,
+        "Reasonable steps (compliance)",
+        "Take reasonable steps to ensure compliance with regulatory requirements",
+    ),
+    ConductRule(
+        "SMCR-3",
+        ConductRuleTier.TIER_2,
+        "Reasonable steps (delegation)",
+        "Take reasonable steps to ensure any delegation is to an appropriate person",
+    ),
+    ConductRule(
+        "SMCR-4",
+        ConductRuleTier.TIER_2,
+        "Disclose information",
+        "Disclose appropriately any information the FCA would reasonably expect notice of",
+    ),
+)

--- a/services/compliance_automation/smcr_registry.py
+++ b/services/compliance_automation/smcr_registry.py
@@ -1,0 +1,78 @@
+"""
+services/compliance_automation/smcr_registry.py
+SMCRRegistryPort Protocol + InMemorySMCRRegistry (IL-GOV-01).
+
+I-24: Append-only stores.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from services.compliance_automation.smcr_models import (
+    BreachReport,
+    CertifiedPerson,
+    SeniorManager,
+)
+
+
+class SMCRRegistryPort(Protocol):
+    """Port for SMCR data storage."""
+
+    def register_senior_manager(self, manager: SeniorManager) -> SeniorManager: ...
+
+    def get_senior_manager(self, person_id: str) -> SeniorManager | None: ...
+
+    def list_senior_managers(self) -> list[SeniorManager]: ...
+
+    def register_certified_person(self, person: CertifiedPerson) -> CertifiedPerson: ...
+
+    def get_certified_person(self, person_id: str) -> CertifiedPerson | None: ...
+
+    def list_certified_persons(self) -> list[CertifiedPerson]: ...
+
+    def file_breach(self, report: BreachReport) -> BreachReport: ...
+
+    def list_breaches(self, status: str | None = None) -> list[BreachReport]: ...
+
+
+class InMemorySMCRRegistry:
+    """In-memory stub implementing SMCRRegistryPort for tests."""
+
+    def __init__(self) -> None:
+        self._managers: dict[str, SeniorManager] = {}
+        self._certified: dict[str, CertifiedPerson] = {}
+        self._breaches: list[BreachReport] = []
+
+    def register_senior_manager(self, manager: SeniorManager) -> SeniorManager:
+        if manager.person_id in self._managers:
+            raise ValueError(f"Senior manager {manager.person_id!r} already registered")
+        self._managers[manager.person_id] = manager
+        return manager
+
+    def get_senior_manager(self, person_id: str) -> SeniorManager | None:
+        return self._managers.get(person_id)
+
+    def list_senior_managers(self) -> list[SeniorManager]:
+        return list(self._managers.values())
+
+    def register_certified_person(self, person: CertifiedPerson) -> CertifiedPerson:
+        if person.person_id in self._certified:
+            raise ValueError(f"Certified person {person.person_id!r} already registered")
+        self._certified[person.person_id] = person
+        return person
+
+    def get_certified_person(self, person_id: str) -> CertifiedPerson | None:
+        return self._certified.get(person_id)
+
+    def list_certified_persons(self) -> list[CertifiedPerson]:
+        return list(self._certified.values())
+
+    def file_breach(self, report: BreachReport) -> BreachReport:
+        self._breaches.append(report)
+        return report
+
+    def list_breaches(self, status: str | None = None) -> list[BreachReport]:
+        if status is None:
+            return list(self._breaches)
+        return [b for b in self._breaches if b.status.value == status]

--- a/tests/test_smcr_framework.py
+++ b/tests/test_smcr_framework.py
@@ -1,0 +1,347 @@
+"""
+tests/test_smcr_framework.py
+Tests for SMCRFramework (IL-GOV-01).
+
+Acceptance criteria:
+- test_smcr_smf_role_registered
+- test_smcr_certified_person_annual_check
+- test_smcr_conduct_rule_breach_reported (I-27)
+- test_smcr_responsibility_map_complete
+- test_smcr_audit_trail (I-24)
+- test_smcr_fca_reporting_data
+"""
+
+import pytest
+
+from services.compliance_automation.smcr_framework import (
+    BreachHITLProposal,
+    CertificationAlert,
+    InMemorySMCRAuditPort,
+    SMCRFramework,
+)
+from services.compliance_automation.smcr_models import (
+    BreachReport,
+    BreachSeverity,
+    BreachStatus,
+    CertificationStatus,
+    ConductRuleTier,
+    SeniorManager,
+    SMFRole,
+)
+from services.compliance_automation.smcr_registry import InMemorySMCRRegistry
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def registry():
+    return InMemorySMCRRegistry()
+
+
+@pytest.fixture
+def audit():
+    return InMemorySMCRAuditPort()
+
+
+@pytest.fixture
+def framework(registry, audit):
+    return SMCRFramework(registry=registry, audit=audit)
+
+
+# ── SMF Registration Tests ───────────────────────────────────────────────────
+
+
+class TestSMFRegistration:
+    def test_smcr_smf_role_registered(self, framework):
+        """AC: SMF16 (Compliance) and SMF17 (MLRO) registered."""
+        smf16 = framework.register_smf(
+            person_id="p-001",
+            name="Jane Compliance",
+            role=SMFRole.SMF16,
+            fca_reference="IRN-001",
+            statement_of_responsibilities="SoR: Compliance Oversight",
+        )
+        smf17 = framework.register_smf(
+            person_id="p-002",
+            name="John MLRO",
+            role=SMFRole.SMF17,
+            fca_reference="IRN-002",
+            statement_of_responsibilities="SoR: MLRO",
+        )
+        assert isinstance(smf16, SeniorManager)
+        assert smf16.role == SMFRole.SMF16
+        assert smf17.role == SMFRole.SMF17
+
+    def test_smf_retrievable(self, framework):
+        """Registered SMF retrievable by person_id."""
+        framework.register_smf(
+            person_id="p-001",
+            name="Jane",
+            role=SMFRole.SMF16,
+            fca_reference="IRN-001",
+            statement_of_responsibilities="SoR",
+        )
+        found = framework.get_smf("p-001")
+        assert found is not None
+        assert found.name == "Jane"
+
+    def test_smf_not_found(self, framework):
+        """Unknown person_id returns None."""
+        assert framework.get_smf("nonexistent") is None
+
+    def test_list_smfs(self, framework):
+        """List all registered SMFs."""
+        framework.register_smf("p-001", "A", SMFRole.SMF16, "IRN-001", "SoR-A")
+        framework.register_smf("p-002", "B", SMFRole.SMF17, "IRN-002", "SoR-B")
+        assert len(framework.list_smfs()) == 2
+
+    def test_duplicate_smf_rejected(self, framework):
+        """Duplicate person_id raises ValueError."""
+        framework.register_smf("p-001", "A", SMFRole.SMF16, "IRN-001", "SoR")
+        with pytest.raises(ValueError, match="already registered"):
+            framework.register_smf("p-001", "B", SMFRole.SMF17, "IRN-002", "SoR2")
+
+    def test_smf_immutable(self, framework):
+        """SeniorManager is frozen (I-24)."""
+        smf = framework.register_smf("p-001", "A", SMFRole.SMF16, "IRN-001", "SoR")
+        with pytest.raises(AttributeError):
+            smf.name = "Modified"  # type: ignore[misc]
+
+
+# ── Responsibility Map Tests ─────────────────────────────────────────────────
+
+
+class TestResponsibilityMap:
+    def test_smcr_responsibility_map_complete(self, framework):
+        """AC: each SMF has Statement of Responsibilities."""
+        framework.register_smf("p-001", "CEO", SMFRole.SMF1, "IRN-001", "SoR: Chief Executive")
+        framework.register_smf("p-002", "MLRO", SMFRole.SMF17, "IRN-002", "SoR: MLRO duties")
+
+        resp_map = framework.get_responsibility_map()
+        assert "p-001" in resp_map
+        assert "p-002" in resp_map
+        assert resp_map["p-001"]["statement_of_responsibilities"] == "SoR: Chief Executive"
+        assert resp_map["p-002"]["role"] == "SMF17"
+
+    def test_responsibility_map_excludes_inactive(self, framework, registry):
+        """Inactive SMFs excluded from responsibility map."""
+        # Register then mark inactive by creating inactive SeniorManager directly.
+        from services.compliance_automation.smcr_models import SeniorManager
+
+        inactive = SeniorManager(
+            person_id="p-inactive",
+            name="Gone",
+            role=SMFRole.SMF3,
+            fca_reference="IRN-X",
+            appointed_at="2025-01-01",
+            statement_of_responsibilities="SoR",
+            is_active=False,
+        )
+        registry.register_senior_manager(inactive)
+
+        resp_map = framework.get_responsibility_map()
+        assert "p-inactive" not in resp_map
+
+
+# ── Certification Tests ──────────────────────────────────────────────────────
+
+
+class TestCertification:
+    def test_smcr_certified_person_registered(self, framework):
+        """Certified person registered with status CERTIFIED."""
+        person = framework.register_certified_person(
+            person_id="cp-001",
+            name="Alice Certified",
+            function_title="Senior Analyst",
+            certified_by="p-001",
+            expires_at="2027-04-28",
+        )
+        assert person.certification_status == CertificationStatus.CERTIFIED
+
+    def test_smcr_certified_person_annual_check_expired(self, framework):
+        """AC: expired certification → alert."""
+        framework.register_certified_person(
+            person_id="cp-001",
+            name="Alice",
+            function_title="Analyst",
+            certified_by="p-001",
+            expires_at="2026-01-01",  # Already expired
+        )
+        alerts = framework.check_certifications("2026-04-28")
+        assert len(alerts) == 1
+        assert isinstance(alerts[0], CertificationAlert)
+        assert "expired" in alerts[0].message.lower()
+
+    def test_smcr_certified_person_annual_check_due(self, framework):
+        """Certification due today → alert."""
+        framework.register_certified_person(
+            person_id="cp-001",
+            name="Bob",
+            function_title="Analyst",
+            certified_by="p-001",
+            expires_at="2026-04-28",
+        )
+        alerts = framework.check_certifications("2026-04-28")
+        assert len(alerts) == 1
+        assert "due" in alerts[0].message.lower()
+
+    def test_certification_not_due(self, framework):
+        """Future certification → no alert."""
+        framework.register_certified_person(
+            person_id="cp-001",
+            name="Carol",
+            function_title="Analyst",
+            certified_by="p-001",
+            expires_at="2027-12-31",
+        )
+        alerts = framework.check_certifications("2026-04-28")
+        assert len(alerts) == 0
+
+
+# ── Conduct Rules Tests ──────────────────────────────────────────────────────
+
+
+class TestConductRules:
+    def test_individual_conduct_rules(self, framework):
+        """5 Individual Conduct Rules (Tier 1)."""
+        rules = framework.get_conduct_rules(ConductRuleTier.TIER_1)
+        assert len(rules) == 5
+
+    def test_senior_manager_conduct_rules(self, framework):
+        """4 Senior Manager Conduct Rules (Tier 2)."""
+        rules = framework.get_conduct_rules(ConductRuleTier.TIER_2)
+        assert len(rules) == 4
+
+    def test_all_conduct_rules(self, framework):
+        """9 total conduct rules."""
+        rules = framework.get_conduct_rules()
+        assert len(rules) == 9
+
+
+# ── Breach Reporting Tests ───────────────────────────────────────────────────
+
+
+class TestBreachReporting:
+    def test_smcr_conduct_rule_breach_minor(self, framework):
+        """MINOR breach → BreachReport (no HITL)."""
+        result = framework.report_breach(
+            person_id="p-001",
+            rule_id="ICR-1",
+            severity=BreachSeverity.MINOR,
+            description="Minor compliance oversight",
+            reported_by="p-002",
+        )
+        assert isinstance(result, BreachReport)
+        assert result.status == BreachStatus.OPEN
+
+    def test_smcr_conduct_rule_breach_major_hitl(self, framework):
+        """AC: MAJOR breach → BreachHITLProposal + HITL (I-27)."""
+        result = framework.report_breach(
+            person_id="p-001",
+            rule_id="SMCR-2",
+            severity=BreachSeverity.MAJOR,
+            description="Failed to ensure compliance",
+            reported_by="p-002",
+        )
+        assert isinstance(result, BreachHITLProposal)
+        assert result.requires_approval_from == "COMPLIANCE_OFFICER"
+        assert "MAJOR" in result.severity
+
+    def test_smcr_conduct_rule_breach_critical_hitl(self, framework):
+        """CRITICAL breach → HITL escalation."""
+        result = framework.report_breach(
+            person_id="p-001",
+            rule_id="ICR-1",
+            severity=BreachSeverity.CRITICAL,
+            description="Integrity failure",
+            reported_by="p-002",
+        )
+        assert isinstance(result, BreachHITLProposal)
+        assert "FCA notification" in result.reason
+
+    def test_list_breaches(self, framework):
+        """List all breaches."""
+        framework.report_breach("p-001", "ICR-1", BreachSeverity.MINOR, "desc", "p-002")
+        framework.report_breach("p-001", "ICR-2", BreachSeverity.MAJOR, "desc", "p-002")
+        assert len(framework.list_breaches()) == 2
+
+    def test_hitl_proposal_immutable(self):
+        """BreachHITLProposal is frozen."""
+        proposal = BreachHITLProposal(
+            breach_id="b-001",
+            person_id="p-001",
+            rule_id="ICR-1",
+            severity="MAJOR",
+            reason="test",
+        )
+        with pytest.raises(AttributeError):
+            proposal.reason = "modified"  # type: ignore[misc]
+
+
+# ── Audit Trail Tests ────────────────────────────────────────────────────────
+
+
+class TestAuditTrail:
+    def test_smcr_audit_trail_smf_registration(self, framework, audit):
+        """AC: SMF registration logged (I-24)."""
+        framework.register_smf("p-001", "A", SMFRole.SMF16, "IRN-001", "SoR")
+        assert len(audit.entries) == 1
+        assert audit.entries[0].action == "REGISTER_SMF"
+        assert audit.entries[0].entity_type == "SENIOR_MANAGER"
+
+    def test_audit_trail_certification(self, framework, audit):
+        """Certification registration logged."""
+        framework.register_certified_person("cp-001", "Alice", "Analyst", "p-001", "2027-12-31")
+        assert any(e.action == "REGISTER_CERTIFIED" for e in audit.entries)
+
+    def test_audit_trail_breach(self, framework, audit):
+        """Breach reporting logged."""
+        framework.report_breach("p-001", "ICR-1", BreachSeverity.MINOR, "desc", "p-002")
+        assert any(e.action == "REPORT_BREACH" for e in audit.entries)
+
+    def test_audit_trail_fca_export(self, framework, audit):
+        """FCA export logged."""
+        framework.export_fca_reporting_data()
+        assert any(e.action == "EXPORT_FCA_DATA" for e in audit.entries)
+
+    def test_audit_entry_immutable(self):
+        """SMCRAuditEntry is frozen (I-24)."""
+        from services.compliance_automation.smcr_models import SMCRAuditEntry
+
+        entry = SMCRAuditEntry(
+            action="TEST",
+            entity_type="TEST",
+            entity_id="t-001",
+            actor="test",
+            details="test",
+        )
+        with pytest.raises(AttributeError):
+            entry.action = "MODIFIED"  # type: ignore[misc]
+
+
+# ── FCA Reporting Tests ──────────────────────────────────────────────────────
+
+
+class TestFCAReporting:
+    def test_smcr_fca_reporting_data(self, framework):
+        """AC: export-ready data for FCA RegData."""
+        framework.register_smf("p-001", "CEO", SMFRole.SMF1, "IRN-001", "SoR-CEO")
+        framework.register_certified_person("cp-001", "Alice", "Analyst", "p-001", "2027-12-31")
+        framework.report_breach("p-001", "ICR-1", BreachSeverity.MINOR, "desc", "p-002")
+
+        data = framework.export_fca_reporting_data()
+        assert "senior_managers" in data
+        assert "certified_persons" in data
+        assert "breaches" in data
+        assert "exported_at" in data
+        assert len(data["senior_managers"]) == 1
+        assert len(data["certified_persons"]) == 1
+        assert len(data["breaches"]) == 1
+        assert data["senior_managers"][0]["role"] == "SMF1"
+
+    def test_empty_export(self, framework):
+        """Empty registry exports empty lists."""
+        data = framework.export_fca_reporting_data()
+        assert data["senior_managers"] == []
+        assert data["certified_persons"] == []
+        assert data["breaches"] == []


### PR DESCRIPTION
## Summary
- SMCRFramework: FCA Senior Managers and Certification Regime
- SMF role registry (SMF1, SMF3, SMF16, SMF17, etc.)
- Annual certification tracking with expiry alerts
- 9 FCA Conduct Rules (5 Individual + 4 Senior Manager)
- Breach reporting with HITL for MAJOR/CRITICAL (I-27)
- FCA RegData export format
- Responsibility map per SMF holder

## Files
- services/compliance_automation/smcr_framework.py
- services/compliance_automation/smcr_models.py
- services/compliance_automation/smcr_registry.py
- tests/test_smcr_framework.py — 27 tests

## Test plan
- [x] 27 tests passing
- [x] Coverage: 91-100%
- [x] Ruff lint + format clean

Closes #33

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced SMCR compliance framework for managing senior manager registrations and certifications.
  * Added certification expiry alerts and conduct rule breach reporting with automatic escalation for critical severities.
  * Enabled FCA reporting data export and comprehensive audit trail logging of compliance actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->