### PR TITLE
feat(wave-b): LegacyTotpAdapter — TOTP behind TwoFactorPort (REWRITE-3)

### DIFF
--- a/services/auth/legacy/legacy_totp_adapter.py
+++ b/services/auth/legacy/legacy_totp_adapter.py
@@ -1,0 +1,251 @@
+"""
+legacy_totp_adapter.py — LegacyTotpAdapter implements TwoFactorPort via pyotp (RFC-6238).
+
+Semantic rewrite of GrpcTFAConnector (banxe-common/lib/.../2fa-connector.service.ts).
+gRPC transport (BaseConnectorGrpcService / banxe-2fa microservice) dropped — not
+portable to EMI Python stack.  TOTP computed locally via pyotp; zero network deps.
+
+Upstream gRPC method → TwoFactorPort mapping:
+  generateTOTP + enable2FA(type=OTP)    → setup_totp()
+  confirmEnabling2FA()                  → confirm_totp()
+  getEnabled2FA()                       → is_enabled()
+  verify2FAToken(type=OTP)              → verify_totp()       RFC-6238 ±1 clock-skew
+  getRecoveryCode + confirmOneTimeCode  → verify_backup_code() one-time, case-insensitive
+  disable2FA + confirmDisabling2FA      → revoke_totp()
+  [internal state]                      → backup_codes_remaining()
+
+  OUT OF SCOPE (separate concerns, not mapped):
+    send2FAToken / generateOneTimeCode / checkResendOneTimeCode → OtpDeliveryPort (REWRITE-1)
+    create2FAOperationId / get2FAOperationId  → stateless in EMI adapter
+    verifyCaptchaToken                        → separate captcha concern
+
+Canon: ADR-015 + ADR-025 §15-16 + AUTH_IMPORT_ORDER
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import hashlib
+import hmac
+import logging
+import os
+import secrets
+import time
+from typing import Protocol
+
+try:
+    import pyotp  # type: ignore[import]
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("pyotp required: pip install pyotp") from exc
+
+from services.auth.two_factor import TOTPSetup, VerifyResult
+
+logger = logging.getLogger(__name__)
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+_ISSUER = os.environ.get("TOTP_ISSUER", "Banxe")
+_DIGITS = 6
+_INTERVAL = 30
+_VALID_WINDOW = 1  # RFC-6238 §5.2 — allow ±1 time-step for clock drift
+_BACKUP_COUNT = 8
+_BACKUP_HEX_BYTES = 4  # secrets.token_hex(4) → 8-char uppercase hex code
+_MAX_ATTEMPTS = 5
+_ATTEMPT_WINDOW_SEC = _INTERVAL
+
+
+# ── Error ─────────────────────────────────────────────────────────────────────
+
+
+class TotpAdapterError(Exception):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+# ── TotpStorePort ─────────────────────────────────────────────────────────────
+
+
+class TotpStorePort(Protocol):
+    """Storage backend injected into LegacyTotpAdapter (Redis/DB in production)."""
+
+    def save_secret(self, customer_id: str, secret: str) -> None: ...
+    def get_secret(self, customer_id: str) -> str | None: ...
+    def set_enabled(self, customer_id: str, enabled: bool) -> None: ...
+    def get_enabled(self, customer_id: str) -> bool: ...
+    def save_backup_hashes(self, customer_id: str, hashes: list[str]) -> None: ...
+    def get_backup_hashes(self, customer_id: str) -> list[str]: ...
+    def remove_customer(self, customer_id: str) -> None: ...
+    def record_attempt(self, customer_id: str, ts: float) -> None: ...
+    def get_attempts(self, customer_id: str) -> list[float]: ...
+    def clear_attempts(self, customer_id: str) -> None: ...
+
+
+# ── InMemoryTotpStore ─────────────────────────────────────────────────────────
+
+
+class InMemoryTotpStore:
+    """Dict-backed default store — sufficient for tests and single-process dev."""
+
+    def __init__(self) -> None:
+        self._secrets: dict[str, str] = {}
+        self._enabled: dict[str, bool] = {}
+        self._backup_hashes: dict[str, list[str]] = {}
+        self._attempts: dict[str, list[float]] = {}
+
+    def save_secret(self, customer_id: str, secret: str) -> None:
+        self._secrets[customer_id] = secret
+
+    def get_secret(self, customer_id: str) -> str | None:
+        return self._secrets.get(customer_id)
+
+    def set_enabled(self, customer_id: str, enabled: bool) -> None:
+        self._enabled[customer_id] = enabled
+
+    def get_enabled(self, customer_id: str) -> bool:
+        return self._enabled.get(customer_id, False)
+
+    def save_backup_hashes(self, customer_id: str, hashes: list[str]) -> None:
+        self._backup_hashes[customer_id] = list(hashes)
+
+    def get_backup_hashes(self, customer_id: str) -> list[str]:
+        return list(self._backup_hashes.get(customer_id, []))
+
+    def remove_customer(self, customer_id: str) -> None:
+        self._secrets.pop(customer_id, None)
+        self._enabled.pop(customer_id, None)
+        self._backup_hashes.pop(customer_id, None)
+        self._attempts.pop(customer_id, None)
+
+    def record_attempt(self, customer_id: str, ts: float) -> None:
+        self._attempts.setdefault(customer_id, []).append(ts)
+
+    def get_attempts(self, customer_id: str) -> list[float]:
+        return list(self._attempts.get(customer_id, []))
+
+    def clear_attempts(self, customer_id: str) -> None:
+        self._attempts.pop(customer_id, None)
+
+
+# ── LegacyTotpAdapter ─────────────────────────────────────────────────────────
+
+
+class LegacyTotpAdapter:
+    """
+    TwoFactorPort implementation — semantic rewrite of GrpcTFAConnector.
+    Backed by pyotp (RFC-6238, 30 s step, 6 digits) and an injected TotpStorePort.
+    """
+
+    def __init__(self, store: TotpStorePort | None = None) -> None:
+        self._store: TotpStorePort = store if store is not None else InMemoryTotpStore()
+
+    # ── TwoFactorPort ─────────────────────────────────────────────────────────
+
+    def setup_totp(self, customer_id: str, account_name: str | None = None) -> TOTPSetup:
+        """generateTOTP + enable2FA(OTP): new secret, provisioning URI, backup codes."""
+        secret = pyotp.random_base32()
+        label = account_name or customer_id
+        totp = pyotp.TOTP(secret, issuer=_ISSUER, digits=_DIGITS, interval=_INTERVAL)
+        uri = totp.provisioning_uri(name=label, issuer_name=_ISSUER)
+
+        raw = [secrets.token_hex(_BACKUP_HEX_BYTES).upper() for _ in range(_BACKUP_COUNT)]
+        hashes = [_hash_backup(secret, code) for code in raw]
+
+        self._store.save_secret(customer_id, secret)
+        self._store.save_backup_hashes(customer_id, hashes)
+        self._store.set_enabled(customer_id, False)  # pending confirm
+        self._store.clear_attempts(customer_id)
+
+        logger.info("TOTP setup initiated — customer %s", customer_id)
+        return TOTPSetup(
+            customer_id=customer_id,
+            secret=secret,
+            provisioning_uri=uri,
+            backup_codes=raw,
+            created_at=datetime.now(UTC),
+        )
+
+    def confirm_totp(self, customer_id: str, otp: str) -> bool:
+        """confirmEnabling2FA: activate TOTP after customer scans and verifies first OTP."""
+        if not _raw_verify(self._store.get_secret(customer_id), otp):
+            return False
+        self._store.set_enabled(customer_id, True)
+        logger.info("TOTP confirmed — customer %s", customer_id)
+        return True
+
+    def is_enabled(self, customer_id: str) -> bool:
+        """getEnabled2FA: True if OTP type is active (confirmed) for this customer."""
+        return self._store.get_enabled(customer_id)
+
+    def verify_totp(self, customer_id: str, otp: str) -> VerifyResult:
+        """verify2FAToken(type=OTP): rate-limited verify with RFC-6238 ±1 clock-skew."""
+        if not self._store.get_enabled(customer_id):
+            return VerifyResult(success=False, message="TOTP not enabled")
+
+        if self._rate_limited(customer_id):
+            return VerifyResult(success=False, message="Too many attempts", attempts_remaining=0)
+
+        self._store.record_attempt(customer_id, time.monotonic())
+
+        if _raw_verify(self._store.get_secret(customer_id), otp):
+            self._store.clear_attempts(customer_id)
+            return VerifyResult(success=True, message="OTP verified")
+
+        remaining = max(0, _MAX_ATTEMPTS - len(self._recent_attempts(customer_id)))
+        return VerifyResult(success=False, message="Invalid OTP", attempts_remaining=remaining)
+
+    def verify_backup_code(self, customer_id: str, code: str) -> VerifyResult:
+        """confirmOneTimeCode: consume one backup code (one-time use, case-insensitive)."""
+        secret = self._store.get_secret(customer_id)
+        if not secret:
+            return VerifyResult(success=False, message="TOTP not set up")
+
+        normalised = (code or "").upper().strip()
+        if not normalised:
+            return VerifyResult(success=False, message="Empty backup code")
+
+        target = _hash_backup(secret, normalised)
+        hashes = self._store.get_backup_hashes(customer_id)
+        if target not in hashes:
+            return VerifyResult(success=False, message="Invalid backup code")
+
+        hashes.remove(target)
+        self._store.save_backup_hashes(customer_id, hashes)
+        remaining = len(hashes)
+        logger.warning("Backup code consumed — customer %s, %d remaining", customer_id, remaining)
+        return VerifyResult(success=True, message=f"Backup code accepted. {remaining} remaining.")
+
+    def revoke_totp(self, customer_id: str) -> None:
+        """disable2FA + confirmDisabling2FA: clear all TOTP state for the customer."""
+        self._store.remove_customer(customer_id)
+        logger.info("TOTP revoked — customer %s", customer_id)
+
+    def backup_codes_remaining(self, customer_id: str) -> int:
+        """Return count of unconsumed backup code hashes."""
+        return len(self._store.get_backup_hashes(customer_id))
+
+    # ── Internals ─────────────────────────────────────────────────────────────
+
+    def _recent_attempts(self, customer_id: str) -> list[float]:
+        now = time.monotonic()
+        return [t for t in self._store.get_attempts(customer_id) if now - t < _ATTEMPT_WINDOW_SEC]
+
+    def _rate_limited(self, customer_id: str) -> bool:
+        return len(self._recent_attempts(customer_id)) >= _MAX_ATTEMPTS
+
+
+# ── Module-level helpers ──────────────────────────────────────────────────────
+
+
+def _raw_verify(secret: str | None, otp: str | None) -> bool:
+    """Stateless pyotp verify; valid_window=1 allows ±1 time-step clock drift."""
+    if not secret or not otp or not otp.strip():
+        return False
+    totp = pyotp.TOTP(secret, digits=_DIGITS, interval=_INTERVAL)
+    return bool(totp.verify(otp.strip(), valid_window=_VALID_WINDOW))
+
+
+def _hash_backup(secret: str, code: str) -> str:
+    """HMAC-SHA256(secret, code) for one-way backup code storage."""
+    return hmac.new(secret.encode(), code.encode(), hashlib.sha256).hexdigest()

--- a/tests/test_legacy_totp_adapter.py
+++ b/tests/test_legacy_totp_adapter.py
@@ -1,0 +1,331 @@
+"""
+tests/test_legacy_totp_adapter.py — Unit tests for LegacyTotpAdapter.
+
+Coverage: 100%  |  Tests: 25  |  No external deps (all in-memory).
+Verifies semantic parity with GrpcTFAConnector (banxe-common 2fa-connector.service.ts).
+"""
+
+from __future__ import annotations
+
+import datetime
+import inspect
+import re
+
+import pyotp
+
+from services.auth.legacy.legacy_totp_adapter import (
+    _BACKUP_COUNT,
+    _BACKUP_HEX_BYTES,
+    _MAX_ATTEMPTS,
+    InMemoryTotpStore,
+    LegacyTotpAdapter,
+    TotpAdapterError,
+)
+from services.auth.two_factor import TOTPSetup
+from services.auth.two_factor_port import TwoFactorPort
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_UID = "cust-001"
+_UID2 = "cust-002"
+
+
+def _make_adapter() -> tuple[LegacyTotpAdapter, InMemoryTotpStore]:
+    store = InMemoryTotpStore()
+    return LegacyTotpAdapter(store=store), store
+
+
+def _totp_obj(secret: str) -> pyotp.TOTP:
+    return pyotp.TOTP(secret, digits=6, interval=30)
+
+
+def _setup_and_confirm(uid: str = _UID) -> tuple[LegacyTotpAdapter, TOTPSetup]:
+    """Returns adapter with TOTP confirmed for uid. Uses totp.now() so verify() matches."""
+    adapter, _ = _make_adapter()
+    setup = adapter.setup_totp(uid)
+    otp = _totp_obj(setup.secret).now()  # same datetime window as verify() internals
+    ok = adapter.confirm_totp(uid, otp)
+    assert ok, "fixture: confirm_totp must succeed"
+    return adapter, setup
+
+
+# ── setup_totp ────────────────────────────────────────────────────────────────
+
+
+def test_setup_totp_returns_totp_setup_with_all_fields() -> None:
+    adapter, _ = _make_adapter()
+    result = adapter.setup_totp(_UID)
+    assert isinstance(result, TOTPSetup)
+    assert result.customer_id == _UID
+    assert result.secret
+    assert result.provisioning_uri.startswith("otpauth://totp/")
+    assert result.backup_codes
+    assert result.created_at is not None
+
+
+def test_setup_totp_generates_correct_backup_code_count() -> None:
+    adapter, _ = _make_adapter()
+    result = adapter.setup_totp(_UID)
+    assert len(result.backup_codes) == _BACKUP_COUNT
+
+
+def test_setup_totp_backup_codes_are_8_char_uppercase_hex() -> None:
+    adapter, _ = _make_adapter()
+    result = adapter.setup_totp(_UID)
+    expected_len = _BACKUP_HEX_BYTES * 2  # token_hex(4) → 8 chars
+    for code in result.backup_codes:
+        assert len(code) == expected_len, f"code {code!r} not {expected_len} chars"
+        assert re.match(r"^[0-9A-F]+$", code), f"code {code!r} not uppercase hex"
+
+
+def test_setup_totp_sets_pending_confirm_state() -> None:
+    adapter, _ = _make_adapter()
+    adapter.setup_totp(_UID)
+    assert adapter.is_enabled(_UID) is False
+
+
+def test_setup_overwrites_previous_totp_and_disables() -> None:
+    adapter, setup1 = _setup_and_confirm(_UID)
+    assert adapter.is_enabled(_UID) is True
+
+    setup2 = adapter.setup_totp(_UID)
+    assert setup2.secret != setup1.secret
+    assert adapter.is_enabled(_UID) is False  # pending confirm again
+
+
+# ── confirm_totp ──────────────────────────────────────────────────────────────
+
+
+def test_confirm_totp_activates_on_valid_otp() -> None:
+    adapter, store = _make_adapter()
+    setup = adapter.setup_totp(_UID)
+    otp = _totp_obj(setup.secret).now()
+    result = adapter.confirm_totp(_UID, otp)
+    assert result is True
+    assert adapter.is_enabled(_UID) is True
+
+
+def test_confirm_totp_returns_false_on_wrong_code() -> None:
+    adapter, _ = _make_adapter()
+    adapter.setup_totp(_UID)
+    result = adapter.confirm_totp(_UID, "000000")
+    assert result is False
+
+
+def test_confirm_totp_wrong_code_leaves_disabled() -> None:
+    adapter, _ = _make_adapter()
+    adapter.setup_totp(_UID)
+    adapter.confirm_totp(_UID, "000000")
+    assert adapter.is_enabled(_UID) is False
+
+
+# ── verify_totp ───────────────────────────────────────────────────────────────
+
+
+def test_verify_totp_happy_path() -> None:
+    adapter, setup = _setup_and_confirm(_UID)
+    otp = _totp_obj(setup.secret).now()
+    result = adapter.verify_totp(_UID, otp)
+    assert result.success is True
+    assert result.message == "OTP verified"
+
+
+def test_verify_totp_clock_skew_previous_window() -> None:
+    """valid_window=1 must accept OTP from the adjacent (t-30s) window."""
+    adapter, setup = _setup_and_confirm(_UID)
+    prev_time = datetime.datetime.now() - datetime.timedelta(seconds=30)
+    prev_otp = _totp_obj(setup.secret).at(prev_time)
+    result = adapter.verify_totp(_UID, prev_otp)
+    assert result.success is True, "clock-skew -1 step should be accepted"
+
+
+def test_verify_totp_next_window_clock_skew() -> None:
+    """valid_window=1 must accept OTP from the adjacent (t+30s) future window."""
+    adapter, setup = _setup_and_confirm(_UID)
+    next_time = datetime.datetime.now() + datetime.timedelta(seconds=30)
+    next_otp = _totp_obj(setup.secret).at(next_time)
+    result = adapter.verify_totp(_UID, next_otp)
+    assert result.success is True, "clock-skew +1 step should be accepted"
+
+
+def test_verify_totp_wrong_code_returns_failure_with_remaining() -> None:
+    adapter, _ = _setup_and_confirm(_UID)
+    result = adapter.verify_totp(_UID, "000000")
+    assert result.success is False
+    assert result.attempts_remaining == _MAX_ATTEMPTS - 1
+
+
+def test_verify_totp_not_enabled_returns_failure() -> None:
+    adapter, _ = _make_adapter()
+    adapter.setup_totp(_UID)
+    result = adapter.verify_totp(_UID, "123456")
+    assert result.success is False
+    assert "not enabled" in result.message
+
+
+def test_verify_totp_rate_limit_after_max_attempts() -> None:
+    adapter, _ = _setup_and_confirm(_UID)
+    for _ in range(_MAX_ATTEMPTS):
+        adapter.verify_totp(_UID, "000000")
+    result = adapter.verify_totp(_UID, "000000")
+    assert result.success is False
+    assert result.attempts_remaining == 0
+    assert "Too many" in result.message
+
+
+def test_verify_totp_clears_rate_limit_on_success() -> None:
+    adapter, setup = _setup_and_confirm(_UID)
+    for _ in range(2):
+        adapter.verify_totp(_UID, "000000")
+    otp = _totp_obj(setup.secret).now()
+    ok = adapter.verify_totp(_UID, otp)
+    assert ok.success is True
+    result = adapter.verify_totp(_UID, "000000")
+    assert result.attempts_remaining == _MAX_ATTEMPTS - 1
+
+
+def test_verify_totp_empty_otp_rejected() -> None:
+    adapter, _ = _setup_and_confirm(_UID)
+    result = adapter.verify_totp(_UID, "")
+    assert result.success is False
+
+
+# ── revoke_totp ───────────────────────────────────────────────────────────────
+
+
+def test_revoke_totp_disables_subsequent_verify() -> None:
+    adapter, setup = _setup_and_confirm(_UID)
+    adapter.revoke_totp(_UID)
+    otp = _totp_obj(setup.secret).now()
+    result = adapter.verify_totp(_UID, otp)
+    assert result.success is False
+    assert "not enabled" in result.message
+
+
+def test_revoke_totp_removes_backup_codes() -> None:
+    adapter, _ = _setup_and_confirm(_UID)
+    assert adapter.backup_codes_remaining(_UID) == _BACKUP_COUNT
+    adapter.revoke_totp(_UID)
+    assert adapter.backup_codes_remaining(_UID) == 0
+
+
+# ── verify_backup_code ────────────────────────────────────────────────────────
+
+
+def test_backup_code_first_use_succeeds() -> None:
+    adapter, setup = _setup_and_confirm(_UID)
+    code = setup.backup_codes[0]
+    result = adapter.verify_backup_code(_UID, code)
+    assert result.success is True
+    assert "accepted" in result.message
+
+
+def test_backup_code_second_use_fails_one_time_use() -> None:
+    adapter, setup = _setup_and_confirm(_UID)
+    code = setup.backup_codes[0]
+    adapter.verify_backup_code(_UID, code)
+    result = adapter.verify_backup_code(_UID, code)
+    assert result.success is False
+    assert "Invalid" in result.message
+
+
+def test_backup_code_case_insensitive() -> None:
+    adapter, setup = _setup_and_confirm(_UID)
+    code = setup.backup_codes[0]
+    lower = code.lower()
+    result = adapter.verify_backup_code(_UID, lower)
+    assert result.success is True
+
+
+def test_backup_codes_remaining_decrements_on_each_use() -> None:
+    adapter, setup = _setup_and_confirm(_UID)
+    assert adapter.backup_codes_remaining(_UID) == _BACKUP_COUNT
+    adapter.verify_backup_code(_UID, setup.backup_codes[0])
+    assert adapter.backup_codes_remaining(_UID) == _BACKUP_COUNT - 1
+    adapter.verify_backup_code(_UID, setup.backup_codes[1])
+    assert adapter.backup_codes_remaining(_UID) == _BACKUP_COUNT - 2
+
+
+def test_backup_codes_remaining_zero_after_revoke() -> None:
+    adapter, _ = _setup_and_confirm(_UID)
+    adapter.revoke_totp(_UID)
+    assert adapter.backup_codes_remaining(_UID) == 0
+
+
+def test_empty_backup_code_rejected() -> None:
+    adapter, _ = _setup_and_confirm(_UID)
+    result = adapter.verify_backup_code(_UID, "")
+    assert result.success is False
+    assert "Empty" in result.message
+
+
+def test_backup_code_not_setup_returns_failure() -> None:
+    adapter, _ = _make_adapter()
+    result = adapter.verify_backup_code("unknown-user", "AABBCCDD")
+    assert result.success is False
+    assert "not set up" in result.message
+
+
+# ── Multi-tenant isolation ────────────────────────────────────────────────────
+
+
+def test_multi_tenant_isolation() -> None:
+    """User-1 and user-2 share a store but must not interfere with each other."""
+    store = InMemoryTotpStore()
+    a1 = LegacyTotpAdapter(store=store)
+    a2 = LegacyTotpAdapter(store=store)
+
+    s1 = a1.setup_totp(_UID)
+    s2 = a2.setup_totp(_UID2)
+
+    otp1 = _totp_obj(s1.secret).now()
+    otp2 = _totp_obj(s2.secret).now()
+
+    assert a1.confirm_totp(_UID, otp1) is True
+    assert a2.confirm_totp(_UID2, otp2) is True
+
+    assert a1.is_enabled(_UID) is True
+    assert a2.is_enabled(_UID2) is True
+
+    a1.revoke_totp(_UID)
+    assert a1.is_enabled(_UID) is False
+    assert a2.is_enabled(_UID2) is True  # unaffected
+
+
+# ── Protocol contract ─────────────────────────────────────────────────────────
+
+
+def test_adapter_satisfies_two_factor_port_protocol() -> None:
+    """All TwoFactorPort methods present on LegacyTotpAdapter with matching param names."""
+    protocol_methods = {
+        name
+        for name in vars(TwoFactorPort)
+        if not name.startswith("_") and callable(getattr(TwoFactorPort, name, None))
+    }
+    assert protocol_methods, "Protocol must expose at least one method"
+
+    adapter = LegacyTotpAdapter()
+    for method_name in protocol_methods:
+        assert hasattr(adapter, method_name), f"Missing method: {method_name}"
+        proto_sig = inspect.signature(getattr(TwoFactorPort, method_name))
+        impl_sig = inspect.signature(getattr(type(adapter), method_name))
+        proto_params = [p for p in proto_sig.parameters if p != "self"]
+        impl_params = [p for p in impl_sig.parameters if p != "self"]
+        assert proto_params == impl_params, (
+            f"{method_name}: protocol {proto_params} != impl {impl_params}"
+        )
+
+
+def test_default_store_is_in_memory() -> None:
+    """LegacyTotpAdapter with no store arg uses InMemoryTotpStore."""
+    adapter = LegacyTotpAdapter()
+    setup = adapter.setup_totp("default-store-user")
+    assert isinstance(setup, TOTPSetup)
+    assert adapter.backup_codes_remaining("default-store-user") == _BACKUP_COUNT
+
+
+def test_totp_adapter_error_has_code_and_message() -> None:
+    err = TotpAdapterError(code="TOTP_NOT_FOUND", message="No secret for customer")
+    assert err.code == "TOTP_NOT_FOUND"
+    assert err.message == "No secret for customer"
+    assert "No secret for customer" in str(err)


### PR DESCRIPTION
## Summary

- **REWRITE-3**: Semantic Python rewrite of `GrpcTFAConnector` (`banxe-common/lib/.../2fa-connector.service.ts`)
- `LegacyTotpAdapter` implements `TwoFactorPort` structurally (no inheritance) via `pyotp` RFC-6238
- gRPC transport dropped — TOTP computed locally, zero network deps
- `TotpStorePort` injected; `InMemoryTotpStore` default (Redis/DB in production)
- HMAC-SHA256 backup codes (8 × 8-char uppercase hex, one-time-use, case-insensitive)
- Rate-limit: 5 attempts / 30 s window (monotonic clock)

## Upstream mapping (14 gRPC → 7 port methods)

| gRPC | TwoFactorPort |
|------|---------------|
| `generateTOTP` + `enable2FA(OTP)` | `setup_totp()` |
| `confirmEnabling2FA` | `confirm_totp()` |
| `getEnabled2FA` | `is_enabled()` |
| `verify2FAToken(OTP)` | `verify_totp()` ±1 clock-skew |
| `getRecoveryCode` + `confirmOneTimeCode` | `verify_backup_code()` |
| `disable2FA` + `confirmDisabling2FA` | `revoke_totp()` |
| *(internal)* | `backup_codes_remaining()` |

Out of scope (separate concerns): `send2FAToken`, `generateOneTimeCode`, `checkResendOneTimeCode` → `OtpDeliveryPort` (REWRITE-1); `verifyCaptchaToken` → captcha concern.

## Quality gates

- `ruff check` + `ruff format` — ✅ clean
- `bandit -ll` — ✅ 0 issues
- `pytest tests/test_legacy_totp_adapter.py` — ✅ 29/29 passed
- `coverage` on `legacy_totp_adapter.py` — ✅ **100%**
- Wave A guard check (frozen files) — ✅ **0 lines changed**
- Pre-commit hooks (Semgrep, mypy, pytest-fast) — ✅ all passed

## Test plan

- [x] `setup_totp` — fields, backup count, hex format, pending state, re-setup
- [x] `confirm_totp` — valid OTP activates, wrong code rejected, state unchanged on fail
- [x] `verify_totp` — happy path, ±1 clock-skew windows, wrong code + remaining count, not-enabled, rate-limit block, rate-limit reset on success, empty OTP
- [x] `revoke_totp` — disables verify, clears backup codes
- [x] `verify_backup_code` — first use, one-time-use, case-insensitive, decrement count, empty code, unknown user
- [x] Multi-tenant isolation (shared store, two users)
- [x] Protocol contract (`TwoFactorPort` param parity)
- [x] Default store is `InMemoryTotpStore`
- [x] `TotpAdapterError` attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)