### PR TITLE
feat(adr-035): add mock smoke gate workflow [Step 2]

### DIFF
--- a/.github/workflows/smoke-gate-mock.yml
+++ b/.github/workflows/smoke-gate-mock.yml
@@ -1,0 +1,35 @@
+name: Smoke Gate — Mock Tier (ADR-035)
+# ADR-035 Step 2 | banxe-emi-stack
+#
+# Required status check for PRs -> main.
+# Runs only the mock smoke surface matrix: no network, no live integrations.
+# Completes in < 3 min. Nightly full-stack tier is smoke-gate-full.yml (Step 4).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  smoke-mock:
+    name: Smoke Gate (mock tier)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio httpx
+
+      - name: Run mock smoke suite
+        run: |
+          python -m pytest tests/test_smoke/test_smoke_mock.py \
+            --override-ini=addopts= \
+            -q --tb=short


### PR DESCRIPTION
## ADR-035 Step 2 — Mock Smoke Gate CI Workflow

### What
Adds `.github/workflows/smoke-gate-mock.yml` — the CI required-check for the ADR-035 hybrid smoke gate (mock tier).

### Scope
- **Implements:** ADR-035 Step 2 only
- **Step 1** (mock smoke surface matrix — 6 tests, marker registration) is already in `main` via PR #100
- **This PR** adds only the GitHub Actions workflow file (35 lines, no product code changes)

### Workflow behaviour
- Triggers on `pull_request → main` and `push → main`
- Job name: `Smoke Gate (mock tier)` — suitable for branch-protection required-check
- Python 3.12, installs `requirements.txt` + `pytest pytest-asyncio httpx`
- Runs: `pytest tests/test_smoke/test_smoke_mock.py --override-ini=addopts= -q --tb=short`
- No network, no live integrations, no Docker — deterministic, < 3 min

### Local verification
```
pytest tests/test_smoke/test_smoke_mock.py --override-ini=addopts= -q --tb=short
# → 6 passed in 0.07s
```

### What remains (separate PRs)
- **Step 3:** Branch-protection `gh api` PATCH to add `Smoke Gate (mock tier)` as required status check
- **Step 4:** `smoke-gate-full.yml` — nightly cron, real docker-compose stack
- **Step 5:** `CI_SMOKE_FAILURE` AuditEvent alerting

🤖 Generated with [Claude Code](https://claude.com/claude-code)