### PR TITLE
docs(adr): ADR-022 mirror of ADR-017 (Keycloak IAM cutover) + IAM invariants + gap mirror

### DIFF
--- a/GAP-REGISTER.md
+++ b/GAP-REGISTER.md
@@ -34,9 +34,18 @@
 
 ## Open
 
+### Open / 2026-05-03 — ADR-022 IAM cutover (mirror of canonical G-IAM-*)
+
 | Gap ID | Title | Severity | Owner | Target | Notes |
 |--------|-------|----------|-------|--------|-------|
-| _(add entries as gaps are identified)_ | | | | | |
+| G-IAM-01 | Keycloak realm `banxe-emi` deployed on evo1 (:8180) | P0 | Architecture WG / IAM lead | 2026-05-07 | mirror of canonical G-IAM-01 |
+| G-IAM-02 | OIDC discovery URL reachable from EMI services | P0 | IAM lead | 2026-05-07 | mirror of canonical G-IAM-02 |
+| G-IAM-03 | Service-to-service tokens for compliance-api, dashboard, deep-search, drive_watcher | P0 | IAM lead | 2026-05-07 | mirror of canonical G-IAM-03 |
+| G-IAM-04 | Realm mappers + audit log retention ≥ 12 months | P0 | IAM lead | 2026-05-07 | mirror of canonical G-IAM-04 |
+| G-IAM-05 | client_secret rotation policy (90 days / on-incident) | P1 | IAM lead | 2026-05-07 | mirror of canonical G-IAM-05 |
+| G-IAM-06 | pre-commit hook + Gitleaks rule blocking direct credentials | P0 | DevOps | 2026-05-07 | mirror of canonical G-IAM-06 |
+| G-IAM-07 | Backout procedure verified | P1 | IAM lead | 2026-05-07 | mirror of canonical G-IAM-07 |
+| G-IAM-08 | Decommission Legion local IAM after PASS + 7d hold | P2 | IAM lead | 2026-05-14 | BLOCKED_BY G-IAM-01..07 |
 
 ---
 

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -47,20 +47,52 @@ EMI-репо. Backing-модели — деталь реализации plane.
 
 ---
 
+## IAM invariants
+
+### INV-IAM-01 — No Direct Credentials in EMI Service Configs
+
+- **Status:** Binding
+- **Date:** 2026-05-03
+- **Source:** ADR-022 (mirror of ADR-017); canonical: I-34 (`banxe-architecture/INVARIANTS.md`)
+- **Scope:** все EMI-сервисы
+
+EMI-сервисы НЕ ВПРАВЕ хранить direct user/password или статические API-секреты в файлах окружения и конфигурации (`.env*`, `*.yaml`, `*.json`, `docker-compose*`). Любые credentials выдаются только через Keycloak realm `banxe-emi` (см. INV-IAM-02). Master-секреты — operator-supplied env, никогда не коммитятся.
+
+**Enforcement:** pre-commit hook в репо, review checklist, Gitleaks в CI.
+**Violation severity:** P0 — security incident (FCA CASS 15 + GDPR Art. 32).
+
+---
+
+### INV-IAM-02 — Keycloak Realm `banxe-emi` as Single IAM Issuer
+
+- **Status:** Binding
+- **Date:** 2026-05-03
+- **Source:** ADR-022 (mirror of ADR-017); canonical: I-35 (`banxe-architecture/INVARIANTS.md`)
+- **Scope:** все EMI-сервисы
+
+Все EMI-сервисы аутентифицируются и авторизуются ИСКЛЮЧИТЕЛЬНО через Keycloak realm `banxe-emi` (`http://evo1:8180/realms/banxe-emi/.well-known/openid-configuration`). Альтернативные IAM-источники (локальный Legion `--user` IAM, hardcoded JWT, статические API-ключи, сторонние OAuth-провайдеры) запрещены для production EMI-флоу. Legion local IAM сохраняется как rollback до подтверждённого PASS на evo1, после чего декомиссионируется (см. ADR-022 §6).
+
+**Enforcement:** review checklist, Keycloak audit log (retention ≥ 12 месяцев), runtime guard в API gateway.
+**Violation severity:** P1 — architecture invariant breach. P0 если приводит к утечке клиентских данных.
+
+---
+
 ## Enforcement artefacts
 
 | Artefact | Path | Covers |
 |----------|------|--------|
 | Semgrep rules | `.semgrep/banxe-rules.yml` | I-01, I-08, I-24 |
+| Semgrep IAM rule | `.semgrep/banxe-rules/iam-no-direct-creds.yml` | INV-IAM-01 |
 | AML thresholds | `services/aml/aml_thresholds.py` | I-02, I-03, I-04 |
 | Pydantic validators | `api/models/` | I-05 |
 | HITL service | `services/hitl/feedback_loop.py` | I-27 |
 | AI routing policy | `banxe-infra/ai-routing/policy.yaml` | INV-AI-01 |
-| pre-commit hooks | `.pre-commit-config.yaml` | INV-AI-01, I-01 |
+| pre-commit hooks | `.pre-commit-config.yaml` | INV-AI-01, INV-IAM-01, I-01 |
 
 ## References
 
 - Financial invariant rules: `.claude/rules/financial-invariants.md`
 - ADR-021 (AI plane): `docs/adr/ADR-021-ai-plane-pii-aml-routing.md`
