### PR TITLE
feat(guardian-shim): pre-bash enforcer + S1 native hook (audit default)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -183,6 +183,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "BASH_CMD=$(echo \"$TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('command',''))\" 2>/dev/null || echo ''); printf '%s' \"$BASH_CMD\" | $HOME/.banxe/guardian-shim/claude-bash-shim.sh",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -196,7 +206,7 @@
           },
           {
             "type": "command",
-            "command": "echo '[LucidShark] Code modified — scan before completing task (mcp__lucidshark__scan or lucidshark scan --fix --format ai)'",
+            "command": "echo '[LucidShark] Code modified \u2014 scan before completing task (mcp__lucidshark__scan or lucidshark scan --fix --format ai)'",
             "timeout": 5
           }
         ]

--- a/infra/guardian-shim/README.md
+++ b/infra/guardian-shim/README.md
@@ -1,0 +1,137 @@
+# Guardian Bash Shim — Claude Code Pre-Command Enforcement
+# ADR-024 | I-36 | banxe-emi-stack
+
+## Overview
+
+`claude-bash-shim.sh` intercepts every Bash tool call from Claude Code and sends it to
+BANXE Guardian `/audit` for policy evaluation before execution. Verdict determines action:
+
+| Verdict | AUDIT mode | ENFORCE mode |
+|---------|-----------|-------------|
+| pass    | proceed   | proceed     |
+| warn    | proceed + log | proceed + log |
+| unknown | proceed + log | proceed + log |
+| fail    | proceed + log (non-blocking) | **BLOCK** (exit 1) |
+
+Guardian unreachable: fail-open in AUDIT, fail-closed in ENFORCE.
+
+## Architecture
+
+```
+Claude Code Bash tool
+      │
+      ▼ PreToolUse hook ($TOOL_INPUT → command field)
+claude-bash-shim.sh
+      │  mask secrets (sed)
+      │  POST /audit {subject_type, subject_id, scope, prompt, actor, dry_run:false}
+      ▼
+Guardian factory :8195 (http://192.168.0.72:8195)
+      │
+      ▼ verdict {result, summary, reasons, sources}
+claude-bash-shim.sh
+      │  log to ~/.claude/guardian-shim/audit.log
+      ▼
+exit 0 (pass/warn/unknown/audit-fail) OR exit 1 (enforce-fail)
+      │
+      ▼ Claude Code: proceed OR block tool call
+```
+
+## Env Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GUARDIAN_BASE_URL` | `http://192.168.0.72:8195` | Guardian factory endpoint (IP-form, WSL2 DNS) |
+| `GUARDIAN_MODE` | `audit` | `audit` / `enforce` / `off` |
+| `GUARDIAN_FAIL_MODE` | `open` (audit) / `closed` (enforce) | Behaviour when Guardian unreachable |
+| `GUARDIAN_TIMEOUT_S` | `5` | HTTP timeout in seconds |
+| `GUARDIAN_SCOPE` | `claude.bash` | Guardian scope identifier |
+| `GUARDIAN_SUBJECT_TYPE` | `claude-code-session` | Guardian subject_type |
+| `GUARDIAN_SUBJECT_ID` | `hostname-$$` | Session identifier |
+| `GUARDIAN_ACTOR` | `$USER` | Operator identity |
+
+## Activation Strategies
+
+### Strategy-S1 — Native Claude Code `PreToolUse` hook (ACTIVE)
+
+Entry in `.claude/settings.json → hooks.PreToolUse`:
+```json
+{
+  "matcher": "Bash",
+  "hooks": [{
+    "type": "command",
+    "command": "BASH_CMD=$(echo \"$TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('command',''))\" 2>/dev/null || echo ''); printf '%s' \"$BASH_CMD\" | $HOME/.banxe/guardian-shim/claude-bash-shim.sh",
+    "timeout": 10
+  }]
+}
+```
+Hook fires before every Bash tool call. `$TOOL_INPUT` is JSON with `command` field.
+Exit 1 from hook → Claude Code blocks the tool call entirely.
+
+### Strategy-S2 — Shell alias wrapper (fallback only)
+
+```bash
+alias claude='~/.banxe/guardian-shim/claude-wrap.sh'
+```
+See `scripts/claude-wrap.sh`. Fragile; only if S1 unavailable.
+
+### Strategy-S3 — PRE_COMMAND_HOOK env
+
+Not supported by current Claude Code binary. Eliminated.
+
+## Installation
+
+```bash
+# 1. Copy shim to stable path
+mkdir -p ~/.banxe/guardian-shim
+cp infra/guardian-shim/scripts/claude-bash-shim.sh ~/.banxe/guardian-shim/
+chmod +x ~/.banxe/guardian-shim/claude-bash-shim.sh
+cp infra/guardian-shim/scripts/claude-bash-shim.env ~/.banxe/guardian-shim/
+
+# 2. Source env from ~/.bashrc
+cat infra/guardian-shim/scripts/claude-bash-shim.env >> ~/.bashrc
+
+# 3. (S1 only) Ensure .claude/settings.json PreToolUse Bash hook is wired
+#    (already done in this PR — settings.json updated)
+
+# 4. Fix hostname resolution (optional; alternative to IP in GUARDIAN_BASE_URL)
+# sudo sh -c 'echo "192.168.0.72 evo1" >> /etc/hosts'
+```
+
+## Switching Modes
+
+```bash
+# Audit only (default — log, non-blocking)
+export GUARDIAN_MODE=audit
+
+# Enforce (block on verdict=fail)
+export GUARDIAN_MODE=enforce
+
+# Emergency bypass (logged)
+export GUARDIAN_MODE=off
+```
+
+## Logs
+
+Local: `~/.claude/guardian-shim/audit.log` (JSON-lines, one per bash call)
+
+```json
+{"ts":"2026-05-04T10:30:00Z","mode":"audit","result":"unknown","summary":"...","reasons":[],"request_id":"..."}
+{"ts":"2026-05-04T10:30:01Z","mode":"audit","action":"unreachable","fail_mode":"open"}
+{"ts":"2026-05-04T10:30:02Z","mode":"off","action":"bypass"}
+```
+
+Canonical: Guardian → ClickHouse (FCA-grade, 12-month retention per G-GUARD-03).
+
+## Running Tests
+
+```bash
+bash infra/guardian-shim/tests/test-shim.sh
+```
+
+## Rollout
+
+| Date | Action |
+|------|--------|
+| T+0 (2026-05-04) | Merged, AUDIT default |
+| T+7 (2026-05-11) | Switch to ENFORCE for compliance repos (G-GUARD-02) |
+| T+14 (2026-05-18) | ENFORCE everywhere (G-GUARD-04) |

