### PR TITLE
feat(wave-b): LegacyScaAdapter — SCA challenge lifecycle behind ScaServicePort (REWRITE-2)

### DIFF
--- a/services/auth/legacy/legacy_sca_adapter.py
+++ b/services/auth/legacy/legacy_sca_adapter.py
@@ -1,0 +1,276 @@
+"""
+legacy_sca_adapter.py — LegacyScaAdapter implements ScaServicePort (in-memory, REWRITE-2).
+
+Semantic rewrite of AuthService SCA challenge lifecycle (banxe-common/auth.service.ts).
+ECDH P-256 channel dropped — not portable to EMI Python stack; only OTP and TOTP mapped.
+gRPC / Apollo transport dropped per ADR-025 §15-16.
+
+Upstream TS method → ScaServicePort mapping:
+  generateCode() + save()          → create_challenge(method="OTP")
+  checkCode()                      → verify(method="OTP")
+  ECDH challenge()                 → ScaApplicationError(code="method_not_supported")
+  JWT issuance (signToken)         → ScaTokenIssuerPort.issue()
+
+OUT OF SCOPE (separate concerns, not mapped):
+  createApolloClient / gRPC calls  → infrastructure
+  addCredentials after verify      → AuthApplicationService concern
+  TOTP setup / confirm             → TwoFactorPort (ADR-015, Wave B Step 1)
+
+Canon: ADR-015 + ADR-025 §15-16 + AUTH_IMPORT_ORDER + ScaServicePort
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import logging
+import secrets
+
+from services.auth.otp_delivery_port import OtpDeliveryPort
+from services.auth.sca_application_service import ScaApplicationError
+from services.auth.sca_models import SCAChallenge, SCAVerifyResult
+from services.auth.sca_token_issuer_port import ScaTokenIssuerPort
+from services.auth.two_factor_port import TwoFactorPort
+
+logger = logging.getLogger(__name__)
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+_CHALLENGE_TTL_SECONDS: int = 300  # 5 min, PSD2 RTS Art.10
+_MAX_ATTEMPTS: int = 5
+_MAX_RESENDS: int = 3
+_OTP_CHANNEL: str = "sms"
+_SUPPORTED_METHODS: frozenset[str] = frozenset({"OTP", "TOTP"})
+
+# ── Internal record ───────────────────────────────────────────────────────────
+
+
+class _ChallengeRecord:
+    """Mutable store entry for a live SCA challenge."""
+
+    __slots__ = (
+        "challenge",
+        "otp_target",
+        "otp_code",
+        "locked",
+    )
+
+    def __init__(
+        self,
+        challenge: SCAChallenge,
+        otp_target: str | None,
+        otp_code: str | None,
+    ) -> None:
+        self.challenge = challenge
+        self.otp_target = otp_target
+        self.otp_code = otp_code
+        self.locked = False
+
+
+# ── Fake token issuer (default when none injected) ────────────────────────────
+
+
+class _InMemoryTokenIssuer:
+    def issue(self, challenge: SCAChallenge) -> str:
+        return secrets.token_urlsafe(32)
+
+
+# ── LegacyScaAdapter ─────────────────────────────────────────────────────────
+
+
+class LegacyScaAdapter:
+    """
+    ScaServicePort implementation — semantic rewrite of SCA lifecycle (REWRITE-2).
+
+    DI ports:
+        otp_port     — OtpDeliveryPort (default: LegacyOtpAdapter)
+        totp_adapter — TwoFactorPort   (default: LegacyTotpAdapter)
+        token_issuer — ScaTokenIssuerPort (default: _InMemoryTokenIssuer)
+
+    In-memory dict keyed by challenge_id. Not durable or concurrency-safe;
+    acceptable for dev/test. Redis adapter (Wave C) handles durability.
+    """
+
+    def __init__(
+        self,
+        otp_port: OtpDeliveryPort,
+        totp_adapter: TwoFactorPort,
+        token_issuer: ScaTokenIssuerPort | None = None,
+    ) -> None:
+        self._otp = otp_port
+        self._totp = totp_adapter
+        self._issuer: ScaTokenIssuerPort = token_issuer or _InMemoryTokenIssuer()
+        self._store: dict[str, _ChallengeRecord] = {}
+
+    # ── ScaServicePort ────────────────────────────────────────────────────────
+
+    def create_challenge(
+        self,
+        customer_id: str,
+        transaction_id: str,
+        method: str,
+        amount: str | None = None,
+        payee: str | None = None,
+    ) -> SCAChallenge:
+        method_upper = method.upper()
+        if method_upper not in _SUPPORTED_METHODS:
+            raise ScaApplicationError(
+                f"SCA method '{method}' not supported by LegacyScaAdapter",
+                code="method_not_supported",
+            )
+
+        challenge_id = secrets.token_urlsafe(16)
+        now = datetime.now(UTC)
+        challenge = SCAChallenge(
+            challenge_id=challenge_id,
+            customer_id=customer_id,
+            transaction_id=transaction_id,
+            method=method_upper,
+            status="pending",
+            created_at=now,
+            expires_at=now + timedelta(seconds=_CHALLENGE_TTL_SECONDS),
+            amount=amount,
+            payee=payee,
+        )
+
+        otp_target: str | None = None
+        otp_code: str | None = None
+
+        if method_upper == "OTP":
+            otp_code = self._otp.generate_otp()
+            otp_target = (
+                customer_id  # target = customer_id; production adapter resolves phone/email
+            )
+            self._otp.send_otp(
+                channel=_OTP_CHANNEL,
+                target=otp_target,
+                code=otp_code,
+                ttl_seconds=_CHALLENGE_TTL_SECONDS,
+            )
+
+        self._store[challenge_id] = _ChallengeRecord(
+            challenge=challenge,
+            otp_target=otp_target,
+            otp_code=otp_code,
+        )
+        logger.info(
+            "SCA challenge created — id=%s customer=%s method=%s tx=%s",
+            challenge_id,
+            customer_id,
+            method_upper,
+            transaction_id,
+        )
+        return challenge
+
+    def verify(
+        self,
+        challenge_id: str,
+        otp_code: str | None = None,
+        biometric_proof: str | None = None,
+    ) -> SCAVerifyResult:
+        record = self._store.get(challenge_id)
+        if record is None:
+            return SCAVerifyResult(verified=False, transaction_id="", error="challenge_not_found")
+
+        ch = record.challenge
+
+        if ch.status == "verified":
+            return SCAVerifyResult(
+                verified=False, transaction_id=ch.transaction_id, error="already_verified"
+            )
+
+        if datetime.now(UTC) > ch.expires_at:
+            ch.status = "expired"
+            return SCAVerifyResult(
+                verified=False, transaction_id=ch.transaction_id, error="challenge_expired"
+            )
+
+        if record.locked:
+            return SCAVerifyResult(
+                verified=False,
+                transaction_id=ch.transaction_id,
+                error="locked",
+                attempts_remaining=0,
+            )
+
+        ch.attempt_count += 1
+
+        if ch.method == "OTP":
+            result = self._otp.verify_otp(
+                channel=_OTP_CHANNEL,
+                target=record.otp_target or ch.customer_id,
+                code=otp_code or "",
+            )
+            success = result.success
+        elif ch.method == "TOTP":
+            totp_result = self._totp.verify_totp(ch.customer_id, otp_code or "")
+            success = totp_result.success
+        else:  # pragma: no cover
+            raise ScaApplicationError(
+                f"Unsupported method in store: {ch.method}",
+                code="method_not_supported",
+            )
+
+        if success:
+            ch.status = "verified"
+            sca_token = self._issuer.issue(ch)
+            logger.info("SCA verified — id=%s tx=%s", challenge_id, ch.transaction_id)
+            return SCAVerifyResult(
+                verified=True,
+                transaction_id=ch.transaction_id,
+                sca_token=sca_token,
+            )
+
+        remaining = max(0, _MAX_ATTEMPTS - ch.attempt_count)
+        if remaining == 0:
+            record.locked = True
+            ch.status = "locked"
+            logger.warning("SCA locked — id=%s customer=%s", challenge_id, ch.customer_id)
+
+        return SCAVerifyResult(
+            verified=False,
+            transaction_id=ch.transaction_id,
+            error="invalid_code",
+            attempts_remaining=remaining,
+        )
+
+    def resend_challenge(self, challenge_id: str) -> SCAChallenge:
+        record = self._store.get(challenge_id)
+        if record is None:
+            raise ScaApplicationError("Challenge not found", code="challenge_not_found")
+
+        ch = record.challenge
+
+        if ch.status != "pending":
+            raise ScaApplicationError(
+                f"Cannot resend: challenge status is '{ch.status}'",
+                code="resend_rejected",
+            )
+
+        if ch.resend_count >= _MAX_RESENDS:
+            raise ScaApplicationError(
+                "Resend limit reached",
+                code="resend_limit_reached",
+            )
+
+        if ch.method != "OTP":
+            raise ScaApplicationError(
+                f"Resend not applicable for method '{ch.method}'",
+                code="resend_not_applicable",
+            )
+
+        ch.resend_count += 1
+        new_code = self._otp.generate_otp()
+        record.otp_code = new_code
+        target = record.otp_target or ch.customer_id
+        self._otp.send_otp(
+            channel=_OTP_CHANNEL,
+            target=target,
+            code=new_code,
+            ttl_seconds=_CHALLENGE_TTL_SECONDS,
+        )
+        logger.info("SCA OTP resent — id=%s resend_count=%d", challenge_id, ch.resend_count)
+        return ch
+
+    def list_methods(self, customer_id: str) -> list[str]:  # noqa: ARG002
+        """Return supported SCA methods (OTP always available; TOTP if enabled)."""
+        return sorted(_SUPPORTED_METHODS)

--- a/tests/_fakes/otp_fake.py
+++ b/tests/_fakes/otp_fake.py
@@ -1,0 +1,100 @@
+"""In-memory OtpDeliveryPort fake — satisfies the full Protocol contract.
+
+Used by LegacyScaAdapter tests so that SCA challenge tests remain deterministic
+and free of secrets.choice entropy.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from services.auth.otp_delivery_port import (
+    OtpDeliveryPort,
+    OtpDeliveryReceipt,
+    OtpVerifyResult,
+    ResendCheck,
+)
+
+
+class FakeOtpAdapter:
+    """Programmable in-memory adapter implementing OtpDeliveryPort.
+
+    Constructor knobs:
+        verify_success  — controls whether verify_otp returns success
+        generated_code  — fixed code returned by generate_otp (default "123456")
+    """
+
+    def __init__(
+        self,
+        *,
+        verify_success: bool = True,
+        generated_code: str = "123456",
+        can_resend_result: bool = True,
+    ) -> None:
+        self._verify_success = verify_success
+        self._generated_code = generated_code
+        self._can_resend_result = can_resend_result
+        self.send_calls: list[dict[str, object]] = []
+        self.verify_calls: list[dict[str, object]] = []
+        self.can_resend_calls: list[dict[str, object]] = []
+        self._last_delivery_id: str = "fake-delivery-id"
+
+    # ── OtpDeliveryPort ───────────────────────────────────────────────────────
+
+    def generate_otp(self, *, length: int = 6, alphabet: str = "digits") -> str:
+        return (
+            self._generated_code[:length]
+            if len(self._generated_code) >= length
+            else self._generated_code
+        )
+
+    def send_otp(
+        self,
+        *,
+        channel: str,
+        target: str,
+        code: str,
+        ttl_seconds: int,
+    ) -> OtpDeliveryReceipt:
+        self.send_calls.append(
+            {"channel": channel, "target": target, "code": code, "ttl_seconds": ttl_seconds}
+        )
+        now = datetime.now(UTC)
+        return OtpDeliveryReceipt(
+            delivery_id=self._last_delivery_id,
+            channel=channel,
+            target=target,
+            sent_at=now,
+            expires_at=now + timedelta(seconds=ttl_seconds),
+        )
+
+    def verify_otp(
+        self,
+        *,
+        channel: str,
+        target: str,
+        code: str,
+    ) -> OtpVerifyResult:
+        self.verify_calls.append({"channel": channel, "target": target, "code": code})
+        if self._verify_success:
+            return OtpVerifyResult(
+                success=True, message="OTP verified", delivery_id=self._last_delivery_id
+            )
+        return OtpVerifyResult(success=False, message="Invalid code")
+
+    def can_resend(
+        self,
+        *,
+        channel: str,
+        target: str,
+        min_interval_seconds: int,
+    ) -> ResendCheck:
+        self.can_resend_calls.append(
+            {"channel": channel, "target": target, "min_interval_seconds": min_interval_seconds}
+        )
+        return ResendCheck(can_resend=self._can_resend_result, seconds_remaining=0)
+
+
+assert issubclass(FakeOtpAdapter, OtpDeliveryPort.__class__) or isinstance(
+    FakeOtpAdapter(), OtpDeliveryPort
+)

