### PR TITLE
feat(adr-035): add nightly full smoke gate workflow [Step 4]

### DIFF
--- a/.github/workflows/smoke-gate-full.yml
+++ b/.github/workflows/smoke-gate-full.yml
@@ -1,0 +1,79 @@
+name: Smoke Gate — Full Tier (ADR-035)
+# ADR-035 Step 4 | banxe-emi-stack
+#
+# Nightly full/live smoke gate. Brings up real infra (postgres, redis, clickhouse,
+# frankfurter) via docker/docker-compose.master.yml, then runs the smoke suite.
+#
+# Not a PR required check (that is smoke-gate-mock.yml / Step 2).
+# Failure triggers Step 5 alerting (CI_SMOKE_FAILURE AuditEvent).
+#
+# docker/docker-compose.master.yml `api` service is excluded — it requires
+# docker/Dockerfile which is not yet present; the test runner connects directly
+# to infra services via env vars.
+
+on:
+  schedule:
+    - cron: "0 3 * * *"   # 03:00 UTC nightly
+  workflow_dispatch:        # manual trigger for ad-hoc runs
+
+concurrency:
+  group: smoke-gate-full
+  cancel-in-progress: false  # never cancel a running nightly; queue instead
+
+jobs:
+  smoke-full:
+    name: Smoke Gate (real stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    env:
+      POSTGRES_USER: banxe
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_DB: banxe
+      DATABASE_URL: postgresql+asyncpg://banxe:changeme@localhost:5432/banxe
+      REDIS_URL: redis://localhost:6379/0
+      CLICKHOUSE_HOST: localhost
+      FRANKFURTER_BASE_URL: http://localhost:8087
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start infra services (postgres, redis, clickhouse, frankfurter)
+        run: |
+          docker compose -f docker/docker-compose.master.yml up -d \
+            postgres redis clickhouse frankfurter
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio httpx
+
+      - name: Wait for infra healthchecks
+        run: |
+          echo "Waiting for postgres..."
+          until docker compose -f docker/docker-compose.master.yml exec -T postgres \
+            pg_isready -U banxe; do sleep 2; done
+          echo "Waiting for redis..."
+          until docker compose -f docker/docker-compose.master.yml exec -T redis \
+            redis-cli ping | grep -q PONG; do sleep 2; done
+          echo "Waiting for clickhouse..."
+          until docker compose -f docker/docker-compose.master.yml exec -T clickhouse \
+            clickhouse-client --query "SELECT 1" 2>/dev/null; do sleep 2; done
+          echo "Waiting for frankfurter..."
+          until curl -sf http://localhost:8087/health; do sleep 2; done
+          echo "All infra services healthy."
+
+      - name: Run smoke suite (full tier)
+        run: |
+          python -m pytest tests/test_smoke/ \
+            --override-ini=addopts= \
+            -q --tb=short
+
+      - name: Tear down infra
+        if: always()
+        run: docker compose -f docker/docker-compose.master.yml down -v --remove-orphans


### PR DESCRIPTION
## ADR-035 Step 4 — Nightly Full/Live Smoke Gate Workflow

### What
Adds `.github/workflows/smoke-gate-full.yml` — the nightly full/live tier of the ADR-035 hybrid smoke gate (Option c).

### Scope
- **Implements:** ADR-035 Step 4 only
- **Step 1** (mock smoke surface matrix) — already in `main`
- **Step 2** (smoke-gate-mock.yml PR required check) — PR #101, pending merge
- **Step 3** (branch-protection required-check wiring) — already applied to `main` protection
- **This PR** adds only the nightly workflow file (79 lines, no product code changes)

### Workflow behaviour
| Property | Value |
|----------|-------|
| Trigger | `schedule: cron: '0 3 * * *'` (03:00 UTC) + `workflow_dispatch` |
| Job name | `Smoke Gate (real stack)` |
| timeout-minutes | 12 |
| concurrency | `cancel-in-progress: false` (never cancel a running nightly) |
| Infra | `docker compose -f docker/docker-compose.master.yml up -d postgres redis clickhouse frankfurter` |
| Test command | `pytest tests/test_smoke/ --override-ini=addopts= -q --tb=short` |
| Cleanup | `docker compose down -v --remove-orphans` (always) |

### Known constraint
`docker/docker-compose.master.yml` `api` service is excluded — it references `docker/Dockerfile` which does not yet exist. The Python test runner connects directly to infra services via env vars (`DATABASE_URL`, `REDIS_URL`, `CLICKHOUSE_HOST`, `FRANKFURTER_BASE_URL`).

### Secrets / env vars required in repo
None at this step — infra uses default dev credentials hard-coded in docker-compose (not production). Production secrets are out of scope for the nightly smoke gate.

### What remains (separate PR)
- **Step 5:** on `smoke-gate-full` failure, emit `AuditEvent` of type `CI_SMOKE_FAILURE` via ADR-027 `BufferedAuditPort` + GitHub notification routing (G-OBS-01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)