--- a/infra/guardian-shim/scripts/claude-bash-shim.env
+++ b/infra/guardian-shim/scripts/claude-bash-shim.env
@@ -1,0 +1,13 @@
+# Guardian shim env template — source from shell init OR Claude Code config.
+# Operator can override per-shell with `export GUARDIAN_MODE=enforce` etc.
+# Copy to ~/.banxe/guardian-shim/claude-bash-shim.env and source from ~/.bashrc.
+
+# IP-form preferred: WSL2 DNS does not resolve evo1 hostname (see PR #47 D6).
+GUARDIAN_BASE_URL=http://192.168.0.72:8195
+GUARDIAN_MODE=audit
+GUARDIAN_FAIL_MODE=open
+GUARDIAN_TIMEOUT_S=5
+GUARDIAN_SCOPE=claude.bash
+GUARDIAN_SUBJECT_TYPE=claude-code-session
+# GUARDIAN_SUBJECT_ID is auto-derived if unset (host-pid). Override to track sessions.
+# GUARDIAN_ACTOR defaults to $USER

--- a/infra/guardian-shim/scripts/claude-bash-shim.sh
+++ b/infra/guardian-shim/scripts/claude-bash-shim.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Guardian bash shim for Claude Code — pre-bash policy enforcement
+# ADR-024 (canonical) | I-32..I-35 | banxe-emi-stack
+#
+# Reads command from stdin OR args, calls POST <GUARDIAN_BASE_URL>/audit,
+# applies verdict per GUARDIAN_MODE.
+#
+# Env:
+#   GUARDIAN_BASE_URL     default http://192.168.0.72:8195
+#                         IP-form preferred: WSL2 DNS does not resolve evo1 hostname (see PR #47 D6).
+#   GUARDIAN_MODE         enforce|audit|off (default: audit)
+#   GUARDIAN_FAIL_MODE    open|closed (default: open in audit, closed in enforce)
+#   GUARDIAN_TIMEOUT_S    default 5
+#   GUARDIAN_SCOPE        default claude.bash
+#   GUARDIAN_SUBJECT_TYPE default claude-code-session
+#   GUARDIAN_SUBJECT_ID   default $(hostname)-$$ (operator can override)
+#   GUARDIAN_ACTOR        default $USER
+#
+# Logs: ~/.claude/guardian-shim/audit.log (JSON-lines)
+# Exit codes:
+#   0  — verdict pass / warn (warn logged) / unknown (allowed, logged)
+#   1  — verdict fail (blocked)
+#   2  — Guardian unreachable AND fail-mode=closed
+#   3  — internal shim error (jq/curl missing)
+
+set -u
+set -o pipefail
+
+GUARDIAN_BASE_URL="${GUARDIAN_BASE_URL:-http://192.168.0.72:8195}"
+GUARDIAN_MODE="${GUARDIAN_MODE:-audit}"
+GUARDIAN_TIMEOUT_S="${GUARDIAN_TIMEOUT_S:-5}"
+GUARDIAN_SCOPE="${GUARDIAN_SCOPE:-claude.bash}"
+GUARDIAN_SUBJECT_TYPE="${GUARDIAN_SUBJECT_TYPE:-claude-code-session}"
+GUARDIAN_SUBJECT_ID="${GUARDIAN_SUBJECT_ID:-$(hostname 2>/dev/null || echo unknown)-$$}"
+GUARDIAN_ACTOR="${GUARDIAN_ACTOR:-${USER:-unknown}}"
+GUARDIAN_FAIL_MODE="${GUARDIAN_FAIL_MODE:-}"
+LOG_DIR="$HOME/.claude/guardian-shim"
+LOG_FILE="$LOG_DIR/audit.log"
+
+# Default fail-mode by mode
+if [ -z "$GUARDIAN_FAIL_MODE" ]; then
+  case "$GUARDIAN_MODE" in
+    enforce) GUARDIAN_FAIL_MODE="closed" ;;
+    *)       GUARDIAN_FAIL_MODE="open"   ;;
+  esac
+fi
+
+mkdir -p "$LOG_DIR"
+
+# OFF mode short-circuit
+if [ "$GUARDIAN_MODE" = "off" ]; then
+  echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"mode\":\"off\",\"action\":\"bypass\"}" >> "$LOG_FILE"
+  exit 0
+fi
+
+command -v curl >/dev/null 2>&1 || { echo "guardian-shim: curl missing" >&2; exit 3; }
+command -v jq   >/dev/null 2>&1 || { echo "guardian-shim: jq missing"   >&2; exit 3; }
+
+# Read command (prompt) from args or stdin
+if [ "$#" -gt 0 ]; then
+  PROMPT="$*"
+else
+  PROMPT="$(cat)"
+fi
+
+# Mask common secret patterns before POST
+MASKED_PROMPT="$(printf '%s' "$PROMPT" | sed -E 's/(password|PASSWORD|secret|SECRET|api[_-]?key|API[_-]?KEY|access[_-]?token|refresh[_-]?token|client[_-]?secret)[^[:space:]]+/\1=***REDACTED***/g')"
+
+REQUEST_ID="$(date -u +%s%N)-$$"
+
+REQ_JSON=$(jq -n \
+  --arg rid "$REQUEST_ID" \
+  --arg st  "$GUARDIAN_SUBJECT_TYPE" \
+  --arg sid "$GUARDIAN_SUBJECT_ID" \
+  --arg sc  "$GUARDIAN_SCOPE" \
+  --arg pr  "$MASKED_PROMPT" \
+  --arg ac  "$GUARDIAN_ACTOR" \
+  '{request_id:$rid, subject_type:$st, subject_id:$sid, scope:$sc, prompt:$pr, actor:$ac, dry_run:false, context:{shim_version:"0.1.0"}}')
+
+RESP=$(curl -fsS --max-time "$GUARDIAN_TIMEOUT_S" -X POST \
+  -H "Content-Type: application/json" \
+  --data "$REQ_JSON" \
+  "$GUARDIAN_BASE_URL/audit" 2>&1) || RESP=""
+
+if [ -z "$RESP" ] || ! echo "$RESP" | jq -e .verdict >/dev/null 2>&1; then
+  echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"mode\":\"$GUARDIAN_MODE\",\"action\":\"unreachable\",\"fail_mode\":\"$GUARDIAN_FAIL_MODE\"}" >> "$LOG_FILE"
+  if [ "$GUARDIAN_FAIL_MODE" = "closed" ]; then
+    echo "guardian-shim: Guardian unreachable; fail-closed (enforce mode). Reasons: connect timeout or invalid response." >&2
+    exit 2
+  fi
+  echo "guardian-shim: Guardian unreachable; fail-open (audit mode); proceeding." >&2
+  exit 0
+fi
+
+RESULT=$(echo "$RESP" | jq -r '.verdict.result')
+SUMMARY=$(echo "$RESP" | jq -r '.verdict.summary')
+REASONS=$(echo "$RESP" | jq -c '.verdict.reasons')
+
+# Log
+echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"mode\":\"$GUARDIAN_MODE\",\"result\":\"$RESULT\",\"summary\":\"$(printf '%s' "$SUMMARY" | sed 's/"/\\"/g')\",\"reasons\":$REASONS,\"request_id\":\"$REQUEST_ID\"}" >> "$LOG_FILE"
+
+case "$RESULT" in
+  pass)
+    exit 0
+    ;;
+  warn)
+    echo "guardian-shim: WARN — $SUMMARY" >&2
+    [ "$REASONS" != "[]" ] && echo "guardian-shim: reasons: $REASONS" >&2
+    exit 0
+    ;;
+  unknown)
+    echo "guardian-shim: UNKNOWN verdict — $SUMMARY (proceeding)" >&2
+    exit 0
+    ;;
+  fail)
+    if [ "$GUARDIAN_MODE" = "enforce" ]; then
+      echo "guardian-shim: BLOCKED — $SUMMARY" >&2
+      echo "guardian-shim: reasons: $REASONS" >&2
+      exit 1
+    else
+      echo "guardian-shim: FAIL verdict in audit mode — $SUMMARY (NOT blocking)" >&2
+      echo "guardian-shim: reasons: $REASONS" >&2
+      exit 0
+    fi
+    ;;
+  *)
+    echo "guardian-shim: unexpected verdict result='$RESULT'" >&2
+    exit 0
+    ;;
+esac

