### PR TITLE
docs(roadmap): add Phase 57 — FCA CASS 15 IAM Cutover DONE [G-IAM-08 G-IAM-99]

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1923,6 +1923,35 @@ commit: IL-FXR-01 + IL-PSD2GW-01 | Sprint 37 | 2026-04-21
 
 ---
 
+
+
+## Phase 57 — FCA CASS 15 IAM Cutover ✅ DONE (2026-05-04)
+
+> **IL:** G-IAM-01..G-IAM-08, G-IAM-99 | **FCA:** CASS 15 (deadline 2026-05-07) | **ADR:** 017 (canonical), 022 (EMI mirror), 023 (applicability) | **Tag:** `cass15-iam-cutover-2026-05-07`
+
+Keycloak `banxe-emi` realm cutover for service-to-service authentication of 4 EMI clients (banxe-compliance-api, banxe-dashboard, deep-search, drive_watcher) via OIDC client_credentials grant. CASS 15 IAM gate closed 3 days ahead of deadline.
+
+| # | Item | IL | Status | Notes |
+|---|---|---|---|---|
+| 561 | Keycloak realm `banxe-emi` deployed | G-IAM-01 | ✅ | Legion host (Tailscale 100.101.218.26:8180), STRATEGY-B post G-IAM-99 |
+| 562 | OIDC discovery cross-host reachable | G-IAM-02 | ✅ | Cross-host smoke 4/4 OK from evo1 |
+| 563 | Service-to-service tokens for 4 clients | G-IAM-03 | ✅ | Bearer JWT, expires_in=900, all 4 verified |
+| 564 | Realm mappers + audit retention ≥12mo | G-IAM-04 | ✅ | protocolMappers (service_id, environment, compliance_scope) + eventsExpiration=31536000 |
+| 565 | Secret rotation policy (90d) | G-IAM-05 | ⏳ | P1 process — re-runnable provision-clients.sh in place |
+| 566 | Pre-commit secrets guard (I-34/INV-IAM-01) | G-IAM-06 | ✅ | Closed 2026-05-03 (`feat/iam-creds-guard`) |
+| 567 | Backout procedure (RUNBOOK §GATE-D) | G-IAM-07 | ✅ | Documented and merged in PR #50 |
+| 568 | Cutover execution | G-IAM-08 | ✅ | PR #50 admin-merged, tag `cass15-iam-cutover-2026-05-07` |
+| 569 | External blockers resolution | G-IAM-99 | ✅ | STRATEGY-B host migration evo1→Legion (Block R R3+R4) |
+| 570 | Tech debt: KC_DB postgres backend | G-IAM-09 | ⏳ | KC_DB=dev-file accepted; Postgres migration target 2026-05-31 |
+
+Root cause for STRATEGY-B: evo1 kernel 6.17 + cgroups v2 systematic SIGKILL of Quarkus build step (R3 diagnostic), no OOM/oomd/user.slice limits visible. Same image works on Legion kernel 6.6 WSL2 (R4). 8 retry strategies on evo1 documented in post-mortem (`docs/postmortems/2026-05-04-keycloak-evo1-quarkus-sigkill.md`).
+
+Cross-host networking: Tailscale mesh (mark-legion 100.101.218.26 ↔ banxe-nucbox-evo-x2 100.68.102.48) provides mTLS at network layer; sslRequired=NONE applied to realm config (Tailscale-only deployment).
+
+Tests not added (infrastructure phase): cross-host validation via curl smoke tests in pre-merge gate, documented in PR #50.
+
+commit: 78b1643 (PR #50) + 754d7e9 (PR #52 GAP-REGISTER finalise) | 2026-05-04
+
 ## Sprint 41 — Phase 56: FOS Escalation + HMRC FATCA Reporting + Client Statements + Lifecycle FSM
 
 ### S41-A: Phase 56A — FOS Escalation Process (IL-FOS-01, closes S5-19)


### PR DESCRIPTION
## Summary

Adds **Phase 57** to `ROADMAP.md` recording the FCA CASS 15 IAM Cutover milestone (tag `cass15-iam-cutover-2026-05-07`).

CASS 15 IAM gate closed 2026-05-04, 3 days ahead of 2026-05-07 deadline, via STRATEGY-B host migration (evo1 → Legion) post G-IAM-99 external blockers.

## What changed

- `ROADMAP.md` — appended `Phase 57 — FCA CASS 15 IAM Cutover ✅ DONE (2026-05-04)` section before `Sprint 41` header.

## Phase 57 contents

10 tracker rows reflecting post-merge production state:

- G-IAM-01..04 + G-IAM-07..08 — DONE via PR #50.
- G-IAM-06 — DONE 2026-05-03 (`feat/iam-creds-guard`).
- G-IAM-99 — RESOLVED via STRATEGY-B (host migration evo1 to Legion).
- G-IAM-05 — P1 process work (re-runnable provision-clients.sh in place; rotation schedule operational).
- G-IAM-09 — accepted tech debt (KC_DB=dev-file → Postgres migration target 2026-05-31).

Cross-references to:
- `docs/postmortems/2026-05-04-keycloak-evo1-quarkus-sigkill.md` (8 retry strategies + STRATEGY-B selection).
- `infra/keycloak-banxe-emi/RUNBOOK.md` §STRATEGY-B Resolution.
- Tag `cass15-iam-cutover-2026-05-07`.

## Approver

CODEOWNERS = @mmber. Self admin-merge after CI green.
