### PR TITLE
feat(audit): drain cron + CI smoke (ADR-027 step 3 final)

### DIFF
--- a/scripts/audit-buffer-drain.py
+++ b/scripts/audit-buffer-drain.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Drain the SQLite audit ring-buffer to ClickHouse.
+
+Reads undrained events from the SQLite buffer (BufferedAuditPort) and forwards
+them to AuditTrail (ClickHouse). Cleans up drained rows older than 14 days.
+
+Usage:
+    python3 scripts/audit-buffer-drain.py
+
+Cron (every 5 minutes):
+    */5 * * * * cd /opt/banxe && python3 scripts/audit-buffer-drain.py >> /var/log/banxe/audit-drain.log 2>&1
+
+Environment variables:
+    CLICKHOUSE_URL      ClickHouse HTTP endpoint (default: http://192.168.0.72:8123)
+    CLICKHOUSE_DB       ClickHouse database name (default: banxe)
+    AUDIT_DRY_RUN       true → log only, no CH writes (default: false)
+    AUDIT_BUFFER_PATH   SQLite ring-buffer path (default: /tmp/banxe-audit-buffer.db)
+
+Exit codes:
+    0  success (including zero events to drain)
+    1  unexpected error
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+logger = logging.getLogger("banxe.audit-drain")
+
+# Ensure repo root is on sys.path when run as a script
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+
+def main() -> int:
+    try:
+        from src.safeguarding.audit_trail import AuditTrail
+        from src.safeguarding.buffered_audit_port import BufferedAuditPort
+    except ImportError as exc:
+        logger.error("Import failed — is PYTHONPATH set correctly? %s", exc)
+        return 1
+
+    ch_url = os.getenv("CLICKHOUSE_URL", "http://192.168.0.72:8123")
+    db = os.getenv("CLICKHOUSE_DB", "banxe")
+    dry_run = os.getenv("AUDIT_DRY_RUN", "false").lower() == "true"
+    buffer_path = os.getenv("AUDIT_BUFFER_PATH", "/tmp/banxe-audit-buffer.db")
+
+    target = AuditTrail(clickhouse_url=ch_url, database=db, dry_run=dry_run)
+    port = BufferedAuditPort(db_path=buffer_path)
+
+    pending_before = port.pending_count()
+    logger.info("audit-drain start: pending=%d buffer=%s", pending_before, buffer_path)
+
+    try:
+        drained = port.drain(target=target, batch_size=100)
+        cleaned = port.cleanup(max_age_days=14)
+        pending_after = port.pending_count()
+        logger.info(
+            "audit-drain done: drained=%d cleaned=%d pending=%d",
+            drained,
+            cleaned,
+            pending_after,
+        )
+    except Exception as exc:
+        logger.error("audit-drain error: %s", exc)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_drain_smoke.py
+++ b/tests/test_audit_drain_smoke.py
@@ -1,0 +1,118 @@
+"""Smoke tests for ADR-027 step 3: drain script + end-to-end buffer flow.
+
+T1 — E2E: record 3 events → drain to mock AuditTrail → all 3 drained, pending=0
+T2 — Drain script subprocess: exits 0 with AUDIT_DRY_RUN=true
+T3 — Drain with target returning False → events stay in buffer
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from services.recon.recon_models import ReconAuditEntry, ReconStatus
+from src.safeguarding.buffered_audit_port import BufferedAuditPort
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_entry(recon_id: str = "smoke-recon") -> ReconAuditEntry:
+    return ReconAuditEntry(
+        recon_id=recon_id,
+        action="DAILY_RECON",
+        status=ReconStatus.BALANCED,
+        client_funds_total=Decimal("2500.00"),
+        safeguarding_total=Decimal("2500.00"),
+        actor="SMOKE_TEST",
+    )
+
+
+class _AlwaysTrue:
+    """Mock AuditTrail that always succeeds."""
+
+    def __init__(self) -> None:
+        self.calls: int = 0
+
+    def log(self, event: Any) -> bool:
+        self.calls += 1
+        return True
+
+
+class _AlwaysFalse:
+    """Mock AuditTrail that always fails (simulates CH down)."""
+
+    def log(self, event: Any) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# T1 — End-to-end: record 3 → drain all → pending=0
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_record_drain_all(tmp_path: Path) -> None:
+    """record 3 events, drain to mock target → all 3 forwarded, pending=0."""
+    port = BufferedAuditPort(db_path=tmp_path / "buf.db")
+    for i in range(3):
+        port.record(make_entry(recon_id=f"smoke-{i}"))
+
+    assert port.pending_count() == 3
+
+    target = _AlwaysTrue()
+    drained = port.drain(target=target, batch_size=100)
+
+    assert drained == 3
+    assert target.calls == 3
+    assert port.pending_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# T2 — Drain script subprocess exits 0
+# ---------------------------------------------------------------------------
+
+
+def test_drain_script_exits_zero(tmp_path: Path) -> None:
+    """scripts/audit-buffer-drain.py exits 0 with AUDIT_DRY_RUN=true."""
+    repo_root = Path(__file__).parent.parent
+    script = repo_root / "scripts" / "audit-buffer-drain.py"
+
+    env = {
+        **os.environ,
+        "AUDIT_DRY_RUN": "true",
+        "AUDIT_BUFFER_PATH": str(tmp_path / "drain-smoke.db"),
+        "PYTHONPATH": str(repo_root),
+    }
+
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Script failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# T3 — CH down (target returns False) → events stay in buffer
+# ---------------------------------------------------------------------------
+
+
+def test_drain_ch_down_keeps_events(tmp_path: Path) -> None:
+    """When target.log() returns False, events are NOT marked drained."""
+    port = BufferedAuditPort(db_path=tmp_path / "buf.db")
+    for i in range(3):
+        port.record(make_entry(recon_id=f"stuck-{i}"))
+
+    drained = port.drain(target=_AlwaysFalse(), batch_size=100)
+
+    assert drained == 0
+    assert port.pending_count() == 3


### PR DESCRIPTION
## Summary

Final implementation step of ADR-027 (BufferedAuditPort audit-trail durability).

- `scripts/audit-buffer-drain.py` — cron drain script flushes SQLite ring-buffer to ClickHouse `AuditTrail`. Reads `CLICKHOUSE_URL`, `CLICKHOUSE_DB`, `AUDIT_DRY_RUN`, `AUDIT_BUFFER_PATH` from env. Logs `drained N / cleaned M / pending K`. Exit 0 on success, 1 on error.
- `tests/test_audit_drain_smoke.py` — 3 smoke tests covering e2e drain, subprocess exit code, and CH-down buffer retention.

## Cron usage

```
*/5 * * * * cd /opt/banxe && python3 scripts/audit-buffer-drain.py >> /var/log/banxe/audit-drain.log 2>&1
```

## Tests

```
tests/test_audit_drain_smoke.py  3 passed (0.18s)
```

## ADR-027 completion summary

| Step | PR | Status |
|------|----|--------|
| Step 1: BufferedAuditPort + 8 unit tests | #66 | merged |
| Step 2: DI wiring + AUDIT_FAIL_CLOSED + 4 tests | #67 | merged |
| Step 3: drain script + 3 smoke tests | this PR | ready |

**Follow-up (operator):** flip ADR-027 status `Proposed → Accepted` in `banxe-architecture` and close `G-CASS-01` audit finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)