--- a/infra/guardian-shim/tests/test-shim.sh
+++ b/infra/guardian-shim/tests/test-shim.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Guardian bash shim — unit tests (T1..T8)
+# ADR-024 | banxe-emi-stack/infra/guardian-shim/tests/
+# Run: bash infra/guardian-shim/tests/test-shim.sh
+
+set -u
+
+SHIM="$(cd "$(dirname "$0")/.." && pwd)/scripts/claude-bash-shim.sh"
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local test_name="$1" expected="$2" actual="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    echo "PASS [$test_name] exit=$actual"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL [$test_name] expected exit=$expected got=$actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_log_contains() {
+  local test_name="$1" pattern="$2" log_file="$3"
+  if grep -q "$pattern" "$log_file" 2>/dev/null; then
+    echo "PASS [$test_name] log contains: $pattern"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL [$test_name] log missing: $pattern (log: $(tail -1 "$log_file" 2>/dev/null || echo EMPTY))"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local test_name="$1" pattern="$2" content="$3"
+  if ! echo "$content" | grep -qE "$pattern"; then
+    echo "PASS [$test_name] no match for: $pattern"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL [$test_name] unexpected match for: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Temp log dir per test run
+TMP_LOG_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_LOG_DIR"; kill "$MOCK_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+start_mock_server() {
+  local verdict="$1"
+  local port="$2"
+  python3 - "$verdict" "$port" &
+  MOCK_PID=$!
+  sleep 0.3  # let server start
+}
+
+# Mock server: responds to POST /audit with configurable verdict
+MOCK_SCRIPT='
+import sys, json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+verdict_result = sys.argv[1]
+port = int(sys.argv[2])
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        try:
+            req = json.loads(body)
+        except Exception:
+            req = {}
+        resp = {
+            "verdict": {
+                "result": verdict_result,
+                "summary": f"mock verdict {verdict_result}",
+                "reasons": [f"mock-reason-{verdict_result}"] if verdict_result == "fail" else [],
+                "sources": []
+            }
+        }
+        data = json.dumps(resp).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+'
+
+echo "=== Guardian Shim Tests (T1..T8) ==="
+echo "SHIM: $SHIM"
+echo ""
+
+# --- T1: GUARDIAN_MODE=off → exit 0, log contains "bypass" ---
+T1_LOG="$TMP_LOG_DIR/t1.log"
+HOME="$TMP_LOG_DIR" GUARDIAN_MODE=off GUARDIAN_BASE_URL="http://127.0.0.1:19001" \
+  bash "$SHIM" "ls -la" 2>/dev/null
+T1_EXIT=$?
+assert_exit "T1: mode=off exit 0" 0 "$T1_EXIT"
+assert_log_contains "T1: mode=off log bypass" "bypass" "$TMP_LOG_DIR/.claude/guardian-shim/audit.log"
+
+# --- T2: Guardian unreachable + fail-open → exit 0 ---
+T2_LOG="$TMP_LOG_DIR/.claude/guardian-shim/audit.log"
+HOME="$TMP_LOG_DIR" GUARDIAN_MODE=audit GUARDIAN_BASE_URL="http://127.0.0.1:19999" GUARDIAN_TIMEOUT_S=1 GUARDIAN_FAIL_MODE=open \
+  bash "$SHIM" "ls" 2>/dev/null
+T2_EXIT=$?
+assert_exit "T2: unreachable+fail-open exit 0" 0 "$T2_EXIT"
+assert_log_contains "T2: unreachable log entry" "unreachable" "$T2_LOG"
+
+# --- T3: Guardian unreachable + fail-closed → exit 2 ---
+HOME="$TMP_LOG_DIR" GUARDIAN_MODE=enforce GUARDIAN_BASE_URL="http://127.0.0.1:19999" GUARDIAN_TIMEOUT_S=1 GUARDIAN_FAIL_MODE=closed \
+  bash "$SHIM" "ls" 2>/dev/null
+T3_EXIT=$?
+assert_exit "T3: unreachable+fail-closed exit 2" 2 "$T3_EXIT"
+
+# --- T4: Mock Guardian verdict=pass → exit 0 ---
+echo "$MOCK_SCRIPT" | python3 - pass 19001 &
+MOCK_PID=$!
+sleep 0.3
+HOME="$TMP_LOG_DIR" GUARDIAN_MODE=audit GUARDIAN_BASE_URL="http://127.0.0.1:19001" GUARDIAN_TIMEOUT_S=3 \
+  bash "$SHIM" "ls" 2>/dev/null
+T4_EXIT=$?
+assert_exit "T4: verdict=pass exit 0" 0 "$T4_EXIT"
+assert_log_contains "T4: verdict=pass in log" '"result":"pass"' "$TMP_LOG_DIR/.claude/guardian-shim/audit.log"
+kill "$MOCK_PID" 2>/dev/null; wait "$MOCK_PID" 2>/dev/null; MOCK_PID=""
+
+# --- T5: Mock Guardian verdict=warn → exit 0 + WARN on stderr ---
+echo "$MOCK_SCRIPT" | python3 - warn 19002 &
+MOCK_PID=$!
+sleep 0.3
+STDERR_T5=$(HOME="$TMP_LOG_DIR" GUARDIAN_MODE=audit GUARDIAN_BASE_URL="http://127.0.0.1:19002" GUARDIAN_TIMEOUT_S=3 \
+  bash "$SHIM" "ls" 2>&1 >/dev/null)
+T5_EXIT=$?
+assert_exit "T5: verdict=warn exit 0" 0 "$T5_EXIT"
+assert_not_contains "T5: verdict=warn stderr has WARN" "^$" "$STDERR_T5"
+kill "$MOCK_PID" 2>/dev/null; wait "$MOCK_PID" 2>/dev/null; MOCK_PID=""
+
+# --- T6: Mock Guardian verdict=fail + GUARDIAN_MODE=audit → exit 0 (non-blocking) ---
+echo "$MOCK_SCRIPT" | python3 - fail 19003 &
+MOCK_PID=$!
+sleep 0.3
+HOME="$TMP_LOG_DIR" GUARDIAN_MODE=audit GUARDIAN_BASE_URL="http://127.0.0.1:19003" GUARDIAN_TIMEOUT_S=3 \
+  bash "$SHIM" "rm -rf /" 2>/dev/null
+T6_EXIT=$?
+assert_exit "T6: verdict=fail+audit exit 0 (non-blocking)" 0 "$T6_EXIT"
+assert_log_contains "T6: fail verdict in audit log" '"result":"fail"' "$TMP_LOG_DIR/.claude/guardian-shim/audit.log"
+kill "$MOCK_PID" 2>/dev/null; wait "$MOCK_PID" 2>/dev/null; MOCK_PID=""
+
+# --- T7: Mock Guardian verdict=fail + GUARDIAN_MODE=enforce → exit 1 (blocked) ---
+echo "$MOCK_SCRIPT" | python3 - fail 19004 &
+MOCK_PID=$!
+sleep 0.3
+HOME="$TMP_LOG_DIR" GUARDIAN_MODE=enforce GUARDIAN_BASE_URL="http://127.0.0.1:19004" GUARDIAN_TIMEOUT_S=3 \
+  bash "$SHIM" "rm -rf /" 2>/dev/null
+T7_EXIT=$?
+assert_exit "T7: verdict=fail+enforce exit 1 (blocked)" 1 "$T7_EXIT"
+kill "$MOCK_PID" 2>/dev/null; wait "$MOCK_PID" 2>/dev/null; MOCK_PID=""
+
+# --- T8: Secret masking — password=hunter2 must not appear in log or POST ---
+# Mock server that captures request body and stores it for inspection
+CAPTURE_FILE="$TMP_LOG_DIR/captured.json"
+python3 - pass 19005 "$CAPTURE_FILE" << 'PYEOF' &
+import sys, json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+verdict_result = sys.argv[1]
+port = int(sys.argv[2])
+capture_file = sys.argv[3]
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        with open(capture_file, "wb") as f:
+            f.write(body)
+        resp = {
+            "verdict": {
+                "result": verdict_result,
+                "summary": "masked check",
+                "reasons": [],
+                "sources": []
+            }
+        }
+        data = json.dumps(resp).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+PYEOF
+MOCK_PID=$!
+sleep 0.3
+HOME="$TMP_LOG_DIR" GUARDIAN_MODE=audit GUARDIAN_BASE_URL="http://127.0.0.1:19005" GUARDIAN_TIMEOUT_S=3 \
+  bash "$SHIM" "echo password=hunter2 something" 2>/dev/null
+T8_EXIT=$?
+sleep 0.1
+# Check that captured POST body does not contain raw "hunter2"
+if [ -f "$CAPTURE_FILE" ]; then
+  CAPTURED=$(cat "$CAPTURE_FILE")
+  assert_not_contains "T8: POST body masked (no hunter2)" "hunter2" "$CAPTURED"
+else
+  echo "FAIL [T8: captured file missing]"
+  FAIL=$((FAIL + 1))
+fi
+# Check local log also doesn't contain hunter2
+LOG_CONTENT=$(cat "$TMP_LOG_DIR/.claude/guardian-shim/audit.log" 2>/dev/null || echo "")
+assert_not_contains "T8: local log masked (no hunter2)" "hunter2" "$LOG_CONTENT"
+kill "$MOCK_PID" 2>/dev/null; wait "$MOCK_PID" 2>/dev/null; MOCK_PID=""
+
+echo ""
+echo "=== Results: $PASS PASS, $FAIL FAIL ==="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Implements `claude-bash-shim.sh` — BANXE Guardian pre-bash policy enforcement for Claude Code sessions.

