### PR TITLE
feat(iam): G-IAM-09 closure — Postgres backend production compose [G-IAM-09]

### DIFF
--- a/infra/keycloak-banxe-emi/RUNBOOK.md
+++ b/infra/keycloak-banxe-emi/RUNBOOK.md
@@ -354,3 +354,32 @@ P3.4 cutover unblocked via STRATEGY-B (host migration to Legion):
 - Realm import OK 2026-05-04 11:00:49.
 - 4 clients (`banxe-compliance-api`, `banxe-dashboard`, `deep-search`, `drive_watcher`): all `serviceAccountsEnabled=true`, `publicClient=false`.
 - client_credentials smoke test: 4/4 returns Bearer JWT, expires_in=900.
+
+---
+
+## G-IAM-09 Closure — 2026-05-04 14:00 CEST (Postgres backend)
+
+KC_DB upgraded from dev-file (H2) to postgres on Legion. Validated on isolated staging stack (`~/keycloak-banxe-emi-pg-test/`) before production replacement:
+
+- Postgres 16-alpine sidecar `keycloak-banxe-emi-pg`, named volume (no UID mismatch like R2 marble-pg bind-mount).
+- KC `keycloak-banxe-emi` 26.2.5 with `KC_DB=postgres` + `KC_DB_URL=jdbc:postgresql://keycloak-pg:5432/keycloak`.
+- Realm import: `Realm 'banxe-emi' imported` + `jdbc-postgresql` feature loaded (Profile prod activated).
+- Admin login + 4 client_credentials grants 4/4 OK on staging port 8181.
+
+### Phase F — production switch procedure
+
+When operator gives "go G-IAM-09 switch":
+
+1. `cd ~/keycloak-banxe-emi-legion && set -a && source ~/.banxe/keycloak.env && set +a`
+2. `docker compose down` (stops dev-file KC)
+3. Update `~/.banxe/keycloak.env`: add `KC_DB_USER=keycloak`, `KC_DB_PASSWORD=<generated>`, `KC_DB_NAME=keycloak`
+4. Pull new compose from main: `cp /data/banxe/banxe-emi-stack/infra/keycloak-banxe-emi/docker-compose.yml ./docker-compose.yml`
+5. `docker compose up -d` (starts Postgres + KC with Postgres backend)
+6. Wait healthy: `docker compose ps`
+7. Re-patch `sslRequired=NONE` on banxe-emi realm (volume reset means realm re-imported from JSON; sslRequired in JSON=none after Phase 57 PR #50)
+8. Re-provision 4 client secrets via `scripts/provision-clients.sh`
+9. Update `~/.banxe/keycloak.env` with new `KC_CLIENT_SECRET_*` values
+10. Smoke test 4/4 client_credentials grants
+11. Tag `g-iam-09-postgres-backend-closed-<date>`
+
+Backout: revert to commit before Phase D, `docker compose down -v`, restore previous compose+env.

--- a/infra/keycloak-banxe-emi/docker-compose.yml
+++ b/infra/keycloak-banxe-emi/docker-compose.yml
@@ -1,10 +1,30 @@
-# Keycloak realm banxe-emi — Legion host (STRATEGY-B post G-IAM-99 resolution)
+# Keycloak realm banxe-emi — Legion host with Postgres backend (G-IAM-09 closure)
 # ADR-017 / ADR-022 / I-34 / I-35 | FCA CASS 15
-# G-IAM-99 STRATEGY-B 2026-05-04: evo1 kernel 6.17 Quarkus SIGKILL -> Legion (kernel 6.6 WSL2).
-# KC_DB=dev-file is G-IAM-09 tech debt; migration to Postgres by 2026-05-31.
+#
+# G-IAM-09 closure 2026-05-04: KC_DB upgraded from dev-file (H2) to postgres
+# (production-grade, validated on staging stack via Phase C smoke 4/4 OK).
+# Postgres sidecar: postgres:16-alpine, named volume (no UID mismatch like R2 marble-pg).
+# KC_HOSTNAME=100.101.218.26 = Legion Tailscale IP.
+#
 # All secrets via ~/.banxe/keycloak.env (chmod 600). Pre-commit iam-no-direct-creds enforces.
 
 services:
+  keycloak-pg:
+    image: postgres:16-alpine
+    container_name: keycloak-banxe-emi-pg
+    environment:
+      POSTGRES_USER: ${KC_DB_USER:?KC_DB_USER is required}
+      POSTGRES_PASSWORD: ${KC_DB_PASSWORD:?KC_DB_PASSWORD is required}
+      POSTGRES_DB: ${KC_DB_NAME:?KC_DB_NAME is required}
+    volumes:
+      - keycloak_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U keycloak"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
   keycloak-banxe-emi:
     image: quay.io/keycloak/keycloak:26.2.5
     container_name: keycloak-banxe-emi
@@ -17,7 +37,10 @@ services:
       - --proxy-headers=xforwarded
       - --import-realm
     environment:
-      KC_DB: dev-file
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://keycloak-pg:5432/${KC_DB_NAME:?KC_DB_NAME is required}
+      KC_DB_USERNAME: ${KC_DB_USER:?KC_DB_USER is required}
+      KC_DB_PASSWORD: ${KC_DB_PASSWORD:?KC_DB_PASSWORD is required}
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOT_ADMIN:?KC_BOOT_ADMIN is required}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOT_ADMIN_PASSWORD:?KC_BOOT_ADMIN_PASSWORD is required}
       KC_HOSTNAME: 100.101.218.26
