### PR TITLE
feat(wave-c): LegacyAbsPaymentAdapter — ABS submit_payment behind PaymentRailPort (REWRITE-2)

### DIFF
--- a/services/payment/legacy/legacy_abs_payment_adapter.py
+++ b/services/payment/legacy/legacy_abs_payment_adapter.py
@@ -1,0 +1,317 @@
+"""
+legacy_abs_payment_adapter.py — LegacyAbsPaymentAdapter implements PaymentRailPort (REWRITE-2).
+
+Semantic rewrite of abs-customer-payment.service.ts (banxe-fiat-backend/abs-api).
+Transport dropped per ADR-025 §15-16:
+  - GCP Bifrost XML gateway (requestToGCPProcessing)
+  - Sequential DB counters (TypeORM)
+  - NestJS EventEmitter
+
+Upstream TS method → Python mapping:
+  createOrUpdateCustomerPayment(dto) → submit_payment(intent)
+  approveCustomerPayment(id, vop)   → advance_to(payment_id, AbsPaymentStatus.SUBMITTED)
+  Bank ref / doc number generation  → _generate_ref() helper
+
+Canon: ADR-025 §15-16 + services.payment.payment_port + SESSION-2026-05-07-WAVE-C
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import Enum
+import secrets
+from typing import Literal
+
+from pydantic import BaseModel
+
+from services.payment.payment_port import (
+    PaymentDirection,
+    PaymentIntent,
+    PaymentRail,
+    PaymentResult,
+    PaymentStatus,
+)
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+_ABS_SUPPORTED_RAILS = frozenset({PaymentRail.SEPA_CT, PaymentRail.SEPA_INSTANT})
+_ABS_REFERENCE_MAX_LEN = 140
+
+_AbsEventType = Literal["CREATED", "SUBMITTED", "SETTLED", "REJECTED", "CANCELLED"]
+
+# ── ABS payment state machine ──────────────────────────────────────────────────
+
+
+class AbsPaymentStatus(str, Enum):
+    PENDING = "PENDING"
+    SUBMITTED = "SUBMITTED"
+    SETTLED = "SETTLED"
+    REJECTED = "REJECTED"
+    CANCELLED = "CANCELLED"
+
+
+_VALID_TRANSITIONS: dict[AbsPaymentStatus, frozenset[AbsPaymentStatus]] = {
+    AbsPaymentStatus.PENDING: frozenset({AbsPaymentStatus.SUBMITTED, AbsPaymentStatus.CANCELLED}),
+    AbsPaymentStatus.SUBMITTED: frozenset({AbsPaymentStatus.SETTLED, AbsPaymentStatus.REJECTED}),
+    AbsPaymentStatus.SETTLED: frozenset(),
+    AbsPaymentStatus.REJECTED: frozenset(),
+    AbsPaymentStatus.CANCELLED: frozenset(),
+}
+
+_TO_PAYMENT_STATUS: dict[AbsPaymentStatus, PaymentStatus] = {
+    AbsPaymentStatus.PENDING: PaymentStatus.PENDING,
+    AbsPaymentStatus.SUBMITTED: PaymentStatus.PROCESSING,
+    AbsPaymentStatus.SETTLED: PaymentStatus.COMPLETED,
+    AbsPaymentStatus.REJECTED: PaymentStatus.FAILED,
+    AbsPaymentStatus.CANCELLED: PaymentStatus.CANCELLED,
+}
+
+
+# ── Domain models ─────────────────────────────────────────────────────────────
+
+
+class AbsPaymentRecord(BaseModel, frozen=True):
+    """Internal domain record — shadows ABS customer payment entity (TypeORM DROP)."""
+
+    payment_id: str
+    idempotency_key: str
+    customer_id: str
+    debtor_account_name: str
+    creditor_account_name: str
+    creditor_iban: str | None
+    amount: Decimal
+    currency: str
+    reference: str
+    bank_ref: str
+    rail: PaymentRail
+    direction: PaymentDirection
+    status: AbsPaymentStatus
+    submitted_at: datetime
+    settled_at: datetime | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class AbsAuditRecord(BaseModel, frozen=True):
+    """
+    Append-only audit event — I-24 compliance.
+
+    Maps the TypeORM event emission DROP; persisted to ClickHouse in Wave D.
+    NEVER folded into PaymentResult.
+    """
+
+    payment_id: str
+    event_type: _AbsEventType
+    amount: Decimal
+    currency: str
+    status_from: AbsPaymentStatus | None
+    status_to: AbsPaymentStatus
+    occurred_at: datetime
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+# ── Error ─────────────────────────────────────────────────────────────────────
+
+
+class AbsApplicationError(Exception):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _generate_ref(customer_id: str) -> str:
+    """Generate unique bank ref — replaces TypeORM sequential counter (ADR-025 §15-16)."""
+    prefix = (customer_id[:4]).upper() if customer_id else "ABS"
+    ts = datetime.now(UTC).strftime("%Y%m%d")
+    token = secrets.token_hex(6)
+    return f"ABS-{prefix}-{ts}-{token}"
+
+
+def _abs_event_for(status: AbsPaymentStatus) -> _AbsEventType:
+    """Map AbsPaymentStatus to audit event type."""
+    if status == AbsPaymentStatus.SUBMITTED:
+        return "SUBMITTED"
+    if status == AbsPaymentStatus.SETTLED:
+        return "SETTLED"
+    if status == AbsPaymentStatus.REJECTED:
+        return "REJECTED"
+    if status == AbsPaymentStatus.CANCELLED:
+        return "CANCELLED"
+    return "CREATED"
+
+
+# ── Adapter ───────────────────────────────────────────────────────────────────
+
+
+class LegacyAbsPaymentAdapter:
+    """
+    PaymentRailPort implementation — ABS domain payment submit + state machine (REWRITE-2).
+
+    In-memory store keyed by payment_id (lookup) and idempotency_key (dedup).
+    Not durable or concurrency-safe; acceptable for dev/test.
+    Production: replace with GCP Bifrost XML adapter + ClickHouse audit sink (Wave D).
+    """
+
+    def __init__(self) -> None:
+        self._by_payment_id: dict[str, AbsPaymentRecord] = {}
+        self._by_idempotency: dict[str, AbsPaymentRecord] = {}
+        self._audit_log: list[AbsAuditRecord] = []
+
+    # ── PaymentRailPort ───────────────────────────────────────────────────────
+
+    def submit_payment(self, intent: PaymentIntent) -> PaymentResult:
+        """
+        createOrUpdateCustomerPayment() semantic — store PENDING, idempotent.
+        Validates rail support + reference length before storing.
+        """
+        if intent.rail not in _ABS_SUPPORTED_RAILS:
+            raise AbsApplicationError(
+                f"Unsupported rail for ABS adapter: {intent.rail}",
+                code="unsupported_rail",
+            )
+        if len(intent.reference) > _ABS_REFERENCE_MAX_LEN:
+            raise AbsApplicationError(
+                f"Reference exceeds {_ABS_REFERENCE_MAX_LEN} chars",
+                code="reference_too_long",
+            )
+        if intent.idempotency_key in self._by_idempotency:
+            return self._to_result(self._by_idempotency[intent.idempotency_key])
+
+        customer_id = str(
+            intent.metadata.get("customer_id", intent.debtor_account.account_holder_name)
+        )
+        payment_id = f"abs-{secrets.token_hex(8)}"
+        bank_ref = _generate_ref(customer_id)
+        record = AbsPaymentRecord(
+            payment_id=payment_id,
+            idempotency_key=intent.idempotency_key,
+            customer_id=customer_id,
+            debtor_account_name=intent.debtor_account.account_holder_name,
+            creditor_account_name=intent.creditor_account.account_holder_name,
+            creditor_iban=intent.creditor_account.iban,
+            amount=intent.amount,
+            currency=intent.currency,
+            reference=intent.reference,
+            bank_ref=bank_ref,
+            rail=intent.rail,
+            direction=intent.direction,
+            status=AbsPaymentStatus.PENDING,
+            submitted_at=datetime.now(UTC),
+        )
+        self._store(record)
+        self._emit_audit(record, event_type="CREATED", status_from=None)
+        return self._to_result(record)
+
+    def get_payment_status(self, provider_payment_id: str) -> PaymentResult:
+        """Fetch current status. Raises AbsApplicationError(code='payment_not_found') on miss."""
+        record = self._by_payment_id.get(provider_payment_id)
+        if record is None:
+            raise AbsApplicationError(
+                f"ABS payment not found: {provider_payment_id!r}",
+                code="payment_not_found",
+            )
+        return self._to_result(record)
+
+    def health_check(self) -> bool:
+        return True
+
+    # ── Extra (beyond port) ───────────────────────────────────────────────────
+
+    def advance_to(
+        self,
+        payment_id: str,
+        new_status: AbsPaymentStatus,
+        *,
+        settled_at: datetime | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> AbsPaymentRecord:
+        """approveCustomerPayment() semantic — drive state machine forward."""
+        existing = self._by_payment_id.get(payment_id)
+        if existing is None:
+            raise AbsApplicationError(
+                f"ABS payment not found: {payment_id!r}",
+                code="payment_not_found",
+            )
+        if new_status not in _VALID_TRANSITIONS[existing.status]:
+            raise AbsApplicationError(
+                f"Invalid state transition: {existing.status} → {new_status}",
+                code="invalid_state_transition",
+            )
+        updated = existing.model_copy(
+            update={
+                "status": new_status,
+                "settled_at": settled_at,
+                "error_code": error_code,
+                "error_message": error_message,
+            }
+        )
+        self._store(updated)
+        self._emit_audit(
+            updated, event_type=_abs_event_for(new_status), status_from=existing.status
+        )
+        return updated
+
+    def list_payments(
+        self,
+        *,
+        customer_id: str | None = None,
+        status: AbsPaymentStatus | None = None,
+    ) -> list[AbsPaymentRecord]:
+        """List payments with optional filters (multi-tenant isolation by customer_id)."""
+        records = list(self._by_payment_id.values())
+        if customer_id is not None:
+            records = [r for r in records if r.customer_id == customer_id]
+        if status is not None:
+            records = [r for r in records if r.status == status]
+        return records
+
+    def collect_audit_records(self) -> list[AbsAuditRecord]:
+        """Return accumulated audit trail — I-24 append-only."""
+        return list(self._audit_log)
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _store(self, record: AbsPaymentRecord) -> None:
+        self._by_payment_id[record.payment_id] = record
+        self._by_idempotency[record.idempotency_key] = record
+
+    def _emit_audit(
+        self,
+        record: AbsPaymentRecord,
+        *,
+        event_type: _AbsEventType,
+        status_from: AbsPaymentStatus | None,
+    ) -> None:
+        self._audit_log.append(
+            AbsAuditRecord(
+                payment_id=record.payment_id,
+                event_type=event_type,
+                amount=record.amount,
+                currency=record.currency,
+                status_from=status_from,
+                status_to=record.status,
+                occurred_at=datetime.now(UTC),
+            )
+        )
+
+    def _to_result(self, record: AbsPaymentRecord) -> PaymentResult:
+        return PaymentResult(
+            idempotency_key=record.idempotency_key,
+            provider_payment_id=record.payment_id,
+            status=_TO_PAYMENT_STATUS[record.status],
+            rail=record.rail,
+            amount=record.amount,
+            currency=record.currency,
+            submitted_at=record.submitted_at,
+            error_code=record.error_code,
+            error_message=record.error_message,
+            estimated_settlement=record.settled_at,
+        )

--- a/tests/test_legacy_abs_payment_adapter.py
+++ b/tests/test_legacy_abs_payment_adapter.py
@@ -1,0 +1,491 @@
+"""
+tests/test_legacy_abs_payment_adapter.py — Unit tests for LegacyAbsPaymentAdapter.
+
+Coverage: 100%  |  Tests: 39  |  No external deps (all in-memory).
+Verifies semantic parity with abs-customer-payment.service.ts (banxe-fiat-backend/abs-api).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from services.payment.legacy.legacy_abs_payment_adapter import (
+    AbsApplicationError,
+    AbsAuditRecord,
+    AbsPaymentStatus,
+    LegacyAbsPaymentAdapter,
+    _abs_event_for,
+    _generate_ref,
+)
+from services.payment.payment_port import (
+    BankAccount,
+    PaymentDirection,
+    PaymentIntent,
+    PaymentRail,
+    PaymentResult,
+    PaymentStatus,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+_DEBTOR = BankAccount(account_holder_name="Banxe EMI", iban="DE89370400440532013000")
+_CREDITOR = BankAccount(account_holder_name="Creditor Ltd", iban="GB82WEST12345698765432")
+
+
+def _adapter() -> LegacyAbsPaymentAdapter:
+    return LegacyAbsPaymentAdapter()
+
+
+def _make_intent(
+    *,
+    idempotency_key: str = "abs-key-001",
+    rail: PaymentRail = PaymentRail.SEPA_CT,
+    amount: Decimal = Decimal("500.00"),
+    reference: str = "INV-001",
+    customer_id: str = "cust-001",
+    debtor: BankAccount = _DEBTOR,
+    creditor: BankAccount = _CREDITOR,
+) -> PaymentIntent:
+    return PaymentIntent(
+        idempotency_key=idempotency_key,
+        rail=rail,
+        direction=PaymentDirection.OUTBOUND,
+        amount=amount,
+        currency="EUR",
+        debtor_account=debtor,
+        creditor_account=creditor,
+        reference=reference,
+        end_to_end_id="e2e-abs-001",
+        requested_at=datetime.now(UTC),
+        metadata={"customer_id": customer_id},
+    )
+
+
+# ── Module-level imports ──────────────────────────────────────────────────────
+
+
+def test_module_imports_cleanly() -> None:
+    from services.payment.legacy import legacy_abs_payment_adapter  # noqa: F401
+
+    assert legacy_abs_payment_adapter is not None
+
+
+def test_no_transport_imports() -> None:
+    import importlib
+    import sys
+
+    mod = sys.modules.get("services.payment.legacy.legacy_abs_payment_adapter")
+    if mod is None:
+        mod = importlib.import_module("services.payment.legacy.legacy_abs_payment_adapter")
+    for banned in ("gcp", "bifrost", "grpc", "sqlalchemy", "nestjs", "eventemitter", "redis"):
+        assert banned not in dir(mod), f"Transport leak: {banned!r} found in adapter module"
+
+
+# ── Adapter surface ───────────────────────────────────────────────────────────
+
+
+def test_adapter_surface_exists() -> None:
+    adapter = _adapter()
+    assert hasattr(adapter, "submit_payment")
+    assert hasattr(adapter, "get_payment_status")
+    assert hasattr(adapter, "health_check")
+    assert hasattr(adapter, "advance_to")
+    assert hasattr(adapter, "list_payments")
+    assert hasattr(adapter, "collect_audit_records")
+
+
+def test_protocol_conformance() -> None:
+    adapter = _adapter()
+    from services.payment.payment_port import PaymentRailPort
+
+    _port: PaymentRailPort = adapter  # type: ignore[assignment]
+    assert _port is adapter
+
+
+def test_health_check_returns_true() -> None:
+    assert _adapter().health_check() is True
+
+
+# ── submit_payment — happy paths ──────────────────────────────────────────────
+
+
+def test_submit_payment_creates_pending_record() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    assert isinstance(result, PaymentResult)
+    assert result.status == PaymentStatus.PENDING
+    assert result.provider_payment_id.startswith("abs-")
+    assert result.rail == PaymentRail.SEPA_CT
+    assert result.amount == Decimal("500.00")
+    assert result.currency == "EUR"
+
+
+def test_submit_payment_sepa_instant_happy_path() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent(rail=PaymentRail.SEPA_INSTANT))
+    assert result.status == PaymentStatus.PENDING
+    assert result.rail == PaymentRail.SEPA_INSTANT
+
+
+def test_submit_payment_customer_id_from_metadata() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent(customer_id="cust-XYZ"))
+    record = adapter._by_payment_id[result.provider_payment_id]
+    assert record.customer_id == "cust-XYZ"
+
+
+def test_submit_payment_customer_id_fallback_to_debtor_name() -> None:
+    adapter = _adapter()
+    intent = PaymentIntent(
+        idempotency_key="no-meta-key",
+        rail=PaymentRail.SEPA_CT,
+        direction=PaymentDirection.OUTBOUND,
+        amount=Decimal("100.00"),
+        currency="EUR",
+        debtor_account=BankAccount(
+            account_holder_name="FallbackName", iban="DE89370400440532013000"
+        ),
+        creditor_account=_CREDITOR,
+        reference="ref",
+        end_to_end_id="e2e",
+        requested_at=datetime.now(UTC),
+        metadata={},
+    )
+    result = adapter.submit_payment(intent)
+    record = adapter._by_payment_id[result.provider_payment_id]
+    assert record.customer_id == "FallbackName"
+
+
+def test_submit_payment_generates_bank_ref() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    record = adapter._by_payment_id[result.provider_payment_id]
+    assert record.bank_ref.startswith("ABS-")
+    assert len(record.bank_ref) > 8
+
+
+# ── submit_payment — idempotency ──────────────────────────────────────────────
+
+
+def test_submit_payment_idempotency_same_key() -> None:
+    adapter = _adapter()
+    intent = _make_intent()
+    r1 = adapter.submit_payment(intent)
+    r2 = adapter.submit_payment(intent)
+    assert r1.provider_payment_id == r2.provider_payment_id
+
+
+def test_submit_payment_different_keys_create_different_records() -> None:
+    adapter = _adapter()
+    r1 = adapter.submit_payment(_make_intent(idempotency_key="k-A"))
+    r2 = adapter.submit_payment(_make_intent(idempotency_key="k-B"))
+    assert r1.provider_payment_id != r2.provider_payment_id
+
+
+# ── submit_payment — validation failures ──────────────────────────────────────
+
+
+def test_submit_unsupported_rail_raises() -> None:
+    adapter = _adapter()
+    fps_intent = PaymentIntent(
+        idempotency_key="fps-key",
+        rail=PaymentRail.FPS,
+        direction=PaymentDirection.OUTBOUND,
+        amount=Decimal("50.00"),
+        currency="GBP",
+        debtor_account=BankAccount(
+            account_holder_name="Name", sort_code="200000", account_number="12345678"
+        ),
+        creditor_account=BankAccount(
+            account_holder_name="Name", sort_code="200000", account_number="12345679"
+        ),
+        reference="ref",
+        end_to_end_id="e2e",
+        requested_at=datetime.now(UTC),
+    )
+    with pytest.raises(AbsApplicationError) as exc_info:
+        adapter.submit_payment(fps_intent)
+    assert exc_info.value.code == "unsupported_rail"
+
+
+def test_submit_reference_too_long_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(AbsApplicationError) as exc_info:
+        adapter.submit_payment(_make_intent(reference="X" * 141))
+    assert exc_info.value.code == "reference_too_long"
+
+
+def test_submit_reference_exactly_140_chars_ok() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent(reference="X" * 140))
+    assert result.status == PaymentStatus.PENDING
+
+
+def test_submit_negative_amount_raises_at_intent_level() -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        _make_intent(amount=Decimal("-1.00"))
+
+
+def test_submit_zero_amount_raises_at_intent_level() -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        _make_intent(amount=Decimal("0"))
+
+
+# ── get_payment_status ────────────────────────────────────────────────────────
+
+
+def test_get_payment_status_known_returns_result() -> None:
+    adapter = _adapter()
+    submitted = adapter.submit_payment(_make_intent())
+    status_result = adapter.get_payment_status(submitted.provider_payment_id)
+    assert status_result.provider_payment_id == submitted.provider_payment_id
+    assert status_result.status == PaymentStatus.PENDING
+
+
+def test_get_payment_status_unknown_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(AbsApplicationError) as exc_info:
+        adapter.get_payment_status("nonexistent-abs-id")
+    assert exc_info.value.code == "payment_not_found"
+
+
+# ── advance_to — state machine ────────────────────────────────────────────────
+
+
+def test_advance_to_pending_submitted() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    updated = adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    assert updated.status == AbsPaymentStatus.SUBMITTED
+    assert adapter.get_payment_status(result.provider_payment_id).status == PaymentStatus.PROCESSING
+
+
+def test_advance_to_submitted_settled() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    now = datetime.now(UTC)
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SETTLED, settled_at=now)
+    status = adapter.get_payment_status(result.provider_payment_id)
+    assert status.status == PaymentStatus.COMPLETED
+    assert status.estimated_settlement == now
+
+
+def test_advance_to_submitted_rejected_with_error_code() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    adapter.advance_to(
+        result.provider_payment_id,
+        AbsPaymentStatus.REJECTED,
+        error_code="INSUFFICIENT_FUNDS",
+        error_message="Balance too low",
+    )
+    status = adapter.get_payment_status(result.provider_payment_id)
+    assert status.status == PaymentStatus.FAILED
+    assert status.error_code == "INSUFFICIENT_FUNDS"
+
+
+def test_advance_to_pending_cancelled() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.CANCELLED)
+    assert adapter.get_payment_status(result.provider_payment_id).status == PaymentStatus.CANCELLED
+
+
+def test_invalid_transition_settled_to_submitted_raises() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SETTLED)
+    with pytest.raises(AbsApplicationError) as exc_info:
+        adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    assert exc_info.value.code == "invalid_state_transition"
+
+
+def test_invalid_transition_cancelled_to_submitted_raises() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.CANCELLED)
+    with pytest.raises(AbsApplicationError) as exc_info:
+        adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    assert exc_info.value.code == "invalid_state_transition"
+
+
+def test_invalid_transition_rejected_to_pending_raises() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.REJECTED)
+    with pytest.raises(AbsApplicationError) as exc_info:
+        adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.PENDING)
+    assert exc_info.value.code == "invalid_state_transition"
+
+
+def test_advance_to_unknown_payment_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(AbsApplicationError) as exc_info:
+        adapter.advance_to("ghost-abs-id", AbsPaymentStatus.SUBMITTED)
+    assert exc_info.value.code == "payment_not_found"
+
+
+# ── list_payments ─────────────────────────────────────────────────────────────
+
+
+def test_list_payments_no_filter_returns_all() -> None:
+    adapter = _adapter()
+    adapter.submit_payment(_make_intent(idempotency_key="k1", customer_id="cust-A"))
+    adapter.submit_payment(_make_intent(idempotency_key="k2", customer_id="cust-B"))
+    assert len(adapter.list_payments()) == 2
+
+
+def test_list_payments_filter_by_customer_id() -> None:
+    adapter = _adapter()
+    r1 = adapter.submit_payment(_make_intent(idempotency_key="k1", customer_id="cust-A"))
+    adapter.submit_payment(_make_intent(idempotency_key="k2", customer_id="cust-B"))
+    results = adapter.list_payments(customer_id="cust-A")
+    assert len(results) == 1
+    assert results[0].payment_id == r1.provider_payment_id
+
+
+def test_list_payments_filter_by_status() -> None:
+    adapter = _adapter()
+    r1 = adapter.submit_payment(_make_intent(idempotency_key="k1"))
+    adapter.submit_payment(_make_intent(idempotency_key="k2"))
+    adapter.advance_to(r1.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    pending = adapter.list_payments(status=AbsPaymentStatus.PENDING)
+    submitted = adapter.list_payments(status=AbsPaymentStatus.SUBMITTED)
+    assert len(pending) == 1
+    assert len(submitted) == 1
+
+
+def test_list_payments_multi_tenant_isolation() -> None:
+    adapter = _adapter()
+    adapter.submit_payment(_make_intent(idempotency_key="k1", customer_id="cust-A"))
+    adapter.submit_payment(_make_intent(idempotency_key="k2", customer_id="cust-B"))
+    assert len(adapter.list_payments(customer_id="cust-A")) == 1
+    assert len(adapter.list_payments(customer_id="cust-B")) == 1
+    assert len(adapter.list_payments(customer_id="cust-C")) == 0
+
+
+# ── Audit trail (I-24) ────────────────────────────────────────────────────────
+
+
+def test_audit_log_empty_initially() -> None:
+    adapter = _adapter()
+    assert adapter.collect_audit_records() == []
+
+
+def test_submit_emits_created_audit_event() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    records = adapter.collect_audit_records()
+    assert len(records) == 1
+    assert records[0].event_type == "CREATED"
+    assert records[0].payment_id == result.provider_payment_id
+    assert records[0].status_from is None
+    assert records[0].status_to == AbsPaymentStatus.PENDING
+
+
+def test_advance_to_submitted_emits_submitted_event() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    records = adapter.collect_audit_records()
+    assert len(records) == 2
+    assert records[1].event_type == "SUBMITTED"
+    assert records[1].status_from == AbsPaymentStatus.PENDING
+    assert records[1].status_to == AbsPaymentStatus.SUBMITTED
+
+
+def test_advance_to_settled_emits_settled_event() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SETTLED)
+    records = adapter.collect_audit_records()
+    assert records[-1].event_type == "SETTLED"
+
+
+def test_advance_to_rejected_emits_rejected_event() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.SUBMITTED)
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.REJECTED)
+    records = adapter.collect_audit_records()
+    assert records[-1].event_type == "REJECTED"
+
+
+def test_advance_to_cancelled_emits_cancelled_event() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, AbsPaymentStatus.CANCELLED)
+    records = adapter.collect_audit_records()
+    assert records[-1].event_type == "CANCELLED"
+
+
+def test_audit_record_is_separate_from_payment_result() -> None:
+    """resolveBaseBalances() concern must NEVER appear in PaymentResult (port boundary)."""
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    audit_records = adapter.collect_audit_records()
+    result_fields = set(vars(result).keys())
+    assert "event_type" not in result_fields
+    assert "status_from" not in result_fields
+    assert isinstance(audit_records[0], AbsAuditRecord)
+    assert not isinstance(audit_records[0], PaymentResult)
+
+
+def test_collect_audit_records_returns_copy() -> None:
+    adapter = _adapter()
+    adapter.submit_payment(_make_intent())
+    records_a = adapter.collect_audit_records()
+    records_b = adapter.collect_audit_records()
+    assert records_a is not records_b
+    assert records_a == records_b
+
+
+# ── _generate_ref helper ──────────────────────────────────────────────────────
+
+
+def test_generate_ref_format() -> None:
+    ref = _generate_ref("cust-001")
+    assert ref.startswith("ABS-CUST")
+    parts = ref.split("-")
+    assert len(parts) >= 4
+
+
+def test_generate_ref_empty_customer_id() -> None:
+    ref = _generate_ref("")
+    assert ref.startswith("ABS-ABS-")
+
+
+def test_generate_ref_unique() -> None:
+    refs = {_generate_ref("cust-001") for _ in range(20)}
+    assert len(refs) == 20
+
+
+# ── _abs_event_for helper ─────────────────────────────────────────────────────
+
+
+def test_abs_event_for_pending_is_created() -> None:
+    assert _abs_event_for(AbsPaymentStatus.PENDING) == "CREATED"
+
+
+def test_abs_event_for_submitted_is_submitted() -> None:
+    assert _abs_event_for(AbsPaymentStatus.SUBMITTED) == "SUBMITTED"
+
+
+def test_abs_event_for_settled_is_settled() -> None:
+    assert _abs_event_for(AbsPaymentStatus.SETTLED) == "SETTLED"
+
+
+def test_abs_event_for_rejected_is_rejected() -> None:
+    assert _abs_event_for(AbsPaymentStatus.REJECTED) == "REJECTED"
+
+
+def test_abs_event_for_cancelled_is_cancelled() -> None:
+    assert _abs_event_for(AbsPaymentStatus.CANCELLED) == "CANCELLED"


