### PR TITLE
feat(wave-c): LegacySepaAdapter REWRITE-3 — SepaAuditRecord + composite idempotency + creditor_name + 2dp precision

### DIFF
--- a/services/payment/legacy/legacy_sepa_adapter.py
+++ b/services/payment/legacy/legacy_sepa_adapter.py
@@ -7,16 +7,20 @@ Transport dropped per ADR-025 §15-16:
   - DWH payment gRPC microservice (getByNostroAccount)
   - Redis cron / NestJS EventEmitter (syncTransactions, needsApprovalHandler)
   - TypeORM (TransactionEntity / FiatPaymentEntity)
+  - SCA factor / VOP approval (approveTransaction SMS/TOTP auth)
 
 Upstream TS method → PaymentRailPort mapping:
-  initTransaction()            → submit_payment(intent)  [stored as PENDING]
-  approveTransaction()         → advance_to(SUBMITTED)   [folded into submit confirm]
-  fetchTransactionStatus()     → get_payment_status()
-  syncTransactions() @Cron     → DROP (pull-on-demand in-memory)
-  needsApprovalHandler() @Cron → DROP (approval folded into submit phase)
+  approveTransaction(dto)        → advance_to(SUBMITTED)   [SCA dropped]
+  needsApprovalHandler() @Cron   → DROP (pull-on-demand)
+  syncTransactions() @Cron       → DROP (in-memory)
 
 State machine: PENDING → SUBMITTED → SETTLED / REJECTED / CANCELLED
+  PENDING → CANCELLED also allowed.
   Illegal transitions raise SepaApplicationError(code="invalid_state_transition").
+
+Idempotency: keyed by (customer_id, reference) composite — not intent idempotency_key.
+  Rationale: SEPA rulebook uniqueness is on (creditor+debtor+reference+amount);
+  using (customer_id, reference) as practical surrogate.
 
 Canon: ADR-025 §15-16 + services.payment.payment_port + SESSION-2026-05-07-WAVE-C
 """
@@ -39,11 +43,14 @@ from services.payment.payment_port import (
     PaymentStatus,
 )
 
-# ── Config ────────────────────────────────────────────────────────────────────
+# ── Constants ─────────────────────────────────────────────────────────────────
 
 _SEPA_RAILS: frozenset[PaymentRail] = frozenset({PaymentRail.SEPA_CT, PaymentRail.SEPA_INSTANT})
 _SCT_INST_MAX_EUR: Decimal = Decimal("100000.00")
-_SEPA_REFERENCE_MAX_LEN: int = 140  # ISO 20022 / SEPA rulebook
+_SEPA_REFERENCE_MAX_LEN: int = 140
+_CREDITOR_NAME_MAX_LEN: int = 70
+
+_SepaEventType = Literal["CREATED", "SUBMITTED", "SETTLED", "REJECTED", "CANCELLED"]
 
 
 # ── Validation helpers ────────────────────────────────────────────────────────
@@ -60,12 +67,12 @@ def _validate_iban(iban: str) -> bool:
 
 
 def _validate_bic(bic: str) -> bool:
-    """Return True if BIC matches SWIFT standard (8 or 11 alphanum chars)."""
+    """Return True if BIC matches SWIFT/RFC-9362 (8 or 11 chars)."""
     clean = bic.strip().upper()
     return bool(re.fullmatch(r"[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?", clean))
 
 
-# ── Internal state ────────────────────────────────────────────────────────────
+# ── State machine ─────────────────────────────────────────────────────────────
 
 
 class SepaPaymentStatus(str, Enum):
@@ -101,8 +108,11 @@ _TO_PAYMENT_STATUS: dict[SepaPaymentStatus, PaymentStatus] = {
 }
 
 
-class SepaPayment(BaseModel, frozen=True):
-    """Internal domain record for an in-flight SEPA payment."""
+# ── Domain models ─────────────────────────────────────────────────────────────
+
+
+class SepaPaymentRecord(BaseModel, frozen=True):
+    """Internal domain record — shadows SEPA TransactionEntity (TypeORM DROP)."""
 
     payment_id: str
     idempotency_key: str
@@ -110,12 +120,34 @@ class SepaPayment(BaseModel, frozen=True):
     debtor_iban: str
     creditor_iban: str
     creditor_bic: str | None
+    creditor_name: str
     amount: Decimal
     currency: str
     reference: str
     scheme: Literal["SCT", "SCT_INST"]
     status: SepaPaymentStatus
-    created_at: datetime
+    submitted_at: datetime
+    settled_at: datetime | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class SepaAuditRecord(BaseModel, frozen=True):
+    """
+    Append-only audit event — I-24 compliance.
+
+    Separate from PaymentResult; persisted to ClickHouse in Wave D.
+    """
+
+    payment_id: str
+    event_type: _SepaEventType
+    amount: Decimal
+    currency: str
+    status_from: SepaPaymentStatus | None
+    status_to: SepaPaymentStatus
+    occurred_at: datetime
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -129,6 +161,21 @@ class SepaApplicationError(Exception):
         self.code = code
 
 
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _sepa_event_for(status: SepaPaymentStatus) -> _SepaEventType:
+    if status == SepaPaymentStatus.SUBMITTED:
+        return "SUBMITTED"
+    if status == SepaPaymentStatus.SETTLED:
+        return "SETTLED"
+    if status == SepaPaymentStatus.REJECTED:
+        return "REJECTED"
+    if status == SepaPaymentStatus.CANCELLED:
+        return "CANCELLED"
+    return "CREATED"
+
+
 # ── Adapter ───────────────────────────────────────────────────────────────────
 
 
@@ -136,26 +183,33 @@ class LegacySepaAdapter:
     """
     PaymentRailPort implementation — SEPA CT + SCT_INST (REWRITE-3).
 
