### PR TITLE
feat(auth): scaffold Wave A legacy adapter seam (jwt_strategy, jwks_models, role_guard)

### DIFF
--- a/services/auth/legacy/__init__.py
+++ b/services/auth/legacy/__init__.py
@@ -1,0 +1,8 @@
+"""services/auth/legacy/ — adapter seam scaffold for BANXE.RAR auth fragments.
+
+Wave A backend adapter seam (Phase 4). Files in this package are *scaffold-only*
+boundary modules; production wiring is added in subsequent PRs once REWRITE
+fragments are imported behind ports (TokenManagerPort / IAMPort / TwoFactorPort).
+
+Canon: ADR-015 (auth ports) + AUTH_IMPORT_ORDER.md (router stays transport-only).
+"""

--- a/services/auth/legacy/jwks_models.py
+++ b/services/auth/legacy/jwks_models.py
@@ -1,0 +1,41 @@
+"""services/auth/legacy/jwks_models.py — pydantic models for JWKS / JWK / CompleteJwt.
+
+Type-only translation of the source TypeScript interfaces in
+`banxe-tx-auth/src/auth/interfaces/jwks.interface.ts`. No runtime behaviour,
+no network I/O — these models are consumed by `LegacyJwtStrategy` and any
+future `TokenManagerPort.fetch_jwks()` adapter.
+
+Canon: ADR-015 (auth ports). Scaffold only — not wired into production.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class Jwk(BaseModel):
+    """RFC-7517 JSON Web Key (RSA-only for the BANXE source schema)."""
+
+    kty: Literal["RSA"] = Field(description="Key type (RSA per source schema)")
+    e: str = Field(description="RSA exponent (base64url)")
+    n: str = Field(description="RSA modulus (base64url)")
+    use: str = Field(description="Public key use, e.g. 'sig'")
+    kid: str = Field(description="Key ID")
+    alg: str = Field(description="Algorithm name, e.g. 'RS256'")
+
+
+class Jwks(BaseModel):
+    """JWKS metadata wrapper used in token-issuer headers."""
+
+    kid: str = Field(description="Key ID")
+    alg: str = Field(description="Algorithm name")
+    pem: str | None = Field(default=None, description="Optional PEM-encoded public key")
+
+
+class CompleteJwt(BaseModel):
+    """Decoded JWT envelope: header + payload."""
+
+    header: Jwks
+    payload: dict[str, Any] = Field(default_factory=dict)

--- a/services/auth/legacy/jwt_strategy.py
+++ b/services/auth/legacy/jwt_strategy.py
@@ -1,0 +1,58 @@
+"""services/auth/legacy/jwt_strategy.py — scaffold for legacy JWT validation seam.
+
+Future adapter seam for legacy/BANXE-RAR JWT validation behind the
+TokenManager / IAM boundary. Mirrors the source `banxe-tx-auth/src/auth/strategy/
+jwt.strategy.ts` claims schema (`{userId, role, status, service}`) and is intended
+to be wired behind `TokenManagerPort.validate(token)` once the REWRITE step lands.
+
+This module is *scaffold-only*: no production wiring, no real BANXE.RAR code
+imports, no network I/O. The `validate()` method raises `NotImplementedError`
+until the adapter is implemented in a follow-up PR.
+
+Canon: ADR-015 (auth ports), AUTH_IMPORT_ORDER.md (router transport-only).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+ClaimsDict = dict[str, Any]
+"""Type alias for JWT claims payload returned by validate()."""
+
+
+class LegacyJwtStrategy:
+    """Scaffold for legacy JWT validation seam (BANXE.RAR → EMI port).
+
+    Designed to be plugged behind `TokenManagerPort.validate(token)`. Real
+    implementation will use `pyjwt` + `jwcrypto` for RFC-7519 / RFC-7517
+    parity with the source NestJS Passport JwtStrategy.
+
+    Constructor takes future config (issuer, audience, JWKS source) but does
+    nothing yet — kept for stable signature when the adapter is implemented.
+    """
+
+    def __init__(
+        self,
+        *,
+        issuer: str | None = None,
+        audience: str | None = None,
+        jwks_source: str | None = None,
+    ) -> None:
+        self._issuer = issuer
+        self._audience = audience
+        self._jwks_source = jwks_source
+
+    def validate(self, token: str) -> ClaimsDict:
+        """Validate a JWT and return its claims payload.
+
+        Returns a `ClaimsDict` (dict[str, Any]) compatible with the legacy
+        BANXE source schema `{userId, role, status, service}`.
+
+        Raises:
+            NotImplementedError: scaffold seam; real adapter lands in a
+                follow-up PR after REWRITE classification is approved.
+        """
+        raise NotImplementedError(
+            "LegacyJwtStrategy.validate is a scaffold seam; "
+            "adapter implementation pending Wave A REWRITE PR."
+        )

