### PR TITLE
diag(p3.4): Block R — evo1 + Legion diagnostics [G-IAM-99]

### DIFF
--- a/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R1-host.txt
+++ b/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R1-host.txt
@@ -1,0 +1,21 @@
+=== uname / kernel ===
+Linux banxe-NucBox-EVO-X2 6.17.0-22-generic #22~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Mar 26 15:25:54 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
+=== uptime ===
+ 11:32:42 up 1 day,  9:43,  3 users,  load average: 35.53, 35.50, 35.46
+=== free -h ===
+               total        used        free      shared  buff/cache   available
+Mem:            30Gi       9.5Gi       3.1Gi        25Mi        19Gi        21Gi
+Swap:          8.0Gi       3.1Gi       4.9Gi
+=== docker version ===
+client 29.1.3, server 29.1.3
+=== systemd-oomd ===
+inactive
+=== /sys cgroup version ===
+cgroup2 on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
+=== user.slice memory limit ===
+max
+=== current KC processes (host or container) ===
+2932007 bash -c echo "=== uname / kernel ==="; uname -a echo "=== uptime ==="; uptime echo "=== free -h ==="; free -h echo "=== docker version ==="; docker version --format "client {{.Client.Version}}, server {{.Server.Version}}" 2>&1 echo "=== systemd-oomd ==="; systemctl is-active systemd-oomd echo "=== /sys cgroup version ==="; mount | grep cgroup | head -5 echo "=== user.slice memory limit ==="; cat /sys/fs/cgroup/user.slice/memory.max 2>/dev/null echo "=== current KC processes (host or container) ==="; pgrep -af "keycloak|kc.sh|QuarkusEntryPoint" 2>/dev/null | sed -E "s/(password=***REDACTED*** || echo "no KC processes" echo "=== port :8180 binding ==="; ss -ltn | grep -E ":(8180|9000) " || echo "free" echo "=== dmesg last 30 min, oom-related ==="; sudo dmesg -T 2>/dev/null | grep -iE "oom|killed process|memory pressure" | tail -30 || journalctl -k --since "30 min ago" 2>/dev/null | grep -iE "oom|killed process|memory pressure" | tail -30 || echo "no kernel oom evidence"
+=== port :8180 binding ===
+LISTEN 0      4096                     127.0.0.1:9000       0.0.0.0:*          
+=== dmesg last 30 min, oom-related ===

--- a/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R2-marble-pg.txt
+++ b/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R2-marble-pg.txt
@@ -1,0 +1,115 @@
+=== container state ===
+banxe-marble-postgres	Up 34 hours (healthy)	postgis/postgis:17-3.5	127.0.0.1:15433->5432/tcp
+=== inspect (key fields) ===
+Status=running Restarting=false ExitCode=0 OOMKilled=false StartedAt=2026-05-02T23:49:35.271747529Z FinishedAt=2026-05-02T23:48:55.820123126Z
+=== mounts ===
+/data/banxe/marble-data/postgres → /var/lib/postgresql/data (rw=true)
+
+=== last 80 logs ===
+2026-05-04 09:41:39.986 UTC [1] LOG:  could not open file "postmaster.pid": Permission denied; continuing anyway
+2026-05-04 09:41:39.987 UTC [107436] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:41:40.418 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:40.418 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:41.418 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:41.418 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:42.418 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:42.418 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:43.085 UTC [107437] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:41:43.418 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:43.418 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:43.704 UTC [107438] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:41:44.418 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:44.418 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:45.419 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:45.419 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:46.419 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:46.419 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:46.725 UTC [107446] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:41:47.419 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:47.419 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:48.419 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:48.419 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:49.419 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:49.419 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:50.419 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:50.420 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:51.420 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:51.420 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:52.420 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:52.420 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:53.420 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:53.420 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:54.420 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:54.421 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:55.421 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:55.421 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:56.421 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:56.421 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:56.801 UTC [107454] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:41:57.105 UTC [107455] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:41:57.421 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:57.421 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:57.704 UTC [107456] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:41:58.421 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:58.421 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:41:59.422 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:41:59.422 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:00.422 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:00.422 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:01.433 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:01.433 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:01.867 UTC [107457] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:42:02.433 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:02.433 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:03.433 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:03.433 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:04.434 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:04.434 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:05.434 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:05.434 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:06.434 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:06.434 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:06.884 UTC [107464] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:42:07.434 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:07.434 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:08.434 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:08.434 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:09.434 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:09.434 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:10.435 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:10.435 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:11.024 UTC [107465] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:42:11.435 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:11.435 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:11.638 UTC [107466] FATAL:  could not open file "global/pg_filenode.map": Permission denied
+2026-05-04 09:42:12.435 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:12.435 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+2026-05-04 09:42:13.435 UTC [25] LOG:  checkpoint starting: time
+2026-05-04 09:42:13.435 UTC [25] ERROR:  could not open directory "pg_logical/snapshots": Permission denied
+=== as postgres user inside ===
+uid=999(postgres) gid=999(postgres) groups=999(postgres),101(ssl-cert)
+=== pg data dir owner inside ===
+total 136
+drwx------ 19     1000     1000  4096 May  2 23:49 .
+drwxrwxrwt  1 postgres postgres  4096 Jul 22  2025 ..
+drwx------  7     1000     1000  4096 Apr 30 07:46 base
+drwx------  2     1000     1000  4096 May  2 23:49 global
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_commit_ts
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_dynshmem
+-rw-------  1     1000     1000  5743 Apr  2 23:18 pg_hba.conf
+-rw-------  1     1000     1000  2640 Apr  2 23:18 pg_ident.conf
+drwx------  4     1000     1000  4096 May  2 23:54 pg_logical
+drwx------  4     1000     1000  4096 Apr  2 23:18 pg_multixact
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_notify
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_replslot
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_serial
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_snapshots
+drwx------  2     1000     1000  4096 May  2 23:49 pg_stat
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_stat_tmp
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_subtrans
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_tblspc
+drwx------  2     1000     1000  4096 Apr  2 23:18 pg_twophase
+=== global/pg_filenode.map perms ===
+-rw------- 1 1000 1000 524 Apr  2 23:18 /var/lib/postgresql/data/global/pg_filenode.map
+=== psql -lA as default user ===
+psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  could not open file "global/pg_filenode.map": Permission denied