### PR DESCRIPTION
## Summary
## Summary

- Semantic rewrite of `banxe-fiat-backend/abs-api/src/abs/services/abs-customer-payment.service.ts` → `LegacyAbsPaymentAdapter` implementing `PaymentRailPort` (REWRITE-2 per Wave C entry-point inventory)
- Transport dropped per ADR-025 §15-16: GCP Bifrost XML gateway (`requestToGCPProcessing`), TypeORM sequential counters, NestJS EventEmitter
- `approveCustomerPayment()` mapped to `advance_to()` state machine — PENDING → SUBMITTED → SETTLED / REJECTED / CANCELLED
- Bank ref generation: `_generate_ref()` helper (replaces TypeORM sequential counter per ADR-025 §15-16)

## Port mapping (TS → Python)

| TS method | Python |
|-----------|--------|
| `createOrUpdateCustomerPayment(dto)` | `submit_payment(intent)` — PENDING store, idempotent |
| `approveCustomerPayment(id, vop)` | `advance_to(payment_id, AbsPaymentStatus.SUBMITTED)` |
| Bank ref / doc number generation | `_generate_ref()` — `secrets.token_hex(6)` prefix |

## State machine

`PENDING → SUBMITTED → SETTLED / REJECTED`  
`PENDING → CANCELLED`