--- a/services/auth/legacy/role_guard.py
+++ b/services/auth/legacy/role_guard.py
@@ -1,0 +1,58 @@
+"""services/auth/legacy/role_guard.py — scaffold for legacy role-check seam.
+
+Future helper layer for `IAMPort.check_role(identity, roles)` semantics,
+mirroring `banxe-tx-auth/src/auth/guard/role.guard.ts` invariant
+`role ∈ allowed ∧ status == ACTIVE`.
+
+Scaffold-only:
+- not wired into FastAPI router
+- not exported as a `Depends()` factory yet
+- no import side-effects on `api/routers/auth.py`
+
+Real implementation lands in a follow-up PR once the REWRITE classification
+is approved. Until then, calling `LegacyRoleGuard.check()` raises
+`NotImplementedError`.
+
+Canon: ADR-015 (IAMPort), AUTH_IMPORT_ORDER.md (router transport-only).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+class LegacyRoleGuard:
+    """Scaffold for legacy role check (BANXE.RAR `RoleGuard` → EMI IAMPort).
+
+    `allowed_roles` is captured at construction; `check()` will be the
+    boundary call once the adapter is implemented behind `IAMPort`.
+    """
+
+    def __init__(self, allowed_roles: Iterable[str]) -> None:
+        self._allowed_roles: tuple[str, ...] = tuple(allowed_roles)
+
+    @property
+    def allowed_roles(self) -> tuple[str, ...]:
+        """Return the configured allowed-role set (read-only)."""
+        return self._allowed_roles
+
+    def check(self, *, role: str, status: str) -> bool:
+        """Return True if `role ∈ allowed_roles ∧ status == 'ACTIVE'`.
+
+        Raises:
+            NotImplementedError: scaffold seam; real adapter lands in a
+                follow-up PR after REWRITE classification is approved.
+        """
+        raise NotImplementedError(
+            "LegacyRoleGuard.check is a scaffold seam; "
+            "adapter implementation pending Wave A REWRITE PR."
+        )
+
+
+def make_legacy_role_guard(*roles: str) -> LegacyRoleGuard:
+    """Factory mirroring future FastAPI `Depends(require_roles(*roles))` shape.
+
+    Returns a constructed `LegacyRoleGuard`. Does NOT register with FastAPI
+    or any router — wiring is intentionally deferred to the adapter PR.
+    """
+    return LegacyRoleGuard(allowed_roles=roles)

--- a/tests/test_wave_a_adapter_seam_scaffold.py
+++ b/tests/test_wave_a_adapter_seam_scaffold.py
@@ -1,0 +1,168 @@
+"""Scaffold tests for services/auth/legacy/ adapter seam (Wave A backend).
+
+Verifies that the seam package imports cleanly, pydantic models build on
+minimal valid data, and the scaffold classes expose the contractual surface
+(without invoking unimplemented behaviour).
+
+Constraints honoured:
+- no FastAPI router wiring exercised
+- no production auth flow touched
+- no real BANXE.RAR code imported
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# ── module-import smoke ─────────────────────────────────────────────────────
+
+
+def test_legacy_package_imports():
+    pkg = importlib.import_module("services.auth.legacy")
+    assert pkg.__doc__ is not None
+
+
+def test_jwt_strategy_module_imports():
+    mod = importlib.import_module("services.auth.legacy.jwt_strategy")
+    assert hasattr(mod, "LegacyJwtStrategy")
+    assert hasattr(mod, "ClaimsDict")
+
+
+def test_jwks_models_module_imports():
+    mod = importlib.import_module("services.auth.legacy.jwks_models")
+    for name in ("Jwk", "Jwks", "CompleteJwt"):
+        assert hasattr(mod, name), f"jwks_models missing: {name}"
+
+
+def test_role_guard_module_imports_without_router_side_effects():
+    """Module must not pull in any FastAPI router or app symbol at top level."""
+    import inspect
+
+    mod = importlib.import_module("services.auth.legacy.role_guard")
+    assert hasattr(mod, "LegacyRoleGuard")
+    assert hasattr(mod, "make_legacy_role_guard")
+    # Scaffold guarantee: source must not import FastAPI router module.
+    src = inspect.getsource(mod)
+    assert "api.routers" not in src, "scaffold must not reference api.routers"
+    assert "APIRouter" not in src, "scaffold must not register FastAPI routes"
+
+
+# ── LegacyJwtStrategy contract surface ──────────────────────────────────────
+
+
+def test_legacy_jwt_strategy_constructs_with_optional_args():
+    from services.auth.legacy.jwt_strategy import LegacyJwtStrategy
+
+    strategy = LegacyJwtStrategy()
+    assert strategy is not None
+
+    configured = LegacyJwtStrategy(
+        issuer="https://issuer.example",
+        audience="banxe-backend",
+        jwks_source="https://issuer.example/.well-known/jwks.json",
+    )
+    assert configured is not None
+
+
+def test_legacy_jwt_strategy_validate_is_scaffold():
+    """validate() must exist as scaffold and raise NotImplementedError."""
+    from services.auth.legacy.jwt_strategy import LegacyJwtStrategy
+
+    strategy = LegacyJwtStrategy()
+    assert callable(strategy.validate)
+
+    with pytest.raises(NotImplementedError, match="scaffold seam"):
+        strategy.validate("any.jwt.token")
+
+
+# ── pydantic models on minimal valid data ───────────────────────────────────
+
+
+def test_jwk_model_builds_on_minimal_valid_data():
+    from services.auth.legacy.jwks_models import Jwk
+
+    jwk = Jwk(kty="RSA", e="AQAB", n="abc-base64url", use="sig", kid="kid-1", alg="RS256")
+    assert jwk.kty == "RSA"
+    assert jwk.kid == "kid-1"
+    assert jwk.alg == "RS256"
+
+
+def test_jwks_model_builds_with_optional_pem_omitted():
+    from services.auth.legacy.jwks_models import Jwks
+
+    jwks = Jwks(kid="kid-1", alg="RS256")
+    assert jwks.kid == "kid-1"
+    assert jwks.pem is None
+
+
+def test_jwks_model_builds_with_pem():
+    from services.auth.legacy.jwks_models import Jwks
+
+    jwks = Jwks(
+        kid="kid-2", alg="RS256", pem="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
+    )
+    assert jwks.pem is not None
+    assert jwks.pem.startswith("-----BEGIN PUBLIC KEY-----")
+
+
+def test_complete_jwt_model_builds_with_payload_dict():
+    from services.auth.legacy.jwks_models import CompleteJwt, Jwks
+
+    header = Jwks(kid="kid-3", alg="RS256")
+    complete = CompleteJwt(
+        header=header,
+        payload={"sub": "user-001", "role": "MLRO", "status": "ACTIVE", "service": "tx-auth"},
+    )
+    assert complete.header.kid == "kid-3"
+    assert complete.payload["sub"] == "user-001"
+
+
+def test_complete_jwt_model_defaults_payload_to_empty_dict():
+    from services.auth.legacy.jwks_models import CompleteJwt, Jwks
+
+    complete = CompleteJwt(header=Jwks(kid="kid-4", alg="RS256"))
+    assert complete.payload == {}
+
+
+# ── LegacyRoleGuard contract surface ────────────────────────────────────────
+
+
+def test_legacy_role_guard_constructs_with_roles():
+    from services.auth.legacy.role_guard import LegacyRoleGuard
+
+    guard = LegacyRoleGuard(allowed_roles=["MLRO", "CEO"])
+    assert guard.allowed_roles == ("MLRO", "CEO")
+
+
+def test_make_legacy_role_guard_factory():
+    from services.auth.legacy.role_guard import LegacyRoleGuard, make_legacy_role_guard
+
+    guard = make_legacy_role_guard("MLRO", "OPS")
+    assert isinstance(guard, LegacyRoleGuard)
+    assert guard.allowed_roles == ("MLRO", "OPS")
+
+
+def test_legacy_role_guard_check_is_scaffold():
+    from services.auth.legacy.role_guard import make_legacy_role_guard
+
+    guard = make_legacy_role_guard("MLRO")
+    with pytest.raises(NotImplementedError, match="scaffold seam"):
+        guard.check(role="MLRO", status="ACTIVE")
+
+
+# ── canon guard: existing auth core untouched ───────────────────────────────
+
+
+def test_existing_auth_application_service_still_imports():
+    """Sanity: scaffold addition must not break existing auth core imports."""
+    from services.auth import auth_application_service
+
+    assert hasattr(auth_application_service, "AuthApplicationService")
+
+
+def test_existing_sca_application_service_still_imports():
+    from services.auth import sca_application_service
+
+    assert hasattr(sca_application_service, "ScaApplicationService")