--- a/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R3-quarkus-repro.txt
+++ b/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R3-quarkus-repro.txt
@@ -1,0 +1,17 @@
+=== docker info security/runtime ===
+ Cgroup Driver: systemd
+ Cgroup Version: 2
+ Runtimes: io.containerd.runc.v2 runc
+ Default Runtime: runc
+ Security Options:
+  cgroupns
+ Kernel Version: 6.17.0-22-generic
+ Docker Root Dir: /var/lib/docker
+=== try docker run, capture exit + dmesg delta ===
+JAVA_OPTS already set in environment; overriding default settings
+Changes detected in configuration. Updating the server image.
+Updating the configuration and installing your custom providers, if any. Please wait.
+/opt/keycloak/bin/kc.sh: line 169:    65 Killed                  'java' -Dkc.config.build-and-exit=true -Djava.util.concurrent.ForkJoinPool.common.threadFactory=io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory '-Xms256m' '-Xmx1g' '-XX:MetaspaceSize=96M' '-XX:MaxMetaspaceSize=256m' '-XX:+UseG1GC' '-Dfile.encoding=UTF-8' '--add-opens=java.base/java.util=ALL-UNNAMED' '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED' '--add-opens=java.base/java.security=ALL-UNNAMED' '-Duser.language=en' '-Duser.country=US' -Dkc.home.dir='/opt/keycloak/bin/..' -Djboss.server.config.dir='/opt/keycloak/bin/../conf' -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dpicocli.disable.closures=true -Dquarkus-log-max-startup-records=10000 -cp '/opt/keycloak/bin/../lib/quarkus-run.jar' io.quarkus.bootstrap.runner.QuarkusEntryPoint 'start' '--hostname-strict=false' '--http-enabled=true' '--http-port=8180' '--proxy-headers=xforwarded'
+EXIT=0
+=== dmesg new oom-related ===
+no kernel events

--- a/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R4-legion.txt
+++ b/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R4-legion.txt
@@ -1,0 +1,8 @@
+=== legion local ===
+Linux mark-legion 6.6.87.2-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
+               total        used        free      shared  buff/cache   available
+Mem:            23Gi       3.5Gi       1.0Gi        33Mi        19Gi        20Gi
+Swap:          8.0Gi        16Mi       8.0Gi
+29.1.3
+=== KC start-dev test ===
+EXIT_LEGION=143