- **Shim:** `infra/guardian-shim/scripts/claude-bash-shim.sh` — POSIX bash, no external deps except curl + jq
- **Modes:** `off` / `audit` (default, non-blocking) / `enforce` (blocks on verdict=fail)
- **Fail behaviour:** fail-open in audit, fail-closed in enforce
- **Secrets:** masked before POST (password|secret|api_key|access_token|refresh_token|client_secret → `***REDACTED***`)
- **Logs:** `~/.claude/guardian-shim/audit.log` (JSON-lines, one per bash call)
- **Guardian endpoint:** `http://192.168.0.72:8195` (IP-form; WSL2 DNS does not resolve `evo1` hostname, per PR #47 D6)

## Strategy-S1 activation

`.claude/settings.json` `hooks.PreToolUse` — new Bash matcher entry:
```json
{
  "matcher": "Bash",
  "hooks": [{"type": "command", "command": "BASH_CMD=$(echo \"$TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('command',''))\" 2>/dev/null || echo ''); printf '%s' \"$BASH_CMD\" | $HOME/.banxe/guardian-shim/claude-bash-shim.sh", "timeout": 10}]
}
```
Home `~/.claude/settings.json`: no pre-existing Bash hook (verified, not touched).

## Tests

`infra/guardian-shim/tests/test-shim.sh` — 14/14 assertions PASS (T1..T8):
- T1: off mode bypass
- T2: unreachable + fail-open → exit 0
- T3: unreachable + fail-closed → exit 2
- T4: verdict=pass → exit 0
- T5: verdict=warn → exit 0 + stderr WARN
- T6: verdict=fail + audit → exit 0 (non-blocking)
- T7: verdict=fail + enforce → exit 1 (blocked)
- T8: secret masking (password=hunter2 → REDACTED in POST body + local log)

## Rollout

| Phase | Date | Action |
|-------|------|--------|
| T+0 | 2026-05-04 | Merged, AUDIT default |
| T+7 | 2026-05-11 | ENFORCE for compliance repos (G-GUARD-02) |
| T+14 | 2026-05-18 | ENFORCE everywhere (G-GUARD-04) |

Closes GS-I + S1-A1. ENFORCE rollout tracked as G-GUARD-02. ADR-024 canonical (banxe-architecture PR pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)