-    In-memory store keyed by idempotency_key (dedup) and payment_id (lookup).
-    Not durable or concurrency-safe; acceptable for dev/test.
-    Production: replace with Modulr SEPA adapter (ModulrPaymentAdapter) or ClearBank.
+    Idempotency keyed by (customer_id, reference) composite — SEPA rulebook surrogate.
+    In-memory; not durable or concurrency-safe. Production: Modulr / ClearBank Wave D.
     """
 
     def __init__(self) -> None:
-        self._by_idempotency: dict[str, SepaPayment] = {}
-        self._by_payment_id: dict[str, SepaPayment] = {}
+        self._by_payment_id: dict[str, SepaPaymentRecord] = {}
+        self._by_composite_key: dict[str, SepaPaymentRecord] = {}
+        self._audit_log: list[SepaAuditRecord] = []
 
     # ── PaymentRailPort ───────────────────────────────────────────────────────
 
     def submit_payment(self, intent: PaymentIntent) -> PaymentResult:
+        """
+        initTransaction() semantic — validate, dedup by (customer_id, reference), store PENDING.
+        """
         if intent.rail not in _SEPA_RAILS:
             raise SepaApplicationError(
                 f"LegacySepaAdapter handles only SEPA rails, got {intent.rail}",
                 code="unsupported_rail",
             )
 
-        if intent.idempotency_key in self._by_idempotency:
-            return self._to_result(self._by_idempotency[intent.idempotency_key])
+        customer_id = str(
+            intent.metadata.get("customer_id", intent.debtor_account.account_holder_name)
+        )
+        composite_key = f"{customer_id}::{intent.reference}"
+        if composite_key in self._by_composite_key:
+            return self._to_result(self._by_composite_key[composite_key])
 
         debtor_iban = intent.debtor_account.iban or ""
         creditor_iban = intent.creditor_account.iban or ""
@@ -171,10 +225,30 @@ class LegacySepaAdapter:
         if creditor_bic and not _validate_bic(creditor_bic):
             raise SepaApplicationError(f"Invalid BIC: {creditor_bic!r}", code="invalid_bic")
 
+        creditor_name = intent.creditor_account.account_holder_name
+        if not creditor_name or not creditor_name.strip():
+            raise SepaApplicationError(
+                "Creditor name must not be empty", code="invalid_creditor_name"
+            )
+        if len(creditor_name) > _CREDITOR_NAME_MAX_LEN:
+            raise SepaApplicationError(
+                f"Creditor name exceeds {_CREDITOR_NAME_MAX_LEN} chars",
+                code="creditor_name_too_long",
+            )
+
+        if not intent.reference or not intent.reference.strip():
+            raise SepaApplicationError("Reference must not be empty", code="invalid_reference")
         if len(intent.reference) > _SEPA_REFERENCE_MAX_LEN:
             raise SepaApplicationError(
                 f"Reference exceeds SEPA max {_SEPA_REFERENCE_MAX_LEN} chars",
                 code="reference_too_long",
+            )
+
+        tup = intent.amount.as_tuple()
+        if tup.exponent < -2:
+            raise SepaApplicationError(
+                f"Amount must have at most 2 decimal places, got {intent.amount}",
+                code="invalid_amount_precision",
             )
 
         scheme: Literal["SCT", "SCT_INST"]
@@ -188,40 +262,73 @@ class LegacySepaAdapter:
         else:
             scheme = "SCT"
 
-        customer_id = intent.metadata.get("customer_id", intent.debtor_account.account_holder_name)
         payment_id = f"sepa-{secrets.token_hex(8)}"
-        now = datetime.now(UTC)
-        payment = SepaPayment(
+        record = SepaPaymentRecord(
             payment_id=payment_id,
             idempotency_key=intent.idempotency_key,
-            customer_id=str(customer_id),
+            customer_id=customer_id,
             debtor_iban=debtor_iban,
             creditor_iban=creditor_iban,
             creditor_bic=creditor_bic,
+            creditor_name=creditor_name,
             amount=intent.amount,
             currency=intent.currency,
             reference=intent.reference,
             scheme=scheme,
             status=SepaPaymentStatus.PENDING,
-            created_at=now,
+            submitted_at=datetime.now(UTC),
         )
-        self._by_idempotency[intent.idempotency_key] = payment
-        self._by_payment_id[payment_id] = payment
-        return self._to_result(payment)
+        self._store(record)
+        self._emit_audit(record, event_type="CREATED", status_from=None)
+        return self._to_result(record)
 
     def get_payment_status(self, provider_payment_id: str) -> PaymentResult:
-        payment = self._by_payment_id.get(provider_payment_id)
-        if payment is None:
+        record = self._by_payment_id.get(provider_payment_id)
+        if record is None:
             raise SepaApplicationError(
                 f"Payment not found: {provider_payment_id!r}",
                 code="payment_not_found",
             )
-        return self._to_result(payment)
+        return self._to_result(record)
 
     def health_check(self) -> bool:
         return True
 
-    # ── Extra (beyond port) ────────────────────────────────────────────────────
+    # ── Extra (beyond port) ───────────────────────────────────────────────────
+
+    def advance_to(
+        self,
+        payment_id: str,
+        new_status: SepaPaymentStatus,
+        *,
+        settled_at: datetime | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> SepaPaymentRecord:
+        """approveTransaction() semantic — drive state machine (SCA dropped)."""
+        existing = self._by_payment_id.get(payment_id)
+        if existing is None:
+            raise SepaApplicationError(
+                f"Payment not found: {payment_id!r}", code="payment_not_found"
+            )
+        if new_status not in _VALID_TRANSITIONS[existing.status]:
+            raise SepaApplicationError(
+                f"Illegal transition: {existing.status} → {new_status}",
+                code="invalid_state_transition",
+            )
+        updated = existing.model_copy(
+            update={
+                "status": new_status,
+                "settled_at": settled_at,
+                "error_code": error_code,
+                "error_message": error_message,
+            }
+        )
+        self._store(updated)
+        self._emit_audit(
+            updated, event_type=_sepa_event_for(new_status), status_from=existing.status
+        )
+        return updated
 
     def list_payments(
         self,
@@ -229,7 +336,8 @@ class LegacySepaAdapter:
         customer_id: str | None = None,
         status: SepaPaymentStatus | None = None,
         scheme: Literal["SCT", "SCT_INST"] | None = None,
-    ) -> list[SepaPayment]:
+    ) -> list[SepaPaymentRecord]:
+        """List payments with optional filters (multi-tenant isolation by customer_id)."""
         results = list(self._by_payment_id.values())
         if customer_id is not None:
             results = [p for p in results if p.customer_id == customer_id]
@@ -239,33 +347,47 @@ class LegacySepaAdapter:
             results = [p for p in results if p.scheme == scheme]
         return results
 
-    def advance_to(self, payment_id: str, new_status: SepaPaymentStatus) -> SepaPayment:
-        """Drive state machine — used to simulate bank confirmations in tests."""
-        payment = self._by_payment_id.get(payment_id)
-        if payment is None:
-            raise SepaApplicationError(
-                f"Payment not found: {payment_id!r}", code="payment_not_found"
-            )
-        if new_status not in _VALID_TRANSITIONS[payment.status]:
-            raise SepaApplicationError(
-                f"Illegal transition: {payment.status} → {new_status}",
-                code="invalid_state_transition",
-            )
-        updated = payment.model_copy(update={"status": new_status})
-        self._by_payment_id[payment_id] = updated
-        self._by_idempotency[payment.idempotency_key] = updated
-        return updated
+    def collect_audit_records(self) -> list[SepaAuditRecord]:
+        """Return accumulated audit trail — I-24 append-only."""
+        return list(self._audit_log)
 
-    # ── Internal ───────────────────────────────────────────────────────────────
+    # ── Internal ──────────────────────────────────────────────────────────────
 
-    def _to_result(self, payment: SepaPayment) -> PaymentResult:
-        rail = PaymentRail.SEPA_INSTANT if payment.scheme == "SCT_INST" else PaymentRail.SEPA_CT
+    def _store(self, record: SepaPaymentRecord) -> None:
+        self._by_payment_id[record.payment_id] = record
+        composite = f"{record.customer_id}::{record.reference}"
+        self._by_composite_key[composite] = record
+
+    def _emit_audit(
+        self,
+        record: SepaPaymentRecord,
+        *,
+        event_type: _SepaEventType,
+        status_from: SepaPaymentStatus | None,
+    ) -> None:
+        self._audit_log.append(
+            SepaAuditRecord(
+                payment_id=record.payment_id,
+                event_type=event_type,
+                amount=record.amount,
+                currency=record.currency,
+                status_from=status_from,
+                status_to=record.status,
+                occurred_at=datetime.now(UTC),
+            )
+        )
+
+    def _to_result(self, record: SepaPaymentRecord) -> PaymentResult:
+        rail = PaymentRail.SEPA_INSTANT if record.scheme == "SCT_INST" else PaymentRail.SEPA_CT
         return PaymentResult(
-            idempotency_key=payment.idempotency_key,
-            provider_payment_id=payment.payment_id,
-            status=_TO_PAYMENT_STATUS[payment.status],
+            idempotency_key=record.idempotency_key,
+            provider_payment_id=record.payment_id,
+            status=_TO_PAYMENT_STATUS[record.status],
             rail=rail,
-            amount=payment.amount,
-            currency=payment.currency,
-            submitted_at=payment.created_at,
+            amount=record.amount,
+            currency=record.currency,
+            submitted_at=record.submitted_at,
+            error_code=record.error_code,
+            error_message=record.error_message,
+            estimated_settlement=record.settled_at,
         )

--- a/tests/test_legacy_sepa_adapter.py
+++ b/tests/test_legacy_sepa_adapter.py
@@ -1,7 +1,7 @@
 """
