### PR TITLE
feat(adr-028): KYC re-trigger events — CI smoke gate + operational check [Step 3]

### DIFF
--- a/scripts/kyc-retrigger-check.py
+++ b/scripts/kyc-retrigger-check.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Operational check: KYC re-trigger events wiring (ADR-028).
+
+Verifies that all 3 KYC re-trigger event types are registered, buildable,
+and wired into the FSM lifecycle engine.
+
+Usage:
+    python3 scripts/kyc-retrigger-check.py
+
+Cron (daily):
+    0 6 * * * cd /opt/banxe && python3 scripts/kyc-retrigger-check.py >> /var/log/banxe/kyc-retrigger-check.log 2>&1
+
+Exit codes:
+    0  all checks PASS
+    1  any check FAIL
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+
+def check_event_types_registered() -> tuple[bool, str]:
+    """Check that all 3 KYC re-trigger event types exist in BanxeEventType."""
+    from services.events.event_bus import BanxeEventType
+
+    required = ["ROLE_CHANGED", "BENEFICIAL_OWNER_CHANGED", "JURISDICTION_CHANGED"]
+    missing = [name for name in required if not hasattr(BanxeEventType, name)]
+    if missing:
+        return False, f"missing enum members: {missing}"
+    return True, "all 3 event types registered"
+
+
+def check_dataclass_importable() -> tuple[bool, str]:
+    """Check that KycReTriggerEvent dataclass is importable."""
+    try:
+        from services.events.event_bus import KycReTriggerEvent  # noqa: F401
+
+        return True, "KycReTriggerEvent importable"
+    except ImportError as exc:
+        return False, f"import failed: {exc}"
+
+
+def check_build_function() -> tuple[bool, str]:
+    """Check build_kyc_retrigger_event() returns valid events for all 3 types."""
+    from services.events.event_bus import (
+        BanxeEventType,
+        KycReTriggerEvent,
+        build_kyc_retrigger_event,
+    )
+
+    types = [
+        BanxeEventType.ROLE_CHANGED,
+        BanxeEventType.BENEFICIAL_OWNER_CHANGED,
+        BanxeEventType.JURISDICTION_CHANGED,
+    ]
+    for event_type in types:
+        event = build_kyc_retrigger_event(
+            event_type=event_type,
+            customer_id="check-cust-001",
+            triggered_by="operational-check",
+            previous_value="old",
+            new_value="new",
+        )
+        if not isinstance(event, KycReTriggerEvent):
+            return False, f"{event_type.name}: returned non-KycReTriggerEvent"
+        if not event.criticality:
+            return False, f"{event_type.name}: empty criticality"
+        if not event.gap_ref:
+            return False, f"{event_type.name}: empty gap_ref"
+    return True, "build_kyc_retrigger_event valid for all 3 types"
+
+
+def check_fsm_wiring() -> tuple[bool, str]:
+    """Check FSM lifecycle engine handles KYC re-trigger events."""
+    from services.customer_lifecycle.fsm import KYCLifecycleEngine
+    from services.events.event_bus import BanxeEventType
+
+    engine = KYCLifecycleEngine()
+    try:
+        result = engine.notify_attribute_change(
+            customer_id="check-cust-002",
+            event_type=BanxeEventType.ROLE_CHANGED,
+            triggered_by="operational-check",
+            previous_value="director",
+            new_value="shareholder",
+        )
+    except Exception as exc:
+        return False, f"FSM notify_attribute_change raised: {exc}"
+    if result is None:
+        return False, "FSM returned None instead of KycReTriggerEvent"
+    return True, "FSM wiring operational"
+
+
+def main() -> int:
+    checks = [
+        ("event_types_registered", check_event_types_registered),
+        ("dataclass_importable", check_dataclass_importable),
+        ("build_function_valid", check_build_function),
+        ("fsm_wiring", check_fsm_wiring),
+    ]
+
+    results: list[tuple[str, bool, str]] = []
+    for name, fn in checks:
+        passed, detail = fn()
+        results.append((name, passed, detail))
+
+    all_pass = all(passed for _, passed, _ in results)
+
+    for name, passed, detail in results:
+        status = "PASS" if passed else "FAIL"
+        print(f"[{status}] {name}: {detail}")
+
+    print(
+        f"\n{'ALL CHECKS PASS' if all_pass else 'SOME CHECKS FAILED'} ({sum(1 for _, p, _ in results if p)}/{len(results)})"
+    )
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/smoke/test_kyc_retrigger_smoke.py
+++ b/tests/smoke/test_kyc_retrigger_smoke.py
@@ -1,0 +1,87 @@
+"""Smoke tests for ADR-028 Step 3: KYC re-trigger operational readiness.
+
+Gap refs: G-KYC-01 (role/UBO change) | G-KYC-02 (jurisdiction change)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+from services.events.event_bus import (
+    BanxeEventType,
+    KycReTriggerEvent,
+    build_kyc_retrigger_event,
+)
+
+
+def test_event_types_registered() -> None:
+    """All 3 KYC re-trigger event types exist in BanxeEventType enum."""
+    assert hasattr(BanxeEventType, "ROLE_CHANGED")
+    assert hasattr(BanxeEventType, "BENEFICIAL_OWNER_CHANGED")
+    assert hasattr(BanxeEventType, "JURISDICTION_CHANGED")
+
+    assert BanxeEventType.ROLE_CHANGED in BanxeEventType
+    assert BanxeEventType.BENEFICIAL_OWNER_CHANGED in BanxeEventType
+    assert BanxeEventType.JURISDICTION_CHANGED in BanxeEventType
+
+
+def test_build_retrigger_event_all_types() -> None:
+    """build_kyc_retrigger_event() returns correct KycReTriggerEvent for each type."""
+    expected = {
+        BanxeEventType.ROLE_CHANGED: ("HIGH", "G-KYC-01"),
+        BanxeEventType.BENEFICIAL_OWNER_CHANGED: ("HIGH", "G-KYC-01"),
+        BanxeEventType.JURISDICTION_CHANGED: ("CRITICAL", "G-KYC-02"),
+    }
+
+    for event_type, (exp_crit, exp_gap) in expected.items():
+        event = build_kyc_retrigger_event(
+            event_type=event_type,
+            customer_id="smoke-cust-001",
+            triggered_by="smoke-test",
+            previous_value="old_val",
+            new_value="new_val",
+        )
+        assert isinstance(event, KycReTriggerEvent)
+        assert event.event_type == event_type
+        assert event.criticality == exp_crit, f"{event_type.name}: expected {exp_crit}"
+        assert event.gap_ref == exp_gap, f"{event_type.name}: expected {exp_gap}"
+        assert event.customer_id == "smoke-cust-001"
+
+
+def test_fsm_handles_kyc_retrigger_event() -> None:
+    """FSM lifecycle engine accepts KycReTriggerEvent without exception."""
+    from services.customer_lifecycle.fsm import KYCLifecycleEngine
+
+    engine = KYCLifecycleEngine()
+
+    for event_type in (
+        BanxeEventType.ROLE_CHANGED,
+        BanxeEventType.BENEFICIAL_OWNER_CHANGED,
+        BanxeEventType.JURISDICTION_CHANGED,
+    ):
+        result = engine.notify_attribute_change(
+            customer_id="smoke-cust-002",
+            event_type=event_type,
+            triggered_by="smoke-test",
+            previous_value="before",
+            new_value="after",
+        )
+        assert isinstance(result, KycReTriggerEvent)
+        assert result.event_type == event_type
+
+
+def test_operational_script_runs() -> None:
+    """scripts/kyc-retrigger-check.py exits with code 0."""
+    script = Path(__file__).resolve().parents[2] / "scripts" / "kyc-retrigger-check.py"
+    assert script.exists(), f"script not found: {script}"
+
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"script failed:\n{result.stdout}\n{result.stderr}"
+    assert "ALL CHECKS PASS" in result.stdout


### PR DESCRIPTION
## Summary

ADR-028 Step 3/4 — operational script + CI smoke tests for KYC re-trigger events.

- `scripts/kyc-retrigger-check.py` — operational cron check (4 checks, exit 0/1)
- `tests/smoke/test_kyc_retrigger_smoke.py` — 4 smoke tests

## Gap refs

- G-KYC-01 (role/UBO change → mandatory re-verification)
- G-KYC-02 (jurisdiction change → CRITICAL re-verification)

## Tests

- 4 new smoke tests + 8 existing unit tests = 12 total, all PASS
- Lint clean (ruff check + ruff format)
- All pre-commit hooks PASS (Spec-First Auditor + Bandit + Semgrep + Pytest)

## ADR-028 progress

| Step | Description | Status |
|------|-------------|--------|
| 1 | BanxeEventType + KycReTriggerEvent + build fn + 8 tests | ✅ on main (PR #69) |
| 2 | FSM wiring + integration test | ✅ on main (PR #70) |
| **3** | **Operational script + CI smoke tests** | **This PR** |
| 4 | Flip ADR Proposed→Accepted + close G-KYC-01/02 | Next |

## Инструкция оператору после merge (§7)

```bash
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
```