--- a/tests/test_legacy_sca_adapter.py
+++ b/tests/test_legacy_sca_adapter.py
@@ -1,0 +1,310 @@
+"""
+tests/test_legacy_sca_adapter.py — Unit tests for LegacyScaAdapter.
+
+Coverage: 100%  |  Tests: 28  |  No external deps (all in-memory).
+Verifies semantic parity with SCA challenge lifecycle (banxe-common/auth.service.ts).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+
+from services.auth.legacy.legacy_sca_adapter import (
+    _CHALLENGE_TTL_SECONDS,
+    _MAX_ATTEMPTS,
+    _MAX_RESENDS,
+    LegacyScaAdapter,
+)
+from services.auth.sca_application_service import ScaApplicationError
+from services.auth.sca_models import SCAChallenge
+from services.auth.sca_service_port import ScaServicePort
+from tests._fakes.otp_fake import FakeOtpAdapter
+from tests._fakes.two_factor_fake import FakeTwoFactor
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+_CUST = "cust-001"
+_TX = "tx-abc-123"
+
+
+def _adapter(
+    *,
+    otp_verify_success: bool = True,
+    totp_verify_success: bool = True,
+    generated_code: str = "654321",
+) -> LegacyScaAdapter:
+    otp = FakeOtpAdapter(verify_success=otp_verify_success, generated_code=generated_code)
+    totp = FakeTwoFactor(verify_success=totp_verify_success)
+    return LegacyScaAdapter(otp_port=otp, totp_adapter=totp)
+
+
+def _otp_challenge(adapter: LegacyScaAdapter, cust: str = _CUST, tx: str = _TX) -> SCAChallenge:
+    return adapter.create_challenge(cust, tx, method="OTP")
+
+
+def _totp_challenge(adapter: LegacyScaAdapter, cust: str = _CUST, tx: str = _TX) -> SCAChallenge:
+    return adapter.create_challenge(cust, tx, method="TOTP")
+
+
+# ── Protocol conformance ──────────────────────────────────────────────────────
+
+
+def test_legacy_sca_adapter_satisfies_port() -> None:
+    adapter = _adapter()
+    # ScaServicePort is not @runtime_checkable; verify structural conformance instead
+    assert hasattr(adapter, "create_challenge")
+    assert hasattr(adapter, "verify")
+    assert hasattr(adapter, "resend_challenge")
+    # Confirm it type-checks: assignment to the port type is the structural guarantee
+    _port: ScaServicePort = adapter  # type: ignore[assignment]
+    assert _port is adapter
+
+
+# ── create_challenge — OTP ────────────────────────────────────────────────────
+
+
+def test_create_challenge_otp_returns_pending_challenge() -> None:
+    adapter = _adapter()
+    ch = _otp_challenge(adapter)
+    assert ch.challenge_id
+    assert ch.customer_id == _CUST
+    assert ch.transaction_id == _TX
+    assert ch.method == "OTP"
+    assert ch.status == "pending"
+
+
+def test_create_challenge_otp_sends_otp() -> None:
+    otp = FakeOtpAdapter()
+    adapter = LegacyScaAdapter(otp_port=otp, totp_adapter=FakeTwoFactor())
+    _otp_challenge(adapter)
+    assert len(otp.send_calls) == 1
+
+
+def test_create_challenge_otp_stores_expires_at() -> None:
+    adapter = _adapter()
+    ch = _otp_challenge(adapter)
+    delta = (ch.expires_at - ch.created_at).total_seconds()
+    assert abs(delta - _CHALLENGE_TTL_SECONDS) < 2
+
+
+def test_create_challenge_otp_with_amount_and_payee() -> None:
+    adapter = _adapter()
+    ch = adapter.create_challenge(_CUST, _TX, method="OTP", amount="50.00", payee="IBAN123")
+    assert ch.amount == "50.00"
+    assert ch.payee == "IBAN123"
+
+
+# ── create_challenge — TOTP ───────────────────────────────────────────────────
+
+
+def test_create_challenge_totp_returns_pending_challenge() -> None:
+    adapter = _adapter()
+    ch = _totp_challenge(adapter)
+    assert ch.method == "TOTP"
+    assert ch.status == "pending"
+
+
+def test_create_challenge_totp_does_not_send_otp() -> None:
+    otp = FakeOtpAdapter()
+    adapter = LegacyScaAdapter(otp_port=otp, totp_adapter=FakeTwoFactor())
+    _totp_challenge(adapter)
+    assert len(otp.send_calls) == 0
+
+
+# ── create_challenge — unsupported methods ────────────────────────────────────
+
+
+def test_create_challenge_ecdh_raises_method_not_supported() -> None:
+    adapter = _adapter()
+    with pytest.raises(ScaApplicationError) as exc_info:
+        adapter.create_challenge(_CUST, _TX, method="ECDH")
+    assert exc_info.value.code == "method_not_supported"
+
+
+def test_create_challenge_bio_raises_method_not_supported() -> None:
+    adapter = _adapter()
+    with pytest.raises(ScaApplicationError) as exc_info:
+        adapter.create_challenge(_CUST, _TX, method="BIO")
+    assert exc_info.value.code == "method_not_supported"
+
+
+def test_create_challenge_unknown_method_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(ScaApplicationError) as exc_info:
+        adapter.create_challenge(_CUST, _TX, method="FINGERPRINT")
+    assert exc_info.value.code == "method_not_supported"
+
+
+# ── verify — OTP happy path ───────────────────────────────────────────────────
+
+
+def test_verify_otp_happy_path() -> None:
+    adapter = _adapter(otp_verify_success=True)
+    ch = _otp_challenge(adapter)
+    result = adapter.verify(ch.challenge_id, otp_code="654321")
+    assert result.verified
+    assert result.transaction_id == _TX
+    assert result.sca_token
+
+
+def test_verify_otp_delegates_to_otp_port() -> None:
+    otp = FakeOtpAdapter(verify_success=True)
+    adapter = LegacyScaAdapter(otp_port=otp, totp_adapter=FakeTwoFactor())
+    ch = _otp_challenge(adapter)
+    adapter.verify(ch.challenge_id, otp_code="654321")
+    assert len(otp.verify_calls) == 1
+
+
+# ── verify — TOTP happy path ──────────────────────────────────────────────────
+
+
+def test_verify_totp_happy_path() -> None:
+    adapter = _adapter(totp_verify_success=True)
+    ch = _totp_challenge(adapter)
+    result = adapter.verify(ch.challenge_id, otp_code="123456")
+    assert result.verified
+    assert result.sca_token
+
+
+def test_verify_totp_delegates_to_totp_adapter() -> None:
+    totp = FakeTwoFactor(verify_success=True)
+    adapter = LegacyScaAdapter(otp_port=FakeOtpAdapter(), totp_adapter=totp)
+    ch = _totp_challenge(adapter)
+    adapter.verify(ch.challenge_id, otp_code="999999")
+    assert len(totp.verify_calls) == 1
+    assert totp.verify_calls[0] == (_CUST, "999999")
+
+
+# ── verify — failure paths ────────────────────────────────────────────────────
+
+
+def test_verify_wrong_code_fails() -> None:
+    adapter = _adapter(otp_verify_success=False)
+    ch = _otp_challenge(adapter)
+    result = adapter.verify(ch.challenge_id, otp_code="000000")
+    assert not result.verified
+    assert result.error == "invalid_code"
+
+
+def test_verify_not_found_returns_error() -> None:
+    adapter = _adapter()
+    result = adapter.verify("nonexistent-id", otp_code="123456")
+    assert not result.verified
+    assert result.error == "challenge_not_found"
+
+
+def test_verify_expired_challenge_fails() -> None:
+    adapter = _adapter()
+    ch = _otp_challenge(adapter)
+    record = adapter._store[ch.challenge_id]
+    record.challenge = dataclasses.replace(
+        record.challenge,
+        expires_at=datetime(2000, 1, 1, tzinfo=UTC),
+    )
+    result = adapter.verify(ch.challenge_id, otp_code="654321")
+    assert not result.verified
+    assert result.error == "challenge_expired"
+
+
+def test_verify_already_verified_fails() -> None:
+    adapter = _adapter(otp_verify_success=True)
+    ch = _otp_challenge(adapter)
+    adapter.verify(ch.challenge_id, otp_code="654321")
+    result = adapter.verify(ch.challenge_id, otp_code="654321")
+    assert not result.verified
+    assert result.error == "already_verified"
+
+
+def test_verify_lockout_after_max_attempts() -> None:
+    adapter = _adapter(otp_verify_success=False)
+    ch = _otp_challenge(adapter)
+    for _ in range(_MAX_ATTEMPTS):
+        adapter.verify(ch.challenge_id, otp_code="wrong")
+    result = adapter.verify(ch.challenge_id, otp_code="wrong")
+    assert not result.verified
+    assert result.error == "locked"
+    assert result.attempts_remaining == 0
+
+
+def test_verify_attempts_remaining_decrements() -> None:
+    adapter = _adapter(otp_verify_success=False)
+    ch = _otp_challenge(adapter)
+    result = adapter.verify(ch.challenge_id, otp_code="wrong")
+    assert result.attempts_remaining == _MAX_ATTEMPTS - 1
+
+
+# ── resend_challenge ──────────────────────────────────────────────────────────
+
+
+def test_resend_otp_challenge_succeeds() -> None:
+    otp = FakeOtpAdapter()
+    adapter = LegacyScaAdapter(otp_port=otp, totp_adapter=FakeTwoFactor())
+    ch = _otp_challenge(adapter)
+    adapter.resend_challenge(ch.challenge_id)
+    assert len(otp.send_calls) == 2  # initial + resend
+
+
+def test_resend_increments_resend_count() -> None:
+    adapter = _adapter()
+    ch = _otp_challenge(adapter)
+    updated = adapter.resend_challenge(ch.challenge_id)
+    assert updated.resend_count == 1
+
+
+def test_resend_not_found_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(ScaApplicationError) as exc_info:
+        adapter.resend_challenge("bad-id")
+    assert exc_info.value.code == "challenge_not_found"
+
+
+def test_resend_limit_raises_after_max_resends() -> None:
+    adapter = _adapter()
+    ch = _otp_challenge(adapter)
+    for _ in range(_MAX_RESENDS):
+        adapter.resend_challenge(ch.challenge_id)
+    with pytest.raises(ScaApplicationError) as exc_info:
+        adapter.resend_challenge(ch.challenge_id)
+    assert exc_info.value.code == "resend_limit_reached"
+
+
+def test_resend_totp_raises_not_applicable() -> None:
+    adapter = _adapter()
+    ch = _totp_challenge(adapter)
+    with pytest.raises(ScaApplicationError) as exc_info:
+        adapter.resend_challenge(ch.challenge_id)
+    assert exc_info.value.code == "resend_not_applicable"
+
+
+def test_resend_verified_challenge_raises() -> None:
+    adapter = _adapter(otp_verify_success=True)
+    ch = _otp_challenge(adapter)
+    adapter.verify(ch.challenge_id, otp_code="654321")
+    with pytest.raises(ScaApplicationError) as exc_info:
+        adapter.resend_challenge(ch.challenge_id)
+    assert exc_info.value.code == "resend_rejected"
+
+
+# ── list_methods ──────────────────────────────────────────────────────────────
+
+
+def test_list_methods_returns_otp_and_totp() -> None:
+    adapter = _adapter()
+    methods = adapter.list_methods(_CUST)
+    assert set(methods) == {"OTP", "TOTP"}
+
+
+# ── Multi-customer isolation ──────────────────────────────────────────────────
+
+
+def test_challenges_are_isolated_per_customer() -> None:
+    adapter = _adapter(otp_verify_success=True)
+    ch1 = adapter.create_challenge("cust-A", "tx-1", method="OTP")
+    ch2 = adapter.create_challenge("cust-B", "tx-2", method="OTP")
+    # Verifying ch2 must not affect ch1
+    adapter.verify(ch2.challenge_id, otp_code="654321")
+    result = adapter.verify(ch1.challenge_id, otp_code="654321")
+    assert result.verified


### PR DESCRIPTION
## Summary

- **LegacyScaAdapter** — `ScaServicePort` implementation (REWRITE-2, in-memory):
  - `method="OTP"` → delegates generate + send + verify to `OtpDeliveryPort` (LegacyOtpAdapter)
  - `method="TOTP"` → delegates verify to `TwoFactorPort` (LegacyTotpAdapter)
  - `method="ECDH"` / `"BIO"` / unknown → `ScaApplicationError(code="method_not_supported")`
  - 5 min TTL, max 5 attempts, lockout after 5 fails, resend limit 3 (OTP only)
  - `ScaTokenIssuerPort` DI; `_InMemoryTokenIssuer` default for dev/test
- **FakeOtpAdapter** (`tests/_fakes/otp_fake.py`) — programmable `OtpDeliveryPort` stub for DI in SCA tests
- **28 tests** — 100% coverage on `legacy_sca_adapter`
- **ECDH P-256 dropped** — `BaseConnectorGrpcService` / Apollo GraphQL not portable to EMI Python stack

## Semantic mapping (from `auth.service.ts`)

| TS method | LegacyScaAdapter |
|-----------|-----------------|
| `generateCode() + save()` | `create_challenge(method="OTP")` → `OtpDeliveryPort.send_otp()` |
| `checkCode()` | `verify(method="OTP")` → `OtpDeliveryPort.verify_otp()` |
| ECDH `challenge()` | `ScaApplicationError(code="method_not_supported")` |
| `signToken()` | `ScaTokenIssuerPort.issue()` |

## What is NOT touched

- Wave A files: `jwt_strategy`, `role_guard`, `jwks_models` — 0 lines diff ✅
- Wave B Step-1 files: `legacy_totp_adapter`, `two_factor_port` — 0 lines diff ✅
- Wave B Step-2 files: `otp_delivery_port`, `legacy_otp_adapter` — 0 lines diff ✅
- Auth application services, API router — 0 lines diff ✅
- ADR-001 through ADR-029 — 0 lines diff ✅

## Canon

- ADR-015 (Auth Ports Formalization)
- ADR-025 §15-16 (REWRITE-1/2 adapter constraints)
- ScaServicePort + OtpDeliveryPort + TwoFactorPort + ScaTokenIssuerPort
- AUTH_IMPORT_ORDER (enforced)

## Test plan

- [x] `ruff check` — 0 issues
- [x] `ruff format` — all files formatted
- [x] `bandit -r -ll` — 0 issues on new modules
- [x] `pytest tests/test_legacy_sca_adapter.py` — 28/28 passed
- [x] Coverage `services.auth.legacy.legacy_sca_adapter` — **100%**
- [x] Pre-commit hook (all gates) — PASS
- [x] Frozen files guard — 0 lines diff on Wave A + Wave B Step-1/2 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced legacy Strong Customer Authentication (SCA) adapter supporting OTP and TOTP verification methods
  * Added challenge creation, verification, and resend functionality with lockout protection after repeated failed attempts
  * Implemented method discovery for supported authentication methods

* **Tests**
  * Added comprehensive unit test coverage for SCA adapter functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->