-tests/test_legacy_sepa_adapter.py — Unit tests for LegacySepaAdapter.
+tests/test_legacy_sepa_adapter.py — Unit tests for LegacySepaAdapter (REWRITE-3).
 
-Coverage: 100%  |  Tests: 28  |  No external deps (all in-memory).
+Coverage target: 100% | Tests: ≥30 | No external deps (all in-memory).
 Verifies semantic parity with SEPA outgoing flow (sepa-service/create-outgoing-transactions).
 """
 
@@ -15,7 +15,10 @@ import pytest
 from services.payment.legacy.legacy_sepa_adapter import (
     LegacySepaAdapter,
     SepaApplicationError,
+    SepaAuditRecord,
+    SepaPaymentRecord,
     SepaPaymentStatus,
+    _sepa_event_for,
     _validate_bic,
     _validate_iban,
 )
@@ -30,11 +33,35 @@ from services.payment.payment_port import (
 
 # ── Test IBANs ────────────────────────────────────────────────────────────────
 
-_DEBTOR_IBAN = "DE89370400440532013000"  # Germany — valid (ISO 13616 example)
-_CREDITOR_IBAN = "GB82WEST12345698765432"  # UK — valid (ISO 13616 example)
-_INVALID_IBAN = "DE00370400440532013000"  # Same structure, bad check digits
+_DEBTOR_IBAN = "DE89370400440532013000"  # Germany — valid ISO 13616
+_CREDITOR_IBAN = "GB82WEST12345698765432"  # UK — valid ISO 13616
+
+# Five invalid IBANs (parametrised below)
+_INVALID_IBANS = [
+    "DE00370400440532013000",  # bad check digits (00 never valid)
+    "NOTANIBAN",  # garbage
+    "DE89",  # too short (fails regex)
+    "",  # empty string
+    "FR7630006000011234567890182",  # wrong checksum for this account number
+]
+
+# Valid IBANs across ≥3 countries (parametrised below) — all verified ISO 13616 mod-97
+_VALID_IBANS = [
+    "DE89370400440532013000",  # Germany (ISO 13616 example)
+    "GB82WEST12345698765432",  # United Kingdom (ISO 13616 example)
+    "FR7630006000011234567890189",  # France (verified mod-97 = 1)
+    "NL91ABNA0417164300",  # Netherlands (ISO 13616 example)
+]
+
 _VALID_BIC_8 = "DEUTDEFF"
 _VALID_BIC_11 = "DEUTDEFFXXX"
+
+_INVALID_BICS = [
+    "ABCD",  # too short
+    "1234DEFF",  # digits in bank code
+    "DEUTDE",  # 6 chars
+    "DEUTDEFF1234",  # too long (12 chars)
+]
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -49,6 +76,7 @@ def _make_intent(
     debtor_iban: str = _DEBTOR_IBAN,
     creditor_iban: str = _CREDITOR_IBAN,
     creditor_bic: str | None = _VALID_BIC_8,
+    creditor_name: str = "Acme GmbH",
     customer_id: str = "cust-001",
 ) -> PaymentIntent:
     return PaymentIntent(
@@ -62,7 +90,7 @@ def _make_intent(
             iban=debtor_iban,
         ),
         creditor_account=BankAccount(
-            account_holder_name="Creditor Name",
+            account_holder_name=creditor_name,
             iban=creditor_iban,
             bic=creditor_bic,
         ),
@@ -77,23 +105,50 @@ def _adapter() -> LegacySepaAdapter:
     return LegacySepaAdapter()
 
 
-# ── IBAN / BIC validators ─────────────────────────────────────────────────────
+# ── No transport imports ──────────────────────────────────────────────────────
 
 
-def test_validate_iban_valid_de() -> None:
-    assert _validate_iban(_DEBTOR_IBAN) is True
+def test_no_gcp_bifrost_import() -> None:
+    import sys
+
+    import services.payment.legacy.legacy_sepa_adapter as mod
+
+    assert not hasattr(mod, "requestToGCPProcessing")
+    assert not any("bifrost" in k for k in sys.modules)
 
 
-def test_validate_iban_valid_gb() -> None:
-    assert _validate_iban(_CREDITOR_IBAN) is True
+def test_no_typeorm_import() -> None:
+    import sys
+
+    assert not any("typeorm" in k for k in sys.modules)
+    assert not any("sqlalchemy" in k for k in sys.modules if "sepa" in k)
 
 
-def test_validate_iban_invalid_check_digits() -> None:
-    assert _validate_iban(_INVALID_IBAN) is False
+def test_no_redis_import() -> None:
+    import services.payment.legacy.legacy_sepa_adapter as mod
+
+    assert not hasattr(mod, "redis")
+    assert not hasattr(mod, "RedisService")
+    assert not hasattr(mod, "redisService")
 
 
-def test_validate_iban_garbage_string() -> None:
-    assert _validate_iban("NOT_AN_IBAN") is False
+# ── IBAN validator — parametrised invalids ────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad_iban", _INVALID_IBANS)
+def test_validate_iban_invalid(bad_iban: str) -> None:
+    assert _validate_iban(bad_iban) is False
+
+
+# ── IBAN validator — parametrised valids ─────────────────────────────────────
+
+
+@pytest.mark.parametrize("good_iban", _VALID_IBANS)
+def test_validate_iban_valid(good_iban: str) -> None:
+    assert _validate_iban(good_iban) is True
+
+
+# ── BIC validator ─────────────────────────────────────────────────────────────
 
 
 def test_validate_bic_8_chars() -> None:
@@ -104,12 +159,27 @@ def test_validate_bic_11_chars() -> None:
     assert _validate_bic(_VALID_BIC_11) is True
 
 
-def test_validate_bic_too_short() -> None:
-    assert _validate_bic("ABCD") is False
+@pytest.mark.parametrize("bad_bic", _INVALID_BICS)
+def test_validate_bic_invalid(bad_bic: str) -> None:
+    assert _validate_bic(bad_bic) is False
 
 
-def test_validate_bic_digits_in_bank_code() -> None:
-    assert _validate_bic("1234DEFF") is False
+# ── Protocol conformance ──────────────────────────────────────────────────────
+
+
+def test_protocol_conformance() -> None:
+    adapter = _adapter()
+    assert hasattr(adapter, "submit_payment")
+    assert hasattr(adapter, "get_payment_status")
+    assert hasattr(adapter, "health_check")
+    from services.payment.payment_port import PaymentRailPort
+
+    _port: PaymentRailPort = adapter  # type: ignore[assignment]
+    assert _port is adapter
+
+
+def test_health_check_returns_true() -> None:
+    assert _adapter().health_check() is True
 
 
 # ── submit_payment — happy paths ──────────────────────────────────────────────
@@ -143,38 +213,124 @@ def test_submit_sct_inst_exactly_at_limit_ok() -> None:
     assert result.status == PaymentStatus.PENDING
 
 
-# ── submit_payment — idempotency ──────────────────────────────────────────────
-
-
-def test_submit_idempotency_same_key_returns_same_payment_id() -> None:
+def test_submit_no_bic_is_allowed() -> None:
     adapter = _adapter()
-    intent = _make_intent()
-    r1 = adapter.submit_payment(intent)
-    r2 = adapter.submit_payment(intent)
+    result = adapter.submit_payment(_make_intent(creditor_bic=None))
+    assert result.status == PaymentStatus.PENDING
+
+
+def test_submit_stores_record_as_sepa_payment_record() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    record = adapter._by_payment_id[result.provider_payment_id]
+    assert isinstance(record, SepaPaymentRecord)
+    assert record.creditor_name == "Acme GmbH"
+    assert record.submitted_at is not None
+
+
+# ── submit_payment — idempotency (customer_id, reference) ────────────────────
+
+
+def test_submit_same_customer_same_reference_returns_same_payment_id() -> None:
+    adapter = _adapter()
+    r1 = adapter.submit_payment(_make_intent(reference="ref-A", customer_id="cust-1"))
+    r2 = adapter.submit_payment(
+        _make_intent(idempotency_key="key-different", reference="ref-A", customer_id="cust-1")
+    )
     assert r1.provider_payment_id == r2.provider_payment_id
 
 
-def test_submit_different_key_same_reference_creates_new_payment() -> None:
+def test_submit_same_reference_different_customer_creates_new_payment() -> None:
     adapter = _adapter()
-    r1 = adapter.submit_payment(_make_intent(idempotency_key="key-A"))
-    r2 = adapter.submit_payment(_make_intent(idempotency_key="key-B"))
+    r1 = adapter.submit_payment(_make_intent(reference="ref-A", customer_id="cust-1"))
+    r2 = adapter.submit_payment(
+        _make_intent(idempotency_key="key-2", reference="ref-A", customer_id="cust-2")
+    )
     assert r1.provider_payment_id != r2.provider_payment_id
 
 
-# ── submit_payment — validation failures ──────────────────────────────────────
+def test_submit_same_customer_different_reference_creates_new_payment() -> None:
+    adapter = _adapter()
+    r1 = adapter.submit_payment(_make_intent(reference="ref-A", customer_id="cust-1"))
+    r2 = adapter.submit_payment(
+        _make_intent(idempotency_key="key-2", reference="ref-B", customer_id="cust-1")
+    )
+    assert r1.provider_payment_id != r2.provider_payment_id
+
+
+# ── submit_payment — creditor_name validation ─────────────────────────────────
+
+
+def test_submit_empty_creditor_name_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(SepaApplicationError) as exc_info:
+        adapter.submit_payment(_make_intent(creditor_name=""))
+    assert exc_info.value.code == "invalid_creditor_name"
+
+
+def test_submit_whitespace_only_creditor_name_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(SepaApplicationError) as exc_info:
+        adapter.submit_payment(_make_intent(creditor_name="   "))
+    assert exc_info.value.code == "invalid_creditor_name"
+
+
+def test_submit_creditor_name_71_chars_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(SepaApplicationError) as exc_info:
+        adapter.submit_payment(_make_intent(creditor_name="A" * 71))
+    assert exc_info.value.code == "creditor_name_too_long"
+
+
+def test_submit_creditor_name_exactly_70_chars_ok() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent(creditor_name="A" * 70))
+    assert result.status == PaymentStatus.PENDING
+
+
+def test_submit_whitespace_reference_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(SepaApplicationError) as exc_info:
+        adapter.submit_payment(_make_intent(reference="   "))
+    assert exc_info.value.code == "invalid_reference"
+
+
+# ── submit_payment — amount precision ─────────────────────────────────────────
+
+
+def test_submit_amount_3_decimal_places_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(SepaApplicationError) as exc_info:
+        adapter.submit_payment(_make_intent(amount=Decimal("100.001")))
+    assert exc_info.value.code == "invalid_amount_precision"
+
+
+def test_submit_amount_exactly_2_decimal_places_ok() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent(amount=Decimal("99.99")))
+    assert result.status == PaymentStatus.PENDING
+
+
+def test_submit_amount_integer_ok() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent(amount=Decimal("50")))
+    assert result.status == PaymentStatus.PENDING
+
+
+# ── submit_payment — other validation failures ────────────────────────────────
 
 
 def test_submit_invalid_debtor_iban_raises() -> None:
     adapter = _adapter()
     with pytest.raises(SepaApplicationError) as exc_info:
-        adapter.submit_payment(_make_intent(debtor_iban=_INVALID_IBAN))
+        adapter.submit_payment(_make_intent(debtor_iban=_INVALID_IBANS[0]))
     assert exc_info.value.code == "invalid_iban"
 
 
 def test_submit_invalid_creditor_iban_raises() -> None:
     adapter = _adapter()
     with pytest.raises(SepaApplicationError) as exc_info:
-        adapter.submit_payment(_make_intent(creditor_iban=_INVALID_IBAN))
+        adapter.submit_payment(_make_intent(creditor_iban=_INVALID_IBANS[0]))
     assert exc_info.value.code == "invalid_iban"
 
 
@@ -183,12 +339,6 @@ def test_submit_invalid_bic_raises() -> None:
     with pytest.raises(SepaApplicationError) as exc_info:
         adapter.submit_payment(_make_intent(creditor_bic="1234DEFF"))
     assert exc_info.value.code == "invalid_bic"
-
-
-def test_submit_no_bic_is_allowed() -> None:
-    adapter = _adapter()
-    result = adapter.submit_payment(_make_intent(creditor_bic=None))
-    assert result.status == PaymentStatus.PENDING
 
 
 def test_submit_sct_inst_over_limit_raises() -> None:
@@ -200,37 +350,10 @@ def test_submit_sct_inst_over_limit_raises() -> None:
     assert exc_info.value.code == "amount_exceeds_sct_inst_limit"
 
 
-def test_submit_wrong_currency_raises_at_intent_level() -> None:
-    with pytest.raises(ValueError, match="only supports EUR"):
-        PaymentIntent(
-            idempotency_key="key",
-            rail=PaymentRail.SEPA_CT,
-            direction=PaymentDirection.OUTBOUND,
-            amount=Decimal("100"),
-            currency="GBP",
-            debtor_account=BankAccount(account_holder_name="A", iban=_DEBTOR_IBAN),
-            creditor_account=BankAccount(account_holder_name="B", iban=_CREDITOR_IBAN),
-            reference="ref",
-            end_to_end_id="e2e",
-            requested_at=datetime.now(UTC),
-        )
-
-
-def test_submit_negative_amount_raises_at_intent_level() -> None:
-    with pytest.raises(ValueError, match="must be positive"):
-        _make_intent(amount=Decimal("-1.00"))
-
-
-def test_submit_zero_amount_raises_at_intent_level() -> None:
-    with pytest.raises(ValueError, match="must be positive"):
-        _make_intent(amount=Decimal("0"))
-
-
 def test_submit_reference_too_long_raises() -> None:
     adapter = _adapter()
-    long_ref = "X" * 141
     with pytest.raises(SepaApplicationError) as exc_info:
-        adapter.submit_payment(_make_intent(reference=long_ref))
+        adapter.submit_payment(_make_intent(reference="X" * 141))
     assert exc_info.value.code == "reference_too_long"
 
 
@@ -263,6 +386,32 @@ def test_submit_unsupported_rail_raises() -> None:
     assert exc_info.value.code == "unsupported_rail"
 
 
+def test_submit_wrong_currency_raises_at_intent_level() -> None:
+    with pytest.raises(ValueError, match="only supports EUR"):
+        PaymentIntent(
+            idempotency_key="key",
+            rail=PaymentRail.SEPA_CT,
+            direction=PaymentDirection.OUTBOUND,
+            amount=Decimal("100"),
+            currency="GBP",
+            debtor_account=BankAccount(account_holder_name="A", iban=_DEBTOR_IBAN),
+            creditor_account=BankAccount(account_holder_name="B", iban=_CREDITOR_IBAN),
+            reference="ref",
+            end_to_end_id="e2e",
+            requested_at=datetime.now(UTC),
+        )
+
+
+def test_submit_negative_amount_raises_at_intent_level() -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        _make_intent(amount=Decimal("-1.00"))
+
+
+def test_submit_zero_amount_raises_at_intent_level() -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        _make_intent(amount=Decimal("0"))
+
+
 # ── get_payment_status ────────────────────────────────────────────────────────
 
 
@@ -291,17 +440,44 @@ def test_state_transition_pending_to_submitted() -> None:
     assert adapter.get_payment_status(result.provider_payment_id).status == PaymentStatus.PROCESSING
 
 
-def test_state_transition_submitted_to_settled() -> None:
+def test_state_transition_submitted_to_settled_with_settled_at() -> None:
     adapter = _adapter()
     result = adapter.submit_payment(_make_intent())
     adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.SUBMITTED)
-    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.SETTLED)
+    ts = datetime.now(UTC)
+    updated = adapter.advance_to(
+        result.provider_payment_id, SepaPaymentStatus.SETTLED, settled_at=ts
+    )
+    assert updated.settled_at == ts
     assert adapter.get_payment_status(result.provider_payment_id).status == PaymentStatus.COMPLETED
+
+
+def test_state_transition_submitted_to_rejected_with_error() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.SUBMITTED)
+    updated = adapter.advance_to(
+        result.provider_payment_id,
+        SepaPaymentStatus.REJECTED,
+        error_code="RJCT_AC01",
+        error_message="Incorrect account number",
+    )
+    assert updated.error_code == "RJCT_AC01"
+    assert updated.error_message == "Incorrect account number"
+    assert adapter.get_payment_status(result.provider_payment_id).status == PaymentStatus.FAILED
 
 
 def test_state_transition_pending_to_cancelled() -> None:
     adapter = _adapter()
     result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.CANCELLED)
+    assert adapter.get_payment_status(result.provider_payment_id).status == PaymentStatus.CANCELLED
+
+
+def test_state_transition_submitted_to_cancelled() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.SUBMITTED)
     adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.CANCELLED)
     assert adapter.get_payment_status(result.provider_payment_id).status == PaymentStatus.CANCELLED
 
@@ -325,13 +501,27 @@ def test_illegal_transition_cancelled_to_submitted_raises() -> None:
     assert exc_info.value.code == "invalid_state_transition"
 
 
+def test_advance_to_unknown_payment_raises() -> None:
+    adapter = _adapter()
+    with pytest.raises(SepaApplicationError) as exc_info:
+        adapter.advance_to("nonexistent-id", SepaPaymentStatus.SUBMITTED)
+    assert exc_info.value.code == "payment_not_found"
+
+
 # ── list_payments ─────────────────────────────────────────────────────────────
+
+
+def test_list_payments_no_filter_returns_all() -> None:
+    adapter = _adapter()
+    adapter.submit_payment(_make_intent(reference="ref-1", idempotency_key="k1"))
+    adapter.submit_payment(_make_intent(reference="ref-2", idempotency_key="k2"))
+    assert len(adapter.list_payments()) == 2
 
 
 def test_list_payments_filter_by_status() -> None:
     adapter = _adapter()
-    r1 = adapter.submit_payment(_make_intent(idempotency_key="k1"))
-    adapter.submit_payment(_make_intent(idempotency_key="k2"))
+    r1 = adapter.submit_payment(_make_intent(reference="ref-1", idempotency_key="k1"))
+    adapter.submit_payment(_make_intent(reference="ref-2", idempotency_key="k2"))
     adapter.advance_to(r1.provider_payment_id, SepaPaymentStatus.SUBMITTED)
     pending = adapter.list_payments(status=SepaPaymentStatus.PENDING)
     assert len(pending) == 1
@@ -339,43 +529,111 @@ def test_list_payments_filter_by_status() -> None:
 
 def test_list_payments_filter_by_scheme() -> None:
     adapter = _adapter()
-    adapter.submit_payment(_make_intent(rail=PaymentRail.SEPA_CT, idempotency_key="k1"))
-    adapter.submit_payment(_make_intent(rail=PaymentRail.SEPA_INSTANT, idempotency_key="k2"))
-    sct = adapter.list_payments(scheme="SCT")
-    sct_inst = adapter.list_payments(scheme="SCT_INST")
-    assert len(sct) == 1
-    assert len(sct_inst) == 1
+    adapter.submit_payment(
+        _make_intent(rail=PaymentRail.SEPA_CT, reference="r1", idempotency_key="k1")
+    )
+    adapter.submit_payment(
+        _make_intent(rail=PaymentRail.SEPA_INSTANT, reference="r2", idempotency_key="k2")
+    )
+    assert len(adapter.list_payments(scheme="SCT")) == 1
+    assert len(adapter.list_payments(scheme="SCT_INST")) == 1
 
 
 def test_list_payments_multi_tenant_isolation() -> None:
     adapter = _adapter()
-    adapter.submit_payment(_make_intent(idempotency_key="k1", customer_id="cust-A"))
-    adapter.submit_payment(_make_intent(idempotency_key="k2", customer_id="cust-B"))
+    adapter.submit_payment(_make_intent(reference="r1", idempotency_key="k1", customer_id="cust-A"))
+    adapter.submit_payment(_make_intent(reference="r2", idempotency_key="k2", customer_id="cust-B"))
     assert len(adapter.list_payments(customer_id="cust-A")) == 1
     assert len(adapter.list_payments(customer_id="cust-B")) == 1
     assert len(adapter.list_payments(customer_id="cust-C")) == 0
 
 
-# ── health_check / protocol conformance ──────────────────────────────────────
+# ── Audit trail ───────────────────────────────────────────────────────────────
 
 
-def test_health_check_returns_true() -> None:
-    assert _adapter().health_check() is True
+def test_audit_empty_initially() -> None:
+    assert _adapter().collect_audit_records() == []
 
 
-def test_protocol_conformance() -> None:
+def test_audit_created_event_on_submit() -> None:
     adapter = _adapter()
-    assert hasattr(adapter, "submit_payment")
-    assert hasattr(adapter, "get_payment_status")
-    assert hasattr(adapter, "health_check")
-    from services.payment.payment_port import PaymentRailPort
+    result = adapter.submit_payment(_make_intent())
+    records = adapter.collect_audit_records()
+    assert len(records) == 1
+    assert records[0].event_type == "CREATED"
+    assert records[0].payment_id == result.provider_payment_id
+    assert records[0].status_from is None
+    assert records[0].status_to == SepaPaymentStatus.PENDING
 
-    _port: PaymentRailPort = adapter  # type: ignore[assignment]
-    assert _port is adapter
 
-
-def test_advance_to_unknown_payment_raises() -> None:
+def test_audit_submitted_event_on_advance_submitted() -> None:
     adapter = _adapter()
-    with pytest.raises(SepaApplicationError) as exc_info:
-        adapter.advance_to("nonexistent-id", SepaPaymentStatus.SUBMITTED)
-    assert exc_info.value.code == "payment_not_found"
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.SUBMITTED)
+    records = adapter.collect_audit_records()
+    assert len(records) == 2
+    assert records[1].event_type == "SUBMITTED"
+    assert records[1].status_from == SepaPaymentStatus.PENDING
+    assert records[1].status_to == SepaPaymentStatus.SUBMITTED
+
+
+def test_audit_settled_event() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.SUBMITTED)
+    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.SETTLED)
+    records = adapter.collect_audit_records()
+    assert records[-1].event_type == "SETTLED"
+    assert records[-1].status_to == SepaPaymentStatus.SETTLED
+
+
+def test_audit_rejected_event() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.SUBMITTED)
+    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.REJECTED)
+    records = adapter.collect_audit_records()
+    assert records[-1].event_type == "REJECTED"
+
+
+def test_audit_cancelled_event() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    adapter.advance_to(result.provider_payment_id, SepaPaymentStatus.CANCELLED)
+    records = adapter.collect_audit_records()
+    assert records[-1].event_type == "CANCELLED"
+
+
+def test_audit_record_is_separate_from_payment_result() -> None:
+    adapter = _adapter()
+    result = adapter.submit_payment(_make_intent())
+    audit = adapter.collect_audit_records()[0]
+    assert isinstance(audit, SepaAuditRecord)
+    assert not hasattr(result, "event_type")
+    assert not hasattr(result, "status_from")
+
+
+def test_audit_log_copy_semantics() -> None:
+    adapter = _adapter()
+    adapter.submit_payment(_make_intent())
+    snapshot = adapter.collect_audit_records()
+    adapter.advance_to(snapshot[0].payment_id, SepaPaymentStatus.SUBMITTED)
+    assert len(snapshot) == 1
+    assert len(adapter.collect_audit_records()) == 2
+
+
+# ── _sepa_event_for helper ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (SepaPaymentStatus.SUBMITTED, "SUBMITTED"),
+        (SepaPaymentStatus.SETTLED, "SETTLED"),
+        (SepaPaymentStatus.REJECTED, "REJECTED"),
+        (SepaPaymentStatus.CANCELLED, "CANCELLED"),
+        (SepaPaymentStatus.PENDING, "CREATED"),
+    ],
+)
+def test_sepa_event_for(status: SepaPaymentStatus, expected: str) -> None:
+    assert _sepa_event_for(status) == expected


### PR DESCRIPTION
## Summary

- Semantic rewrite of `sepa-service/create-outgoing-transactions.service.ts` → `LegacySepaAdapter` implementing `PaymentRailPort` (REWRITE-3 per Wave C entry-point inventory, closes Wave C)
- Transport dropped per ADR-025 §15-16: GCP Bifrost XML, DWH gRPC, Redis cron, NestJS EventEmitter/Cron, TypeORM, SCA/VOP approval chain
- Completes all 3 Wave C rewrites: REWRITE-1 (PR #82 ✅) → REWRITE-2 (PR #83 ✅) → REWRITE-3 (this PR)

## Enhancements over Wave-C step-1 baseline

| Feature | Before | After |
|---------|--------|-------|
| Domain record | `SepaPayment` (no error/settlement fields) | `SepaPaymentRecord` (adds `creditor_name`, `submitted_at`, `settled_at`, `error_code`, `error_message`) |
| Audit trail | None | `SepaAuditRecord` (I-24 append-only, separate from `PaymentResult`) |
| Idempotency key | `intent.idempotency_key` | `(customer_id, reference)` composite key (SEPA rulebook surrogate) |
| Creditor name | Not validated | Non-empty + ≤70 chars (ISO 20022 field length) |
| Amount precision | Not checked | ≤2 decimal places via `Decimal.as_tuple().exponent` |
| `advance_to()` | `payment_id, new_status` only | `+ settled_at, error_code, error_message` kwargs (parity with ABS) |
| Audit collection | None | `collect_audit_records()` → Wave D ClickHouse sink |

## Port mapping (TS → Python)

| TS method | Python | Notes |
|-----------|--------|-------|
| `approveTransaction(dto)` | `advance_to(SUBMITTED)` | SCA factor + VOP dropped |
| `needsApprovalHandler() @Cron` | DROP | pull-on-demand in-memory |
| `syncTransactions() @Cron` | DROP | in-memory |

## Audit boundary (I-24)

`SepaAuditRecord` (frozen Pydantic) captures: `CREATED / SUBMITTED / SETTLED / REJECTED / CANCELLED` event types with `status_from / status_to` transition pair. Never folded into `PaymentResult`. Production: ClickHouse append-only sink (Wave D).

## Files changed

- `services/payment/legacy/legacy_sepa_adapter.py` — replaced (153 stmts, 273 lines)
- `tests/test_legacy_sepa_adapter.py` — replaced (73 tests, 100% coverage)

## Frozen files untouched

- `services/payment/payment_port.py`
- `services/payment/legacy/__init__.py`
- `api/routers/auth.py`

(`git diff origin/main -- <frozen-files> | wc -l → 0`)

## Test plan

- [x] `ruff check` — 0 issues
- [x] `ruff format` — clean
- [x] Bandit `-ll` — 0/0/0 issues
- [x] Semgrep banxe-rules — Passed (pre-commit)
- [x] 73 tests, **100% statement coverage** (153 stmts, 0 missed)
- [x] Parametrised invalid IBANs × 5; valid IBANs × 4 (DE/GB/FR/NL)
- [x] Parametrised invalid BICs × 4
- [x] `(customer_id, reference)` idempotency × 3 cases
- [x] creditor_name: empty / whitespace / >70 / =70
- [x] Amount precision: 3dp raises / 2dp ok / integer ok
- [x] Audit trail: all 5 event types, I-24 isolation, copy semantics
- [x] Frozen guard: 0 lines diff on protected files
- [x] Pre-commit: all 8 hooks Passed

## Wave C complete — Wave D readiness

Wave C closes here (3/3 REWRITE adapters merged). Wave D will wire:
- `LegacyTransactionsAdapter`, `LegacyAbsPaymentAdapter`, `LegacySepaAdapter` → ClickHouse audit sink
- GCP Bifrost XML adapter for live SEPA submission
- Modulr/ClearBank adapter for production SEPA CT/SCT_INST

## Canon

ADR-025 §15-16 + ADR-029 + services.payment.payment_port (PaymentRailPort Protocol)
SESSION-2026-05-07-WAVE-C-PAYMENTS-START.md (REWRITE-3 mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)