Invalid transitions raise `AbsApplicationError(code="invalid_state_transition")`.

## Status mapping (AbsPaymentStatus → PaymentStatus)

| AbsPaymentStatus | PaymentStatus |
|---|---|
| PENDING | PENDING |
| SUBMITTED | PROCESSING |
| SETTLED | COMPLETED |
| REJECTED | FAILED |
| CANCELLED | CANCELLED |

## Audit boundary (I-24)

`AbsAuditRecord` (frozen Pydantic model) captures:
- `event_type`: CREATED / SUBMITTED / SETTLED / REJECTED / CANCELLED
- `status_from` / `status_to` transition pair
- `amount`, `currency`, `occurred_at`

Never folded into `PaymentResult`. In production: sink to ClickHouse append-only table (Wave D).

## Files changed

- `services/payment/legacy/legacy_abs_payment_adapter.py` — new adapter (118 stmts)
- `tests/test_legacy_abs_payment_adapter.py` — 47 tests, 100% coverage

## Frozen files untouched

- `api/routers/auth.py`
- `services/auth/`
- `services/payment/payment_port.py`
- `services/payment/legacy/__init__.py`

(`git diff origin/main -- <frozen-files> | wc -l → 0`)

## Test plan

- [x] `ruff check` — 0 issues
- [x] `ruff format` — clean
- [x] Bandit `-ll` — 0/0/0 issues
- [x] Semgrep banxe-rules — Passed (0 findings on 2 files)
- [x] 47 tests, **100% statement coverage** (`services/payment/legacy/legacy_abs_payment_adapter.py 118 0 100%`)
- [x] Frozen guard: 0 lines diff on protected files
- [x] Pre-commit: all 8 hooks Passed

## Canon

ADR-015 + ADR-025 §15-16 + ADR-029  
`services/payment/payment_port.py` (PaymentRailPort Protocol)  
`docs/sessions/SESSION-2026-05-07-WAVE-C-PAYMENTS-START.md` (REWRITE-2 mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)