### PR TITLE
feat(wave-c): ModulrSepaAdapter — PaymentRailPort via Modulr sandbox [IL-SEPA-PROD-01]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,11 @@ SENDGRID_FROM_EMAIL=otp-noreply@banxe.com
 SUMSUB_APP_TOKEN=your_sumsub_app_token
 SUMSUB_SECRET_KEY=your_sumsub_secret_key
 SUMSUB_BASE_URL=https://api.sumsub.com
+
+# === Payments / Modulr Finance (Sprint 8 — ADR-025, [IL-SEPA-PROD-01]) ===
+# Modulr sandbox: https://api-sandbox.modulrfinance.com (used when MODULR_SANDBOX=true)
+MODULR_API_KEY=your_modulr_api_key
+MODULR_API_SECRET=your_modulr_api_secret
+MODULR_EUR_ACCOUNT_ID=your_modulr_eur_account_id
+# Only needed for production (sandbox=False); defaults to https://api.modulrfinance.com
+MODULR_API_URL=https://api.modulrfinance.com

--- a/services/payment/production/modulr_sepa_adapter.py
+++ b/services/payment/production/modulr_sepa_adapter.py
@@ -1,0 +1,252 @@
+"""
+modulr_sepa_adapter.py — ModulrSepaAdapter: PaymentRailPort via Modulr Finance REST API.
+
+Production HTTP adapter for SEPA CT + SEPA Instant payments.
+All env vars are read in __init__ (no module-level globals).
+Sandbox-only by default — no live API calls unless sandbox=False is explicit.
+
+Modulr endpoints used:
+  POST /accounts/{eur_account_id}/payments   → submit_payment
+  GET  /payments/{payment_id}                → get_payment_status
+  GET  /ping                                 → health
+
+Auth: Authorization: Basic {api_key}:{api_secret}
+Idempotency: x-mod-nonce: {idempotency_key} header
+
+Env: MODULR_API_KEY, MODULR_API_SECRET, MODULR_EUR_ACCOUNT_ID, MODULR_API_URL
+Canon: ADR-025 §15-16 + PORT-CONTRACTS-FREEZE-2026-05-08 + [IL-SEPA-PROD-01]
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime
+from decimal import Decimal
+import os
+from typing import Any
+
+import httpx
+
+from services.payment.legacy.legacy_sepa_adapter import (
+    _validate_bic,
+    _validate_iban,
+)
+from services.payment.payment_port import (
+    PaymentIntent,
+    PaymentRail,
+    PaymentResult,
+    PaymentStatus,
+)
+
+_SEPA_RAILS: frozenset[PaymentRail] = frozenset({PaymentRail.SEPA_CT, PaymentRail.SEPA_INSTANT})
+_SCT_INST_MAX_EUR: Decimal = Decimal("100000.00")
+_SANDBOX_BASE_URL: str = "https://api-sandbox.modulrfinance.com"
+_PROD_BASE_URL: str = "https://api.modulrfinance.com"
+
+_MODULR_STATUS_MAP: dict[str, PaymentStatus] = {
+    "PROCESSED": PaymentStatus.COMPLETED,
+    "PROCESSING": PaymentStatus.PROCESSING,
+    "SUBMITTED": PaymentStatus.PENDING,
+    "FAILED": PaymentStatus.FAILED,
+    "RETURNED": PaymentStatus.RETURNED,
+}
+
+
+class ModulrSepaError(Exception):
+    def __init__(self, message: str, *, code: str = "modulr_error") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ModulrSepaAdapter:
+    """
+    PaymentRailPort — Modulr Finance REST API, SEPA CT + SEPA Instant only.
+
+    SEPA validation: IBAN mod-97, BIC SWIFT regex, SCT_INST ≤ €100k.
+    4xx/5xx responses are fail-safe: returns PaymentResult(status=FAILED).
+    """
+
+    def __init__(
+        self,
+        *,
+        sandbox: bool = True,
+        timeout_seconds: float = 10.0,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self._api_key: str = os.environ["MODULR_API_KEY"]
+        self._api_secret: str = os.environ.get("MODULR_API_SECRET", "")
+        self._eur_account_id: str = os.environ["MODULR_EUR_ACCOUNT_ID"]
+        self._base_url: str = (
+            _SANDBOX_BASE_URL
+            if sandbox
+            else os.environ.get("MODULR_API_URL", _PROD_BASE_URL).rstrip("/")
+        )
+        self._timeout = timeout_seconds
+        self._http: httpx.Client = (
+            http_client if http_client is not None else httpx.Client(timeout=timeout_seconds)
+        )
+
+    # ── PaymentRailPort ───────────────────────────────────────────────────────
+
+    def submit_payment(self, intent: PaymentIntent) -> PaymentResult:
+        """POST /accounts/{eur_account_id}/payments — SEPA CT / SEPA Instant."""
+        if intent.rail not in _SEPA_RAILS:
+            return self._fail_result(
+                intent,
+                code="unsupported_rail",
+                message=f"ModulrSepaAdapter only handles SEPA rails, got {intent.rail.value}",
+            )
+
+        creditor = intent.creditor_account
+        iban = creditor.iban or ""
+        bic = creditor.bic or ""
+
+        if not _validate_iban(iban):
+            return self._fail_result(intent, code="invalid_iban", message=f"Invalid IBAN: {iban!r}")
+        if bic and not _validate_bic(bic):
+            return self._fail_result(intent, code="invalid_bic", message=f"Invalid BIC: {bic!r}")
+
+        if intent.rail == PaymentRail.SEPA_INSTANT and intent.amount > _SCT_INST_MAX_EUR:
+            return self._fail_result(
+                intent,
+                code="amount_exceeds_sct_inst_max",
+                message=f"SEPA Instant max €{_SCT_INST_MAX_EUR}, got €{intent.amount}",
+            )
+
+        amount_minor = int(intent.amount * 100)
+
+        body: dict[str, Any] = {
+            "type": "SEPA_INSTANT" if intent.rail == PaymentRail.SEPA_INSTANT else "SEPA_CT",
+            "amount": amount_minor,
+            "currency": intent.currency,
+            "destination": {
+                "type": "IBAN",
+                "iban": iban.replace(" ", "").upper(),
+                "name": creditor.account_holder_name[:70],
+            },
+            "reference": intent.reference[:140],
+            "externalReference": intent.idempotency_key,
+            "endToEndReference": intent.end_to_end_id[:35],
+        }
+        if bic:
+            body["destination"]["bic"] = bic.upper()
+
+        try:
+            data = self._request(
+                "POST",
+                f"/accounts/{self._eur_account_id}/payments",
+                body=body,
+                idempotency_key=intent.idempotency_key,
+            )
+        except httpx.HTTPStatusError as exc:
+            return self._fail_result(
+                intent,
+                code=f"http_{exc.response.status_code}",
+                message=str(exc),
+            )
+
+        provider_id: str = data.get("id", "")
+        raw_status: str = data.get("status", "SUBMITTED")
+        status = _MODULR_STATUS_MAP.get(raw_status, PaymentStatus.PENDING)
+        return PaymentResult(
+            idempotency_key=intent.idempotency_key,
+            provider_payment_id=provider_id,
+            status=status,
+            rail=intent.rail,
+            amount=intent.amount,
+            currency=intent.currency,
+            submitted_at=datetime.now(UTC),
+        )
+
+    def get_payment_status(self, provider_payment_id: str) -> PaymentResult:
+        """GET /payments/{payment_id} — returns current Modulr status."""
+        try:
+            data = self._request("GET", f"/payments/{provider_payment_id}")
+        except httpx.HTTPStatusError as exc:
+            return PaymentResult(
+                idempotency_key="",
+                provider_payment_id=provider_payment_id,
+                status=PaymentStatus.FAILED,
+                rail=PaymentRail.SEPA_CT,
+                amount=Decimal("0"),
+                currency="EUR",
+                submitted_at=datetime.now(UTC),
+                error_code=f"http_{exc.response.status_code}",
+                error_message=str(exc),
+            )
+
+        raw_status: str = data.get("status", "FAILED")
+        status = _MODULR_STATUS_MAP.get(raw_status, PaymentStatus.FAILED)
+        amount_minor: int = data.get("amount", 0)
+        amount = Decimal(amount_minor) / 100
+        rail_raw: str = data.get("type", "SEPA_CT")
+        rail = PaymentRail.SEPA_INSTANT if rail_raw == "SEPA_INSTANT" else PaymentRail.SEPA_CT
+        ext_ref: str = data.get("externalReference", "")
+        return PaymentResult(
+            idempotency_key=ext_ref,
+            provider_payment_id=provider_payment_id,
+            status=status,
+            rail=rail,
+            amount=amount,
+            currency=data.get("currency", "EUR"),
+            submitted_at=datetime.now(UTC),
+        )
+
+    def health(self) -> bool:
+        """GET /ping — True if Modulr API is reachable."""
+        try:
+            self._request("GET", "/ping")
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def close(self) -> None:
+        self._http.close()
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _auth_header(self) -> str:
+        credentials = f"{self._api_key}:{self._api_secret}"
+        encoded = base64.b64encode(credentials.encode()).decode()
+        return f"Basic {encoded}"
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        import json
+
+        headers: dict[str, str] = {
+            "Authorization": self._auth_header(),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        if idempotency_key:
+            headers["x-mod-nonce"] = idempotency_key
+
+        body_str = json.dumps(body) if body else ""
+        resp = self._http.request(
+            method,
+            self._base_url + path,
+            headers=headers,
+            content=body_str.encode() if body_str else None,
+        )
+        resp.raise_for_status()
+        return resp.json()  # type: ignore[no-any-return]
+
+    def _fail_result(self, intent: PaymentIntent, *, code: str, message: str) -> PaymentResult:
+        return PaymentResult(
+            idempotency_key=intent.idempotency_key,
+            provider_payment_id="",
+            status=PaymentStatus.FAILED,
+            rail=intent.rail,
+            amount=intent.amount,
+            currency=intent.currency,
+            submitted_at=datetime.now(UTC),
+            error_code=code,
+            error_message=message,
+        )

--- a/tests/test_modulr_sepa_adapter.py
+++ b/tests/test_modulr_sepa_adapter.py
@@ -1,0 +1,312 @@
+"""
+tests/test_modulr_sepa_adapter.py — Unit tests for ModulrSepaAdapter.
+
+All HTTP calls are mocked — no real Modulr API calls.
+Integration tests (real Modulr sandbox) are a separate CI job requiring
+MODULR_API_KEY / MODULR_API_SECRET secrets.
+
+Tests: 18
+Canon: ADR-025 §15-16 + PORT-CONTRACTS-FREEZE-2026-05-08 + [IL-SEPA-PROD-01]
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from services.payment.payment_port import (
+    BankAccount,
+    PaymentDirection,
+    PaymentIntent,
+    PaymentRail,
+    PaymentResult,
+    PaymentStatus,
+)
+
+# ── Shared test data ──────────────────────────────────────────────────────────
+
+_VALID_IBAN = "GB29NWBK60161331926819"
+_VALID_BIC = "NWBKGB2L"
+
+_PAYMENT_SUBMITTED = {
+    "id": "pay-001",
+    "status": "SUBMITTED",
+    "amount": 50000,
+    "currency": "EUR",
+    "type": "SEPA_CT",
+    "externalReference": "idem-key-001",
+}
+
+_PAYMENT_PROCESSED = {**_PAYMENT_SUBMITTED, "status": "PROCESSED"}
+_PAYMENT_FAILED = {**_PAYMENT_SUBMITTED, "status": "FAILED"}
+_PAYMENT_INSTANT = {**_PAYMENT_SUBMITTED, "type": "SEPA_INSTANT", "status": "PROCESSING"}
+
+
+def _make_resp(json_data: object, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    return resp
+
+
+@pytest.fixture()
+def env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODULR_API_KEY", "test_api_key_000000000000")
+    monkeypatch.setenv("MODULR_API_SECRET", "test_api_secret_00000000")
+    monkeypatch.setenv("MODULR_EUR_ACCOUNT_ID", "A1EUR000001")
+
+
+@pytest.fixture()
+def mock_http() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def adapter(env_vars: None, mock_http: MagicMock) -> object:
+    from unittest.mock import patch
+
+    with patch(
+        "services.payment.production.modulr_sepa_adapter.httpx.Client",
+        return_value=mock_http,
+    ):
+        from services.payment.production.modulr_sepa_adapter import ModulrSepaAdapter
+
+        return ModulrSepaAdapter(sandbox=True)
+
+
+def _make_intent(
+    rail: PaymentRail = PaymentRail.SEPA_CT,
+    amount: str = "500.00",
+    iban: str = _VALID_IBAN,
+    bic: str = _VALID_BIC,
+) -> PaymentIntent:
+    from datetime import datetime
+
+    return PaymentIntent(
+        idempotency_key="idem-key-001",
+        rail=rail,
+        direction=PaymentDirection.OUTBOUND,
+        amount=Decimal(amount),
+        currency="EUR",
+        debtor_account=BankAccount(account_holder_name="Banxe EUR", iban="DE89370400440532013000"),
+        creditor_account=BankAccount(account_holder_name="Alice Smith", iban=iban, bic=bic),
+        reference="Invoice 12345",
+        end_to_end_id="E2E-2026-0001",
+        requested_at=datetime.now(UTC),
+    )
+
+
+# ── Protocol structure ────────────────────────────────────────────────────────
+
+
+def test_adapter_has_all_port_methods(adapter: object) -> None:
+    for method in ("submit_payment", "get_payment_status", "health"):
+        assert callable(getattr(adapter, method, None)), f"Missing port method: {method}"
+
+
+# ── submit_payment ────────────────────────────────────────────────────────────
+
+
+def test_submit_payment_sends_post_to_accounts_endpoint(
+    adapter: object, mock_http: MagicMock
+) -> None:
+    mock_http.request.return_value = _make_resp(_PAYMENT_SUBMITTED)
+
+    adapter.submit_payment(_make_intent())  # type: ignore[attr-defined]
+
+    call = mock_http.request.call_args
+    assert call[0][0] == "POST"
+    assert "/accounts/" in call[0][1]
+    assert "/payments" in call[0][1]
+
+
+def test_submit_payment_returns_payment_result(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.return_value = _make_resp(_PAYMENT_SUBMITTED)
+
+    result = adapter.submit_payment(_make_intent())  # type: ignore[attr-defined]
+
+    assert isinstance(result, PaymentResult)
+    assert result.provider_payment_id == "pay-001"
+    assert result.status == PaymentStatus.PENDING
+    assert result.idempotency_key == "idem-key-001"
+
+
+def test_submit_payment_maps_processed_to_completed(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.return_value = _make_resp(_PAYMENT_PROCESSED)
+
+    result = adapter.submit_payment(_make_intent())  # type: ignore[attr-defined]
+
+    assert result.status == PaymentStatus.COMPLETED
+
+
+def test_submit_payment_sepa_instant_maps_processing(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.return_value = _make_resp(_PAYMENT_INSTANT)
+
+    result = adapter.submit_payment(  # type: ignore[attr-defined]
+        _make_intent(rail=PaymentRail.SEPA_INSTANT)
+    )
+
+    assert result.status == PaymentStatus.PROCESSING
+
+
+def test_submit_payment_sets_x_mod_nonce_header(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.return_value = _make_resp(_PAYMENT_SUBMITTED)
+
+    adapter.submit_payment(_make_intent())  # type: ignore[attr-defined]
+
+    headers = mock_http.request.call_args[1]["headers"]
+    assert "x-mod-nonce" in headers
+    assert headers["x-mod-nonce"] == "idem-key-001"
+
+
+def test_submit_payment_sets_basic_auth_header(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.return_value = _make_resp(_PAYMENT_SUBMITTED)
+
+    adapter.submit_payment(_make_intent())  # type: ignore[attr-defined]
+
+    headers = mock_http.request.call_args[1]["headers"]
+    assert "Authorization" in headers
+    assert headers["Authorization"].startswith("Basic ")
+
+
+def test_submit_payment_rejects_fps_rail(adapter: object) -> None:
+    from datetime import datetime
+
+    intent = PaymentIntent(
+        idempotency_key="idem-fps-001",
+        rail=PaymentRail.FPS,
+        direction=PaymentDirection.OUTBOUND,
+        amount=Decimal("100.00"),
+        currency="GBP",
+        debtor_account=BankAccount(
+            account_holder_name="Banxe GBP",
+            sort_code="20-20-15",
+            account_number="12345678",
+        ),
+        creditor_account=BankAccount(
+            account_holder_name="Bob Jones",
+            sort_code="40-47-84",
+            account_number="87654321",
+        ),
+        reference="FPS payment",
+        end_to_end_id="E2E-FPS-001",
+        requested_at=datetime.now(UTC),
+    )
+
+    result = adapter.submit_payment(intent)  # type: ignore[attr-defined]
+
+    assert result.status == PaymentStatus.FAILED
+    assert result.error_code == "unsupported_rail"
+
+
+def test_submit_payment_rejects_invalid_iban(adapter: object) -> None:
+    result = adapter.submit_payment(  # type: ignore[attr-defined]
+        _make_intent(iban="INVALID-IBAN-0000")
+    )
+
+    assert result.status == PaymentStatus.FAILED
+    assert result.error_code == "invalid_iban"
+
+
+def test_submit_payment_rejects_invalid_bic(adapter: object) -> None:
+    result = adapter.submit_payment(  # type: ignore[attr-defined]
+        _make_intent(bic="BAD!")
+    )
+
+    assert result.status == PaymentStatus.FAILED
+    assert result.error_code == "invalid_bic"
+
+
+def test_submit_payment_blocks_sct_inst_above_100k(adapter: object) -> None:
+    result = adapter.submit_payment(  # type: ignore[attr-defined]
+        _make_intent(rail=PaymentRail.SEPA_INSTANT, amount="100000.01")
+    )
+
+    assert result.status == PaymentStatus.FAILED
+    assert result.error_code == "amount_exceeds_sct_inst_max"
+
+
+def test_submit_payment_allows_sct_inst_at_100k(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.return_value = _make_resp(_PAYMENT_INSTANT)
+
+    result = adapter.submit_payment(  # type: ignore[attr-defined]
+        _make_intent(rail=PaymentRail.SEPA_INSTANT, amount="100000.00")
+    )
+
+    assert (
+        result.status != PaymentStatus.FAILED or result.error_code != "amount_exceeds_sct_inst_max"
+    )
+
+
+def test_submit_payment_failsafe_on_http_error(adapter: object, mock_http: MagicMock) -> None:
+    err_resp = _make_resp({}, status_code=500)
+    err_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "server error", request=MagicMock(), response=err_resp
+    )
+    mock_http.request.return_value = err_resp
+
+    result = adapter.submit_payment(_make_intent())  # type: ignore[attr-defined]
+
+    assert result.status == PaymentStatus.FAILED
+    assert result.error_code == "http_500"
+
+
+# ── get_payment_status ────────────────────────────────────────────────────────
+
+
+def test_get_payment_status_calls_payments_get(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.return_value = _make_resp(_PAYMENT_PROCESSED)
+
+    adapter.get_payment_status("pay-001")  # type: ignore[attr-defined]
+
+    call = mock_http.request.call_args
+    assert call[0][0] == "GET"
+    assert "pay-001" in call[0][1]
+
+
+def test_get_payment_status_returns_completed(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.return_value = _make_resp(_PAYMENT_PROCESSED)
+
+    result = adapter.get_payment_status("pay-001")  # type: ignore[attr-defined]
+
+    assert isinstance(result, PaymentResult)
+    assert result.status == PaymentStatus.COMPLETED
+    assert result.amount == Decimal("500.00")
+
+
+def test_get_payment_status_failsafe_on_404(adapter: object, mock_http: MagicMock) -> None:
+    err_resp = _make_resp({}, status_code=404)
+    err_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "not found", request=MagicMock(), response=err_resp
+    )
+    mock_http.request.return_value = err_resp
+
+    result = adapter.get_payment_status("nonexistent")  # type: ignore[attr-defined]
+
+    assert result.status == PaymentStatus.FAILED
+    assert result.error_code == "http_404"
+
+
+# ── health ────────────────────────────────────────────────────────────────────
+
+
+def test_health_returns_true_on_200(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.return_value = _make_resp({"status": "OK"})
+    assert adapter.health() is True  # type: ignore[attr-defined]
+
+
+def test_health_returns_false_on_exception(adapter: object, mock_http: MagicMock) -> None:
+    mock_http.request.side_effect = httpx.ConnectError("unreachable")
+    assert adapter.health() is False  # type: ignore[attr-defined]
+
+
+# ── close ─────────────────────────────────────────────────────────────────────
+
+
+def test_close_calls_http_close(adapter: object, mock_http: MagicMock) -> None:
+    adapter.close()  # type: ignore[attr-defined]
+    mock_http.close.assert_called_once()


### PR DESCRIPTION
## Summary

- Implements `ModulrSepaAdapter` — production `PaymentRailPort` via Modulr Finance REST API
- Handles **SEPA CT** and **SEPA Instant** rails only; FPS/BACS/CHAPS fail-safe with `error_code=unsupported_rail`
- All env vars read in `__init__` (no module-level globals, fixes pattern from `modulr_client.py`)
- HMAC-free: Modulr uses `Authorization: Basic {key}:{secret}` + `x-mod-nonce` idempotency header
- IBAN ISO 13616 mod-97 validation + BIC SWIFT regex (reuses `_validate_iban`/`_validate_bic` from legacy adapter)
- SCT Instant max €100,000 enforced; 4xx/5xx → fail-safe `PaymentResult(status=FAILED, error_code=...)`
- Amount encoding: minor units (cents) on submit, `Decimal / 100` on parse

## Files changed

- `services/payment/production/modulr_sepa_adapter.py` — new adapter (~170 lines)
- `tests/test_modulr_sepa_adapter.py` — 19 unit tests, all HTTP mocked
- `.env.example` — Modulr vars section added (Sprint 8)

## Test plan

- [x] 19 unit tests pass (all mocked — no Modulr API calls)
- [x] `test_production_stubs.py` unmodified — `ModulrSepaStub` stub stays
- [x] `test_sumsub_http_adapter.py` 18 tests unaffected
- [x] Ruff lint + format clean
- [x] Semgrep, Bandit, pre-commit all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)