### PR TITLE
feat(adr-029): wire Postgres backup into DI + integration tests [Step 2]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,3 +105,13 @@ MODULR_API_SECRET=your_modulr_api_secret
 MODULR_EUR_ACCOUNT_ID=your_modulr_eur_account_id
 # Only needed for production (sandbox=False); defaults to https://api.modulrfinance.com
 MODULR_API_URL=https://api.modulrfinance.com
+
+# === PostgreSQL Backup (ADR-029) ===
+# Feature flag — set to "true" to enable backup operations
+BACKUP_ENABLED=false
+BACKUP_PG_HOST=localhost
+BACKUP_PG_PORT=5432
+BACKUP_PG_USER=banxe
+BACKUP_PG_PASSWORD=
+BACKUP_DIR=/data/banxe/backups
+BACKUP_RETENTION_COUNT=7

--- a/services/backup/__init__.py
+++ b/services/backup/__init__.py
@@ -7,13 +7,17 @@ from services.backup.backup_port import (
     RestoreResult,
     RotationResult,
 )
+from services.backup.factory import BackupConfig, BackupDisabledError, get_backup_adapter
 from services.backup.pg_backup_adapter import PgDumpBackupAdapter
 
 __all__ = [
+    "BackupConfig",
+    "BackupDisabledError",
     "BackupMetadata",
     "BackupPort",
     "BackupResult",
     "PgDumpBackupAdapter",
     "RestoreResult",
     "RotationResult",
+    "get_backup_adapter",
 ]