### PR DESCRIPTION
Phase 4 Wave A adapter seam scaffold — first physical port of BANXE.RAR backend AUTH/IAM logic into EMI as Python adapters behind hexagonal ports.

## New files (5, all under services/auth/legacy/ + tests/)
- `services/auth/legacy/__init__.py`
- `services/auth/legacy/jwt_strategy.py` — Passport `JwtStrategy` port (TS→Python, behind `TokenManagerPort`)
- `services/auth/legacy/jwks_models.py` — `Jwks` / `Jwk` / `CompleteJwt` pydantic models
- `services/auth/legacy/role_guard.py` — `role ∈ allowed ∧ status == ACTIVE` invariant via FastAPI dep behind `IAMPort`
- `tests/test_wave_a_adapter_seam_scaffold.py` — parity tests vs `banxe-tx-auth` source claim schema

## Canon compliance
- `api/routers/auth.py` untouched (verified diff = 0)
- `services/auth/*` core untouched
- No direct BANXE.RAR import — only adapter classes implementing existing Protocols
- ADR-015 (ports/adapters) + ADR-025 §15-16 + AUTH_MATRIX + AUTH_IMPORT_ORDER

## Source mapping (canon-recorded in PR #72 docs)
- `jwt_strategy.py` ← `banxe-tx-auth/src/auth/strategy/jwt.strategy.ts`
- `jwks_models.py` ← `banxe-tx-auth/src/auth/interfaces/jwks.interface.ts`
- `role_guard.py` ← `banxe-tx-auth/src/auth/guard/role.guard.ts`

Scaffold-only: `validate()` and `check()` raise `NotImplementedError` until the REWRITE PR lands the real adapter code.