@@ -28,13 +51,17 @@ services:
       KC_HEALTH_ENABLED: "true"
       KC_METRICS_ENABLED: "true"
       KC_LOG_LEVEL: INFO
-      JAVA_OPTS: "-Xms256m -Xmx1g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -XX:+UseG1GC"
+      JAVA_OPTS: "-Xms256m -Xmx1g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -Dfile.encoding=UTF-8"
     volumes:
       - keycloak_data:/opt/keycloak/data
       - ./realms:/opt/keycloak/data/import:ro
     ports:
       - "8180:8180"
     mem_limit: 2g
+    memswap_limit: 4g
+    depends_on:
+      keycloak-pg:
+        condition: service_healthy
     healthcheck:
       test:
         - CMD-SHELL
@@ -49,4 +76,5 @@ services:
     restart: unless-stopped
 
 volumes:
+  keycloak_pg_data:
   keycloak_data:


### PR DESCRIPTION
## Summary

Closes **G-IAM-09** (KC_DB Postgres backend migration) ahead of 2026-05-31 target. Replaces `KC_DB=dev-file` (H2 file-backed in volume) with production-grade `KC_DB=postgres` + Postgres 16-alpine sidecar.

## Validation evidence

End-to-end smoke on isolated staging stack (`~/keycloak-banxe-emi-pg-test/` on Legion, port 8181, separate volume namespace):

- Postgres sidecar `keycloak-pg-test` healthy (named volume — avoids R2 UID mismatch from marble-pg bind-mount).
- KC 26.2.5 starts in 10.7s with `Profile prod activated` and `jdbc-postgresql` feature loaded.
- Liquibase changelog `META-INF/jpa-changelog-master.xml` initialises Postgres schema cleanly.
- Realm `banxe-emi` imported from JSON.
- Admin login via password grant: token len 773 OK.
- `sslRequired=NONE` patch applied via Admin REST API: HTTP 204.
- 4 client_credentials grants: all return Bearer JWT, expires_in=900.

Production KC on port 8180 (dev-file backend) was unaffected during validation: HTTP 200 throughout.

## What changed (3 files)

- `infra/keycloak-banxe-emi/docker-compose.yml` — added `keycloak-pg` service (Postgres 16-alpine), KC env switched to `KC_DB=postgres` + `KC_DB_URL=jdbc:postgresql://keycloak-pg:5432/keycloak`, KC depends_on Postgres healthy.
- `infra/keycloak-banxe-emi/RUNBOOK.md` — appended G-IAM-09 closure section with Phase F operator switch procedure.
- `GAP-REGISTER.md` — G-IAM-09 to DONE 2026-05-04.

## Phase F — production switch (operator-initiated)

Live switch from dev-file to Postgres backend is documented in RUNBOOK section "G-IAM-09 Closure" Phase F. Requires explicit operator "go G-IAM-09 switch" — not part of this PR.

## Backout

Revert this commit + `docker compose down -v` + restore previous compose+env. Documented in RUNBOOK.

## Approver

CODEOWNERS = @mmber. Self admin-merge after CI green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive migration guide for Keycloak database backend transition, including operator procedures and rollback steps.

* **Chores**
  * Updated deployment configuration to support PostgreSQL backend for Keycloak.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->