### PR TITLE
feat(adr-029): Postgres backup port + adapter + unit tests [Step 1]

### DIFF
--- a/services/backup/backup_port.py
+++ b/services/backup/backup_port.py
@@ -1,0 +1,66 @@
+"""BackupPort — abstract backup interface (ADR-029, G-OPS-01/02).
+
+Defines the port for PostgreSQL backup operations. Concrete adapters
+(PgDumpBackupAdapter) implement this protocol for pg_dump/pg_restore.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class BackupResult:
+    """Result of a backup operation."""
+
+    success: bool
+    path: str
+    timestamp: datetime
+    size_bytes: int
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    """Result of a restore operation."""
+
+    success: bool
+    db_name: str
+    backup_path: str
+    timestamp: datetime
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class BackupMetadata:
+    """Metadata for an existing backup file."""
+
+    path: str
+    db_name: str
+    timestamp: datetime
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class RotationResult:
+    """Result of a rotation (cleanup) operation."""
+
+    success: bool
+    kept: int
+    deleted: int
+    freed_bytes: int
+    error: str | None = None
+
+
+class BackupPort(Protocol):
+    """Abstract port for PostgreSQL backup operations (ADR-029)."""
+
+    def backup(self, db_name: str) -> BackupResult: ...
+
+    def restore(self, db_name: str, backup_path: str) -> RestoreResult: ...
+
+    def list_backups(self, db_name: str) -> list[BackupMetadata]: ...
+
+    def rotate(self, db_name: str, keep_last: int) -> RotationResult: ...

--- a/services/backup/pg_backup_adapter.py
+++ b/services/backup/pg_backup_adapter.py
@@ -1,0 +1,182 @@
+"""PgDumpBackupAdapter — pg_dump/pg_restore implementation of BackupPort (ADR-029).
+
+Designed for cron-driven daily backup of PostgreSQL instances on evo1,
+with local retention + evo2 MinIO upload (Step 2 wiring).
+
+Environment variables:
+    PG_BACKUP_HOST      PostgreSQL host (default: localhost)
+    PG_BACKUP_PORT      PostgreSQL port (default: 5432)
+    PG_BACKUP_USER      PostgreSQL user (default: banxe)
+    PG_BACKUP_PASSWORD  PostgreSQL password (default: empty)
+    PG_BACKUP_DIR       Backup directory (default: /data/banxe/backups)
+    PG_BACKUP_RETAIN    Number of backups to keep (default: 7)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import logging
+import os
+from pathlib import Path
+import subprocess
+
+from services.backup.backup_port import (
+    BackupMetadata,
+    BackupResult,
+    RestoreResult,
+    RotationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PgDumpBackupAdapter:
+    """Concrete BackupPort implementation using pg_dump/pg_restore."""
+
+    def __init__(
+        self,
+        *,
+        pg_host: str | None = None,
+        pg_port: int | None = None,
+        pg_user: str | None = None,
+        pg_password: str | None = None,
+        backup_dir: str | None = None,
+        retention_count: int | None = None,
+    ) -> None:
+        self._pg_host = pg_host or os.getenv("PG_BACKUP_HOST", "localhost")
+        self._pg_port = pg_port or int(os.getenv("PG_BACKUP_PORT", "5432"))
+        self._pg_user = pg_user or os.getenv("PG_BACKUP_USER", "banxe")
+        self._pg_password = pg_password or os.getenv("PG_BACKUP_PASSWORD", "")
+        self._backup_dir = Path(backup_dir or os.getenv("PG_BACKUP_DIR", "/data/banxe/backups"))
+        self._retention_count = retention_count or int(os.getenv("PG_BACKUP_RETAIN", "7"))
+
+    def backup(self, db_name: str) -> BackupResult:
+        """Run pg_dump for the given database."""
+        now = datetime.now(tz=UTC)
+        filename = f"{db_name}_{now.strftime('%Y%m%d_%H%M%S')}.sql.gz"
+        target_dir = self._backup_dir / db_name
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path = target_dir / filename
+
+        env = os.environ.copy()
+        if self._pg_password:
+            env["PGPASSWORD"] = self._pg_password
+
+        cmd = [
+            "pg_dump",
+            f"--host={self._pg_host}",
+            f"--port={self._pg_port}",
+            f"--username={self._pg_user}",
+            "--format=custom",
+            f"--file={target_path}",
+            db_name,
+        ]
+
+        try:
+            subprocess.run(cmd, env=env, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as exc:
+            return BackupResult(
+                success=False,
+                path=str(target_path),
+                timestamp=now,
+                size_bytes=0,
+                error=f"pg_dump failed (exit {exc.returncode}): {exc.stderr[:200]}",
+            )
+
+        size = target_path.stat().st_size if target_path.exists() else 0
+        logger.info("backup OK: %s (%d bytes)", target_path, size)
+        return BackupResult(success=True, path=str(target_path), timestamp=now, size_bytes=size)
+
+    def restore(self, db_name: str, backup_path: str) -> RestoreResult:
+        """Run pg_restore for the given database from a backup file."""
+        now = datetime.now(tz=UTC)
+        path = Path(backup_path)
+
+        if not path.exists():
+            return RestoreResult(
+                success=False,
+                db_name=db_name,
+                backup_path=backup_path,
+                timestamp=now,
+                error=f"backup file not found: {backup_path}",
+            )
+
+        env = os.environ.copy()
+        if self._pg_password:
+            env["PGPASSWORD"] = self._pg_password
+
+        cmd = [
+            "pg_restore",
+            f"--host={self._pg_host}",
+            f"--port={self._pg_port}",
+            f"--username={self._pg_user}",
+            f"--dbname={db_name}",
+            "--clean",
+            "--if-exists",
+            backup_path,
+        ]
+
+        try:
+            subprocess.run(cmd, env=env, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as exc:
+            return RestoreResult(
+                success=False,
+                db_name=db_name,
+                backup_path=backup_path,
+                timestamp=now,
+                error=f"pg_restore failed (exit {exc.returncode}): {exc.stderr[:200]}",
+            )
+
+        logger.info("restore OK: %s -> %s", backup_path, db_name)
+        return RestoreResult(success=True, db_name=db_name, backup_path=backup_path, timestamp=now)
+
+    def list_backups(self, db_name: str) -> list[BackupMetadata]:
+        """List existing backups for a database, sorted by timestamp descending."""
+        target_dir = self._backup_dir / db_name
+        if not target_dir.exists():
+            return []
+
+        backups: list[BackupMetadata] = []
+        for f in target_dir.iterdir():
+            if f.is_file() and f.name.startswith(db_name):
+                stat = f.stat()
+                backups.append(
+                    BackupMetadata(
+                        path=str(f),
+                        db_name=db_name,
+                        timestamp=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
+                        size_bytes=stat.st_size,
+                    )
+                )
+
+        backups.sort(key=lambda b: b.timestamp, reverse=True)
+        return backups
+
+    def rotate(self, db_name: str, keep_last: int | None = None) -> RotationResult:
+        """Delete oldest backups, keeping only `keep_last` most recent."""
+        keep = keep_last if keep_last is not None else self._retention_count
+        backups = self.list_backups(db_name)
+
+        if len(backups) <= keep:
+            return RotationResult(success=True, kept=len(backups), deleted=0, freed_bytes=0)
+
+        to_delete = backups[keep:]
+        freed = 0
+        deleted = 0
+
+        for backup in to_delete:
+            try:
+                Path(backup.path).unlink()
+                freed += backup.size_bytes
+                deleted += 1
+            except OSError as exc:
+                return RotationResult(
+                    success=False,
+                    kept=keep,
+                    deleted=deleted,
+                    freed_bytes=freed,
+                    error=f"failed to delete {backup.path}: {exc}",
+                )
+
+        logger.info("rotation OK: kept=%d deleted=%d freed=%d bytes", keep, deleted, freed)
+        return RotationResult(success=True, kept=keep, deleted=deleted, freed_bytes=freed)

--- a/tests/unit/backup/test_backup_port.py
+++ b/tests/unit/backup/test_backup_port.py
@@ -1,0 +1,148 @@
+"""Unit tests for ADR-029 Step 1: BackupPort + PgDumpBackupAdapter.
+
+Gap refs: G-OPS-01 (backup rotation policy) | G-OPS-02 (restore drill)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+import subprocess
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from services.backup.pg_backup_adapter import PgDumpBackupAdapter
+
+
+def test_backup_creates_file() -> None:
+    """pg_dump success returns BackupResult with success=True and valid path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        adapter = PgDumpBackupAdapter(backup_dir=tmpdir)
+
+        with patch("services.backup.pg_backup_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+
+            # Create the expected file to simulate pg_dump output
+            db_dir = Path(tmpdir) / "test_db"
+            db_dir.mkdir()
+
+            result = adapter.backup("test_db")
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == "pg_dump"
+            assert "--format=custom" in cmd
+            assert "test_db" in cmd
+            assert result.success is True
+            assert "test_db" in result.path
+
+
+def test_backup_failure_returns_error() -> None:
+    """pg_dump failure returns BackupResult with success=False and error message."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        adapter = PgDumpBackupAdapter(backup_dir=tmpdir)
+
+        with patch("services.backup.pg_backup_adapter.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, "pg_dump", stderr="connection refused"
+            )
+
+            result = adapter.backup("test_db")
+
+            assert result.success is False
+            assert result.error is not None
+            assert "pg_dump failed" in result.error
+            assert result.size_bytes == 0
+
+
+def test_restore_success() -> None:
+    """pg_restore success returns RestoreResult with success=True."""
+    with tempfile.NamedTemporaryFile(suffix=".sql.gz") as tmp:
+        adapter = PgDumpBackupAdapter()
+
+        with patch("services.backup.pg_backup_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+
+            result = adapter.restore("test_db", tmp.name)
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == "pg_restore"
+            assert "--dbname=test_db" in cmd
+            assert result.success is True
+            assert result.db_name == "test_db"
+            assert result.backup_path == tmp.name
+
+
+def test_restore_missing_file_error() -> None:
+    """Restore of non-existent file returns error without calling pg_restore."""
+    adapter = PgDumpBackupAdapter()
+
+    with patch("services.backup.pg_backup_adapter.subprocess.run") as mock_run:
+        result = adapter.restore("test_db", "/nonexistent/path/backup.sql.gz")
+
+        mock_run.assert_not_called()
+        assert result.success is False
+        assert result.error is not None
+        assert "not found" in result.error
+
+
+def test_list_backups_returns_sorted() -> None:
+    """list_backups returns BackupMetadata sorted by timestamp descending."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_dir = Path(tmpdir) / "mydb"
+        db_dir.mkdir()
+
+        # Create 3 fake backup files with different mtimes
+
+        for i, name in enumerate(
+            ["mydb_20260501.sql.gz", "mydb_20260503.sql.gz", "mydb_20260502.sql.gz"]
+        ):
+            f = db_dir / name
+            f.write_text(f"backup content {i}" * 100)
+            # Set mtime: 501, 503, 502
+            ts = datetime(2026, 5, 1 + int(name[5:13][-2:]), tzinfo=UTC).timestamp()
+            import os
+
+            os.utime(f, (ts, ts))
+
+        adapter = PgDumpBackupAdapter(backup_dir=tmpdir)
+        backups = adapter.list_backups("mydb")
+
+        assert len(backups) == 3
+        assert backups[0].timestamp >= backups[1].timestamp >= backups[2].timestamp
+        assert all(b.db_name == "mydb" for b in backups)
+        assert all(b.size_bytes > 0 for b in backups)
+
+
+def test_rotate_keeps_last_n() -> None:
+    """rotate(keep_last=2) deletes oldest backups, keeps 2 most recent."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_dir = Path(tmpdir) / "rotdb"
+        db_dir.mkdir()
+
+        import os
+
+        # Create 4 backups with different timestamps
+        files = []
+        for day in [1, 2, 3, 4]:
+            f = db_dir / f"rotdb_2026050{day}_060000.sql.gz"
+            f.write_text(f"data day {day}" * 50)
+            ts = datetime(2026, 5, day, 6, 0, 0, tzinfo=UTC).timestamp()
+            os.utime(f, (ts, ts))
+            files.append(f)
+
+        adapter = PgDumpBackupAdapter(backup_dir=tmpdir)
+        result = adapter.rotate("rotdb", keep_last=2)
+
+        assert result.success is True
+        assert result.kept == 2
+        assert result.deleted == 2
+        assert result.freed_bytes > 0
+
+        # Verify only newest 2 remain
+        remaining = list(db_dir.iterdir())
+        assert len(remaining) == 2
+        remaining_names = sorted(f.name for f in remaining)
+        assert "rotdb_20260503_060000.sql.gz" in remaining_names
+        assert "rotdb_20260504_060000.sql.gz" in remaining_names


### PR DESCRIPTION
## Summary

ADR-029 Step 1/4 — BackupPort abstraction + PgDumpBackupAdapter + 6 unit tests.

- `services/backup/backup_port.py` — Protocol with 4 methods: backup, restore, list_backups, rotate
- `services/backup/pg_backup_adapter.py` — pg_dump/pg_restore implementation
- `tests/unit/backup/test_backup_port.py` — 6 unit tests (all mocked, no real PG)

## Gap refs

- G-OPS-01 (backup rotation policy not defined)
- G-OPS-02 (backup-restore CI smoke test absent)

## Tests

- 6 new unit tests, all PASS
- Lint clean (ruff check + ruff format)
- All pre-commit hooks PASS

## ADR-029 progress

| Step | Description | Status |
|------|-------------|--------|
| **1** | **BackupPort + PgDumpBackupAdapter + 6 tests** | **This PR** |
| 2 | DI wiring + integration tests | Next |
| 3 | Cron script + CI smoke | Next |
| 4 | Flip ADR Proposed→Accepted + close G-OPS-01/02 | Next |

## Инструкция оператору после merge (§7)

```bash
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
```