--- a/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R5-resources.txt
+++ b/infra/keycloak-banxe-emi/diagnostics/2026-05-04T10/R5-resources.txt
@@ -1,0 +1,48 @@
+=== R5 evo1 resources ===
+== disk /data ==
+Filesystem      Size  Used Avail Use% Mounted on
+/dev/nvme0n1p1  1.9T  258G  1.5T  15% /data
+== docker volumes ==
+0ac95a3ae78c09e1b47a7af1ab8eb9d5f183d19af96b542fd755a9883be52236
+9fbafd8baae1b29845480610755de9545b13bd41e13ff7be3925bc3051bcc96d
+18d7d51f2d47aa5b2adc177ef1c6681ca05d6f11c682440422fbdaa73220f737
+72b3df82bea54cec2ec7790a3b58a1eaaccc1a73b04bae329316f84cd2186e2b
+92d5444e9e5e74e83f709352777c0fcc71f5d39ecdb8407810f4a15dbcb8cc7f
+99f33589dd541d5ded8af3376891b11015662132a7f9f0792a43b95c6b38ddbc
+697c2ae68db2ad352b7ea47e9a21a0dc539c54405bc0f7eb82cc6432d7a9a39f
+703dc1f846d976ef42c66e218906ce619b8088736ba8f5d219914d5c960a09da
+0017727f7da3f3db4a2a76a6b2e43319e902f486bb7c886cccb77199d5404111
+18427cf79121f2ef812e236f89568d33fcbb78567ba6091a1bcc11b6ea2646a1
+27200cfcc4b4d821048ecea0b593ae85d90ae4926f9320c9124a920d6d12a6ba
+51520eabd6bf3eeb594dcc04fa981f209bbfdd16d13a92b4a8ff627928ecbf30
+76271ddd31e2fc3ff7737262dbf567da8fc1291becafd8d2d830748c7a168be8
+b1cf194aa82fc8ef217f493da9cf34d9ba02fccc228cfe5232ea3fd7709b60d7
+b671044f72e3e26adfd6e330fcb68848967817f1c36b27587b5aa0d116d0c8f6
+ballerine-x_postgres15
+braslina_pgdata
+docker_hyperswitch-pg-data
+e2044a9fb75b0f7efcca58a780161b62833a2199bd8d3b85c1c099c04e981fbf
+ebe21c864e00aa07223895a5d406f82bef9252e719632f03a7f141ad1eed9c6b
+f4c436efc017ad9af786eedcf94f4f416a7badb2da3fec698661e23d8647bd7e
+hyperswitch_pg_data
+keycloak-banxe-emi_keycloak_data
+keycloak-banxe-emi_keycloak_pg_data
+midaz_midaz-mongodb-data
+midaz_midaz-rabbitmq-data
+vibe-coding_midaz-mongodb-data
+vibe-coding_midaz-rabbitmq-data
+== docker system df ==
+TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
+Images          50        31        24.36GB   21.64GB (88%)
+Containers      38        13        523MB     173.8MB (33%)
+Local Volumes   28        11        1.262GB   96.25MB (7%)
+Build Cache     183       0         16.9GB    14.65GB
+== ports 5430-5470 ==
+LISTEN 0      200                      127.0.0.1:5433       0.0.0.0:*                                            
+== memory ==
+               total        used        free      shared  buff/cache   available
+Mem:            30Gi       9.5Gi       2.7Gi        25Mi        19Gi        21Gi
+Swap:          8.0Gi       3.1Gi       4.9Gi
+== port 8180 8182 status ==
+LISTEN 0      4096                       0.0.0.0:8181       0.0.0.0:*                                            
+LISTEN 0      4096                          [::]:8181          [::]:*                                            


### PR DESCRIPTION
## Block R — P3.4 Pre-Deployment Diagnostics

Five read-only host snapshots collected 2026-05-04T10 to support strategy selection for G-IAM-99.

### Findings

| File | Finding | Impact |
|------|---------|--------|
| R1-host.txt | Kernel 6.17, load 35+, 21GB RAM free, port :8180 free | evo1 resources OK |
| R2-marble-pg.txt | UID mismatch 1000 vs 999 on marble-postgres volume | Not our bug — Marble owner |
| R3-quarkus-repro.txt | Quarkus `kc.sh build` SIGKILL confirmed persistent; EXIT=0 | STRATEGY-A (compose on evo1) risky |
| R4-legion.txt | Legion WSL2: KC start-dev runs 60s+ without kill (EXIT=143=timeout) | STRATEGY-B viable |
| R5-resources.txt | evo1: 1.5TB /data free, :8180 free, KC volumes exist | Resources not a constraint |

### Strategy Options (awaiting `go STRATEGY-X`)

- **STRATEGY-A** — Own postgres sidecar + KC compose on evo1 (Quarkus kill risk remains)
- **STRATEGY-B** — KC on Legion, KC_BASE_URL updated in all EMI services (cleanest, Legion not affected)
- **STRATEGY-C** — Host-installed KC binary + dedicated postgres compose sidecar on evo1 (bypasses Docker-Quarkus kill)

FCA CASS 15 deadline: 2026-05-07

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added diagnostic reports documenting host system metrics, container health status, resource utilization, database logs, and runtime environment snapshots to support infrastructure troubleshooting and performance monitoring activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->