--- a/services/backup/factory.py
+++ b/services/backup/factory.py
@@ -1,0 +1,70 @@
+"""Backup DI factory — creates configured PgDumpBackupAdapter from env (ADR-029).
+
+Reads connection parameters and backup config from environment variables.
+Feature flag BACKUP_ENABLED controls whether backup operations are active.
+
+Usage:
+    from services.backup.factory import get_backup_adapter
+    adapter = get_backup_adapter()  # raises BackupDisabledError if disabled
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+from services.backup.pg_backup_adapter import PgDumpBackupAdapter
+
+
+class BackupDisabledError(Exception):
+    """Raised when backup operations are attempted while BACKUP_ENABLED=false."""
+
+
+@dataclass(frozen=True)
+class BackupConfig:
+    """Configuration for PgDumpBackupAdapter, loaded from environment."""
+
+    enabled: bool
+    pg_host: str
+    pg_port: int
+    pg_user: str
+    pg_password: str
+    backup_dir: str
+    retention_count: int
+
+    @classmethod
+    def from_env(cls) -> BackupConfig:
+        """Load backup config from environment variables."""
+        return cls(
+            enabled=os.environ.get("BACKUP_ENABLED", "false").lower() == "true",
+            pg_host=os.environ.get("BACKUP_PG_HOST", "localhost"),
+            pg_port=int(os.environ.get("BACKUP_PG_PORT", "5432")),
+            pg_user=os.environ.get("BACKUP_PG_USER", "banxe"),
+            pg_password=os.environ.get("BACKUP_PG_PASSWORD", ""),
+            backup_dir=os.environ.get("BACKUP_DIR", "/data/banxe/backups"),
+            retention_count=int(os.environ.get("BACKUP_RETENTION_COUNT", "7")),
+        )
+
+
+def get_backup_adapter(config: BackupConfig | None = None) -> PgDumpBackupAdapter:
+    """Create a configured PgDumpBackupAdapter from environment.
+
+    Raises:
+        BackupDisabledError: if BACKUP_ENABLED is not "true".
+    """
+    cfg = config or BackupConfig.from_env()
+
+    if not cfg.enabled:
+        raise BackupDisabledError(
+            "Backup operations disabled (BACKUP_ENABLED != 'true'). "
+            "Set BACKUP_ENABLED=true in environment to enable."
+        )
+
+    return PgDumpBackupAdapter(
+        pg_host=cfg.pg_host,
+        pg_port=cfg.pg_port,
+        pg_user=cfg.pg_user,
+        pg_password=cfg.pg_password,
+        backup_dir=cfg.backup_dir,
+        retention_count=cfg.retention_count,
+    )

--- a/tests/integration/test_backup_integration.py
+++ b/tests/integration/test_backup_integration.py
@@ -1,0 +1,112 @@
+"""Integration tests for ADR-029 Step 2: DI wiring + backup roundtrip.
+
+Gap refs: G-OPS-01 (backup rotation policy) | G-OPS-02 (restore drill)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import os
+from pathlib import Path
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.backup.factory import BackupDisabledError, get_backup_adapter
+from services.backup.pg_backup_adapter import PgDumpBackupAdapter
+
+
+def test_factory_creates_adapter_from_env() -> None:
+    """Factory returns PgDumpBackupAdapter with correct params from env."""
+    env = {
+        "BACKUP_ENABLED": "true",
+        "BACKUP_PG_HOST": "192.168.0.72",
+        "BACKUP_PG_PORT": "15433",
+        "BACKUP_PG_USER": "marble",
+        "BACKUP_PG_PASSWORD": "secret123",
+        "BACKUP_DIR": "/tmp/test-backups",
+        "BACKUP_RETENTION_COUNT": "14",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        adapter = get_backup_adapter()
+
+    assert isinstance(adapter, PgDumpBackupAdapter)
+    assert adapter._pg_host == "192.168.0.72"
+    assert adapter._pg_port == 15433
+    assert adapter._pg_user == "marble"
+    assert adapter._pg_password == "secret123"
+    assert str(adapter._backup_dir) == "/tmp/test-backups"
+    assert adapter._retention_count == 14
+
+
+def test_factory_disabled_flag() -> None:
+    """BACKUP_ENABLED=false raises BackupDisabledError."""
+    env = {"BACKUP_ENABLED": "false"}
+    with patch.dict(os.environ, env, clear=False):
+        with pytest.raises(BackupDisabledError, match="disabled"):
+            get_backup_adapter()
+
+
+def test_factory_disabled_by_default() -> None:
+    """Default (no BACKUP_ENABLED set) raises BackupDisabledError."""
+    env_clean = {k: v for k, v in os.environ.items() if k != "BACKUP_ENABLED"}
+    with patch.dict(os.environ, env_clean, clear=True):
+        with pytest.raises(BackupDisabledError):
+            get_backup_adapter()
+
+
+def test_backup_and_list_roundtrip() -> None:
+    """Backup creates entry visible in list_backups (mock subprocess)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        adapter = PgDumpBackupAdapter(backup_dir=tmpdir, retention_count=7)
+
+        with patch("services.backup.pg_backup_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+
+            # Perform backup (pg_dump mocked)
+            result = adapter.backup("keycloak")
+            assert result.success is True
+
+            # Create the file that pg_dump would have created
+            Path(result.path).parent.mkdir(parents=True, exist_ok=True)
+            Path(result.path).write_text("fake backup data")
+
+        # List should find it
+        backups = adapter.list_backups("keycloak")
+        assert len(backups) == 1
+        assert backups[0].db_name == "keycloak"
+        assert backups[0].size_bytes > 0
+
+
+def test_rotate_integration() -> None:
+    """Rotate with 10 backups and keep_last=7 removes 3 oldest."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_dir = Path(tmpdir) / "compliance_db"
+        db_dir.mkdir()
+
+        # Create 10 backup files with sequential timestamps
+        for day in range(1, 11):
+            f = db_dir / f"compliance_db_2026050{day:02d}_060000.sql.gz"
+            f.write_text(f"backup data day {day}" * 100)
+            ts = datetime(2026, 5, day, 6, 0, 0, tzinfo=UTC).timestamp()
+            os.utime(f, (ts, ts))
+
+        adapter = PgDumpBackupAdapter(backup_dir=tmpdir, retention_count=7)
+
+        # Verify 10 backups exist
+        assert len(adapter.list_backups("compliance_db")) == 10
+
+        # Rotate: keep 7
+        result = adapter.rotate("compliance_db", keep_last=7)
+        assert result.success is True
+        assert result.kept == 7
+        assert result.deleted == 3
+        assert result.freed_bytes > 0
+
+        # Verify only 7 remain (newest)
+        remaining = adapter.list_backups("compliance_db")
+        assert len(remaining) == 7
+        # Oldest remaining should be day 4 (days 1,2,3 deleted)
+        oldest_remaining = remaining[-1]
+        assert "04" in oldest_remaining.path or "05" in oldest_remaining.path


### PR DESCRIPTION
## Summary

ADR-029 Step 2/4 — DI factory wiring + BACKUP_ENABLED feature flag + 5 integration tests.

- `services/backup/factory.py` — `BackupConfig.from_env()` + `get_backup_adapter()` + `BackupDisabledError`
- `tests/integration/test_backup_integration.py` — 5 integration tests
- `.env.example` — new BACKUP_* env vars documented
- `services/backup/__init__.py` — updated exports

## Gap refs

- G-OPS-01 (backup rotation policy)
- G-OPS-02 (backup-restore CI smoke test)

## Tests

- 5 new integration + 6 existing unit = 11 total, all PASS
- Lint clean (ruff check + ruff format)
- All pre-commit hooks PASS

## ADR-029 progress

| Step | Description | Status |
|------|-------------|--------|
| 1 | BackupPort + PgDumpBackupAdapter + 6 tests | ✅ on main (PR #102) |
| **2** | **DI wiring + BACKUP_ENABLED + 5 integration tests** | **This PR** |
| 3 | Cron script + CI smoke | Next |
| 4 | Flip ADR Proposed→Accepted + close G-OPS-01/02 | Next |

## Инструкция оператору после merge (§7)

```bash
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
```