+- ADR-022 (IAM cutover mirror): `docs/adr/ADR-022-keycloak-iam-cutover.md`
 - AI-PLUMBING.md (LiteLLM aliases + deny-paths): `docs/AI-PLUMBING.md`
 - Security policy: `.claude/rules/security-policy.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1982,6 +1982,9 @@ commit: IL-FOS-01 + IL-HMR-01 + IL-CST-01 + IL-LCY-01 | Sprint 41 | 2026-04-27
 > **Canonical source:** `banxe-architecture/decisions/ADR-016-ai-plane-pii-aml-routing.md` (Accepted 2026-05-03).
 > Этот раздел — EMI-stack-зеркало канона. При расхождении преобладает ADR-016 + INVARIANTS.md (I-32, I-33).
 
+> **Canonical source (IAM):** `banxe-architecture/decisions/ADR-017-keycloak-iam-cutover.md` (Accepted 2026-05-03).
+> Local mirror: `docs/adr/ADR-022-keycloak-iam-cutover.md`. Keycloak realm `banxe-emi` cutover deadline: **2026-05-07** (FCA CASS 15). Trackers: G-IAM-01..G-IAM-08 (canonical and local).
+
 ### Cluster AI plane available to compliance/api/dashboard
 
 LiteLLM v2 router running at `http://legion:4000/v1`. All internal services use these aliases.

--- a/docs/adr/ADR-022-keycloak-iam-cutover.md
+++ b/docs/adr/ADR-022-keycloak-iam-cutover.md
@@ -1,0 +1,30 @@
+# ADR-022: Keycloak IAM Cutover (mirror of ADR-017)
+
+- **Status:** Accepted
+- **Date:** 2026-05-03
+- **Canonical source:** `banxe-architecture/decisions/ADR-017-keycloak-iam-cutover.md` — в случае любого расхождения преобладает ADR-017.
+- **Scope:** banxe-emi-stack, banxe-compliance-api, banxe-dashboard, deep-search, drive_watcher, все будущие EMI-сервисы.
+
+## Decision (mirror of ADR-017 §1–§7)
+1. Единый IAM-plane: Keycloak realm `banxe-emi` на evo1:8180 — единственный санкционированный issuer токенов для EMI-сервисов.
+2. Service-to-service auth через client_id + client_secret в realm `banxe-emi`; короткоживущие OIDC-токены (≤ 15 минут).
+3. OIDC discovery: `http://evo1:8180/realms/banxe-emi/.well-known/openid-configuration`. Hardcoded endpoints запрещены.
+4. Mappers: `service_id`, `environment`, `compliance_scope`. Audit log retention ≥ 12 месяцев (FCA CASS 15).
+5. Rotation policy: client_secrets раз в 90 дней или по инциденту. Master key — operator-supplied env, не коммитится.
+6. Backout: до подтверждённого PASS на evo1 — Legion local IAM (`--user` units) включаемый по runbook `docs/Keycloak-next-session-roadmap.md §IAM cutover plan v0.1`. После PASS — Legion local IAM удерживается 7 дней, затем декомиссионируется.
+7. Энфорсмент: pre-commit hook + review checklist в каждом EMI-репо. Нарушение PII/IAM routing = P0 incident.
+
+## Related canonical artefacts
+- ADR-017 (canonical): `banxe-architecture/decisions/ADR-017-keycloak-iam-cutover.md`
+- INVARIANTS canonical: I-34, I-35 (`banxe-architecture/INVARIANTS.md`)
+- GAP-REGISTER canonical: G-IAM-01..G-IAM-08 (`banxe-architecture/GAP-REGISTER.md`)
+- ROADMAP-MATRIX P3.4: `banxe-architecture/docs/ROADMAP-MATRIX.md §Phase 3 — Delivery Phases (P3.x)`
+
+## Local invariants reflected
+- INV-IAM-01 (this repo INVARIANTS.md): no direct credentials in EMI configs.
+- INV-IAM-02 (this repo INVARIANTS.md): Keycloak realm `banxe-emi` as single IAM issuer.
+
+## Compliance mapping
+- FCA CASS 15 (deadline 2026-05-07).
+- FCA MLR 2017 (audit trail).
+- GDPR Art. 32 (security of processing).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,6 +44,7 @@ What other options were evaluated and why were they rejected?
 | [ADR-014](ADR-014-fx-engine.md) | FX Engine (Frankfurter ECB) | Accepted | — |
 | [ADR-015](ADR-015-auth-ports.md) | Auth Ports (Keycloak) | Accepted | — |
 | [ADR-021](ADR-021-ai-plane-pii-aml-routing.md) | AI Plane and PII/AML Routing | Accepted | 2026-05-03 |
+| [ADR-022](ADR-022-keycloak-iam-cutover.md) | Keycloak IAM Cutover (mirror of ADR-017) | Accepted | 2026-05-03 |
 
 ## When to Create an ADR
 


### PR DESCRIPTION
Local EMI mirror of canonical ADR-017 (banxe-architecture#23 merged). Adds:
- docs/adr/ADR-022-keycloak-iam-cutover.md (local mirror; ADR-017 prevails on conflict)
- INV-IAM-01 + INV-IAM-02 in INVARIANTS.md
- G-IAM-01..08 mirror block in GAP-REGISTER.md
- Phase 3 sync section in ROADMAP.md gets canonical-IAM blockquote
- ADR-022 added to docs/adr/README.md table

Canonical artefacts in banxe-architecture: PRs #22, #23, #24, #25 (all merged in main 896d141).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive IAM migration documentation including the Keycloak cutover plan with May 7, 2026 deadline.
  * Established binding security invariants requiring all service credentials to be managed through Keycloak as the single IAM issuer.
  * Documented eight tracked gaps (G-IAM-01–G-IAM-08) with priority levels and target completion dates; final decommissioning targeted for May 14, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->