### PR TITLE
docs(iam): P3.4 execution STOP — external blockers (2026-05-04)

### DIFF
--- a/GAP-REGISTER.md
+++ b/GAP-REGISTER.md
@@ -52,6 +52,7 @@
 | G-IAM-06 | pre-commit hook + Semgrep rule blocking direct credentials | P0 | DevOps | 2026-05-07 | **DONE 2026-05-03** — `feat/iam-creds-guard`: `.semgrep/banxe-rules/iam-no-direct-creds.yml` + pre-commit hook `iam-no-direct-creds` + `docs/CONTRIBUTING.md` |
 | G-IAM-07 | Backout procedure verified | P1 | IAM lead | 2026-05-07 | prep artefacts: `infra/keycloak-banxe-emi/RUNBOOK.md` §GATE-D Backout (WAITING_FOR_GATE-L) |
 | G-IAM-08 | Decommission Legion local IAM after PASS + 7d hold | P2 | IAM lead | 2026-05-14 | BLOCKED_BY G-IAM-01..07 |
+| G-IAM-99 | EXTERNAL: P3.4 execution blocked by broken `banxe-marble-postgres` (shared DB) AND Quarkus/Docker `kc.sh build` kill on evo1 | P0 | Architecture WG | 2026-05-07 (at risk) | See RUNBOOK §Execution STOP — 2026-05-04 01:10 CEST. Documentation/canon at 100%; execution requires external action. |
 
 ---
 

--- a/infra/keycloak-banxe-emi/RUNBOOK.md
+++ b/infra/keycloak-banxe-emi/RUNBOOK.md
@@ -310,3 +310,30 @@ Process started outside systemd. Kill it: `pkill -f 'kc.sh start'` then
 - Realm JSON spec: [Keycloak 26.2 Realm Export docs](https://www.keycloak.org/docs/latest/server_admin/#admin-cli)
 - healthcheck.sh: `scripts/healthcheck.sh`
 - provision-clients.sh: `scripts/provision-clients.sh`
+
+---
+
+## Execution STOP — 2026-05-04 01:10 CEST
+
+P3.4 execution on evo1 is **STOPPED** pending two external blockers:
+
+1. Shared Postgres `banxe-marble-postgres` (port 15433, postgis/postgis:17-3.5) is broken. Host-installed KC 26.2.5 was previously configured to use database `keycloak` on this Postgres instance. Current error from `banxe-marble-postgres`: `FATAL: could not open file "global/pg_filenode.map": Permission denied`. This is the Marble service's database, not Keycloak's. It must be repaired by Marble owner. NOT in scope of P3.4.
+
+2. Quarkus `kc.sh build` step is systematically killed inside Docker on evo1, regardless of `--memory`, `JAVA_OPTS`, dev-file vs postgres backend. JVM receives `Killed` (SIGKILL) at `-Dkc.config.build-and-exit=true` step. systemd-oomd inactive, no OOM journal entries, user.slice cgroup unlimited. Likely a kernel/cgroups v2 + Quarkus interaction bug specific to this host.
+
+### Canon status (unchanged by this STOP)
+- ADR-017 / ADR-022 / I-34 / I-35: ACCEPTED, fully documented.
+- G-IAM-01..05, G-IAM-07: prep artefacts ready in `infra/keycloak-banxe-emi/` (compose, realm JSON, scripts, runbook, examples). Status remains IN_PROGRESS / WAITING_FOR_GATE-A.
+- G-IAM-06: DONE (credentials guard) — independent of this STOP.
+- G-IAM-08: BLOCKED_BY G-IAM-01..07.
+- G-IAM-09: ACCEPTED (dev-file fallback as tech debt — irrelevant since dev-file also fails on this host).
+
+### Unblock conditions
+- Marble owner repairs `banxe-marble-postgres` permissions, OR
+- A separate Postgres instance reachable from evo1 is provisioned for Keycloak, OR
+- Quarkus/Docker `Killed`-bug root cause identified and worked around (e.g. KC installed on a different host where Quarkus build works, OR kernel/Docker upgrade on evo1).
+
+### Recommended next session
+- Coordinate with Marble owner on `banxe-marble-postgres` permissions fix.
+- Either provision dedicated `keycloak-pg` Postgres for our compose stack OR install KC 26.2.5 on a different host (legion?) where Quarkus build-step works.
+- Re-attempt GATE-A on a clean Postgres + working `kc.sh build`.


### PR DESCRIPTION
## Summary

Documents the STOP after 6+ hours of attempts to bring up Keycloak realm banxe-emi on evo1. Root causes: (1) shared banxe-marble-postgres on :15433 is broken (Permission denied on pg_filenode.map); (2) Quarkus kc.sh build step systematically Killed inside Docker on evo1 regardless of JAVA_OPTS / mem_limit / db backend. Canon (ADR-017/022, I-34/35, G-IAM-06) remains 100% documented. Execution-side gaps (G-IAM-01..05, 07) remain IN_PROGRESS pending external action. Adds G-IAM-99 EXTERNAL blocker entry.

## Test plan
- [ ] RUNBOOK.md §Execution STOP section present and accurate
- [ ] GAP-REGISTER.md G-IAM-99 row added
- [ ] No secrets in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)