### PR TITLE
feat(adr-035): emit CI_SMOKE_FAILURE audit signal on nightly smoke gate [Step 5]

### DIFF
--- a/.github/workflows/smoke-gate-full.yml
+++ b/.github/workflows/smoke-gate-full.yml
@@ -1,0 +1,84 @@
+name: Smoke Gate — Full Tier (ADR-035)
+# ADR-035 Step 4 + Step 5 | banxe-emi-stack
+#
+# Nightly full/live smoke gate. Brings up real infra (postgres, redis, clickhouse,
+# frankfurter) via docker/docker-compose.master.yml, then runs the smoke suite.
+# On failure, emits CI_SMOKE_FAILURE AuditEvent via ADR-027 BufferedAuditPort (Step 5).
+#
+# Not a PR required check (that is smoke-gate-mock.yml).
+#
+# docker/docker-compose.master.yml `api` service is excluded — it requires
+# docker/Dockerfile which is not yet present; the test runner connects directly
+# to infra services via env vars.
+
+on:
+  schedule:
+    - cron: "0 3 * * *"   # 03:00 UTC nightly
+  workflow_dispatch:        # manual trigger for ad-hoc runs
+
+concurrency:
+  group: smoke-gate-full
+  cancel-in-progress: false  # never cancel a running nightly; queue instead
+
+jobs:
+  smoke-full:
+    name: Smoke Gate (real stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    env:
+      POSTGRES_USER: banxe
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_DB: banxe
+      DATABASE_URL: postgresql+asyncpg://banxe:changeme@localhost:5432/banxe
+      REDIS_URL: redis://localhost:6379/0
+      CLICKHOUSE_HOST: localhost
+      CLICKHOUSE_DB: banxe
+      FRANKFURTER_BASE_URL: http://localhost:8087
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start infra services (postgres, redis, clickhouse, frankfurter)
+        run: |
+          docker compose -f docker/docker-compose.master.yml up -d \
+            postgres redis clickhouse frankfurter
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio httpx
+
+      - name: Wait for infra healthchecks
+        run: |
+          echo "Waiting for postgres..."
+          until docker compose -f docker/docker-compose.master.yml exec -T postgres \
+            pg_isready -U banxe; do sleep 2; done
+          echo "Waiting for redis..."
+          until docker compose -f docker/docker-compose.master.yml exec -T redis \
+            redis-cli ping | grep -q PONG; do sleep 2; done
+          echo "Waiting for clickhouse..."
+          until docker compose -f docker/docker-compose.master.yml exec -T clickhouse \
+            clickhouse-client --query "SELECT 1" 2>/dev/null; do sleep 2; done
+          echo "Waiting for frankfurter..."
+          until curl -sf http://localhost:8087/health; do sleep 2; done
+          echo "All infra services healthy."
+
+      - name: Run smoke suite (full tier)
+        run: |
+          python -m pytest tests/test_smoke/ \
+            --override-ini=addopts= \
+            -q --tb=short
+
+      - name: Emit CI_SMOKE_FAILURE audit signal
+        if: failure()
+        run: python3 scripts/emit_ci_smoke_failure.py
+
+      - name: Tear down infra
+        if: always()
+        run: docker compose -f docker/docker-compose.master.yml down -v --remove-orphans

--- a/scripts/emit_ci_smoke_failure.py
+++ b/scripts/emit_ci_smoke_failure.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""scripts/emit-ci-smoke-failure.py — ADR-035 Step 5
+
+Emits a CI_SMOKE_FAILURE AuditEvent when the nightly smoke-gate-full
+workflow fails. Called via `if: failure()` in smoke-gate-full.yml.
+
+Write path: AuditTrail → ClickHouse (direct, if CLICKHOUSE_HOST is set).
+Fallback:   BufferedAuditPort → SQLite ring-buffer (ADR-027 Option b).
+
+Always exits 0 — never block or re-fail CI on audit emission error.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import logging
+import os
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("banxe.ci-smoke-failure")
+
+# Repo root on sys.path so src.safeguarding imports work from scripts/
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.safeguarding.audit_trail import AuditEvent, AuditTrail  # noqa: E402
+
+
+def build_event() -> AuditEvent:
+    run_id = os.getenv("GITHUB_RUN_ID", "unknown")
+    repo = os.getenv("GITHUB_REPOSITORY", "CarmiBanxe/banxe-emi-stack")
+    return AuditEvent(
+        event_type="CI_SMOKE_FAILURE",
+        entity_id=f"ci-smoke-{run_id}",
+        actor="smoke-gate-full / GitHub Actions",
+        payload={
+            "workflow": "smoke-gate-full.yml",
+            "run_id": run_id,
+            "run_url": f"https://github.com/{repo}/actions/runs/{run_id}",
+            "tier": "full",
+            "occurred_at": datetime.now(UTC).isoformat(),
+        },
+        severity="CRITICAL",
+    )
+
+
+def emit() -> None:
+    event = build_event()
+
+    clickhouse_host = os.getenv("CLICKHOUSE_HOST", "")
+    if clickhouse_host:
+        ch_url = f"http://{clickhouse_host}:8123"
+        trail = AuditTrail(
+            clickhouse_url=ch_url,
+            database=os.getenv("CLICKHOUSE_DB", "banxe"),
+            dry_run=False,
+        )
+        if trail.log(event):
+            logger.info(
+                "CI_SMOKE_FAILURE → ClickHouse: event_id=%s run_id=%s",
+                event.event_id,
+                os.getenv("GITHUB_RUN_ID", "unknown"),
+            )
+            return
+        logger.warning("ClickHouse write failed — falling back to BufferedAuditPort")
+
+    from src.safeguarding.buffered_audit_port import BufferedAuditPort
+
+    buffer_path = os.getenv("AUDIT_BUFFER_PATH", "/tmp/banxe-audit-buffer.db")  # noqa: S108  # nosec B108
+    port = BufferedAuditPort(db_path=buffer_path)
+    port.record(event)
+    logger.info(
+        "CI_SMOKE_FAILURE → SQLite buffer: entity_id=%s path=%s",
+        event.entity_id,
+        buffer_path,
+    )
+
+
+def main() -> None:
+    try:
+        emit()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("CI_SMOKE_FAILURE emission error (non-fatal): %s", exc)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ci_smoke_failure_emitter.py
+++ b/tests/test_ci_smoke_failure_emitter.py
@@ -1,0 +1,160 @@
+"""tests/test_ci_smoke_failure_emitter.py — ADR-035 Step 5 unit tests.
+
+Covers scripts/emit-ci-smoke-failure.py: event construction, routing logic,
+and resilience (always exits 0).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure repo root is importable (mirrors how the script bootstraps itself)
+REPO_ROOT = str(Path(__file__).parent.parent)
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+import scripts.emit_ci_smoke_failure as emitter  # type: ignore[import]
+
+# ── build_event() ─────────────────────────────────────────────────────────────
+
+
+def test_build_event_type() -> None:
+    event = emitter.build_event()
+    assert event.event_type == "CI_SMOKE_FAILURE"
+
+
+def test_build_event_severity_critical() -> None:
+    event = emitter.build_event()
+    assert event.severity == "CRITICAL"
+
+
+def test_build_event_actor_contains_smoke_gate() -> None:
+    event = emitter.build_event()
+    assert "smoke-gate-full" in event.actor
+
+
+def test_build_event_entity_id_contains_run_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", "99887766")
+    event = emitter.build_event()
+    assert "99887766" in event.entity_id
+
+
+def test_build_event_payload_workflow_name() -> None:
+    event = emitter.build_event()
+    assert event.payload["workflow"] == "smoke-gate-full.yml"
+
+
+def test_build_event_payload_run_id_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345678")
+    event = emitter.build_event()
+    assert event.payload["run_id"] == "12345678"
+
+
+def test_build_event_payload_tier_is_full() -> None:
+    event = emitter.build_event()
+    assert event.payload["tier"] == "full"
+
+
+def test_build_event_payload_run_url_contains_github(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", "55544433")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "CarmiBanxe/banxe-emi-stack")
+    event = emitter.build_event()
+    assert "github.com" in event.payload["run_url"]
+    assert "55544433" in event.payload["run_url"]
+
+
+def test_build_event_payload_occurred_at_is_iso() -> None:
+    import re
+
+    event = emitter.build_event()
+    iso_pattern = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+    assert re.match(iso_pattern, event.payload["occurred_at"])
+
+
+def test_build_event_has_unique_event_id() -> None:
+    e1 = emitter.build_event()
+    e2 = emitter.build_event()
+    assert e1.event_id != e2.event_id
+
+
+# ── emit() routing logic ───────────────────────────────────────────────────────
+
+
+def test_emit_uses_audit_trail_when_clickhouse_host_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLICKHOUSE_HOST", "localhost")
+    mock_trail = MagicMock()
+    mock_trail.log.return_value = True
+    with patch("scripts.emit_ci_smoke_failure.AuditTrail", return_value=mock_trail):
+        emitter.emit()
+    mock_trail.log.assert_called_once()
+
+
+def test_emit_uses_buffered_port_when_no_clickhouse_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLICKHOUSE_HOST", raising=False)
+    mock_port = MagicMock()
+    with (
+        patch("scripts.emit_ci_smoke_failure.AuditTrail") as mock_trail_cls,
+        patch("src.safeguarding.buffered_audit_port.BufferedAuditPort", return_value=mock_port),
+    ):
+        emitter.emit()
+    mock_trail_cls.assert_not_called()
+    mock_port.record.assert_called_once()
+
+
+def test_emit_falls_back_to_buffer_when_clickhouse_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLICKHOUSE_HOST", "localhost")
+    mock_trail = MagicMock()
+    mock_trail.log.return_value = False  # write failed
+    mock_port = MagicMock()
+    with (
+        patch("scripts.emit_ci_smoke_failure.AuditTrail", return_value=mock_trail),
+        patch("src.safeguarding.buffered_audit_port.BufferedAuditPort", return_value=mock_port),
+    ):
+        emitter.emit()
+    mock_port.record.assert_called_once()
+
+
+def test_emit_uses_audit_buffer_path_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("CLICKHOUSE_HOST", raising=False)
+    db_path = str(tmp_path / "test-audit.db")
+    monkeypatch.setenv("AUDIT_BUFFER_PATH", db_path)
+    emitter.emit()
+    assert Path(db_path).exists()
+
+
+def test_emit_uses_clickhouse_db_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLICKHOUSE_HOST", "localhost")
+    monkeypatch.setenv("CLICKHOUSE_DB", "banxe_test")
+    mock_trail = MagicMock()
+    mock_trail.log.return_value = True
+    with patch("scripts.emit_ci_smoke_failure.AuditTrail", return_value=mock_trail) as cls:
+        emitter.emit()
+    _, kwargs = cls.call_args
+    assert kwargs.get("database") == "banxe_test"
+
+
+# ── main() resilience ─────────────────────────────────────────────────────────
+
+
+def test_main_exits_zero_on_success() -> None:
+    with (
+        patch("scripts.emit_ci_smoke_failure.emit"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        emitter.main()
+    assert exc_info.value.code == 0
+
+
+def test_main_exits_zero_even_on_emit_exception() -> None:
+    with (
+        patch("scripts.emit_ci_smoke_failure.emit", side_effect=RuntimeError("boom")),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        emitter.main()
+    assert exc_info.value.code == 0


### PR DESCRIPTION
## ADR-035 Step 5 — CI_SMOKE_FAILURE Audit Signal

### What this PR does (Step 5 only)

Implements the observability/audit hook that fires when the nightly full-tier smoke gate fails.
No other ADR-035 steps are bundled here.

### New files

| File | Purpose |
|------|---------|
| `scripts/emit_ci_smoke_failure.py` | Emits `CI_SMOKE_FAILURE` AuditEvent on nightly failure |
| `.github/workflows/smoke-gate-full.yml` | Nightly full/live smoke gate (cron 03:00 UTC) with `if: failure()` hook |
| `tests/test_ci_smoke_failure_emitter.py` | 17 unit tests — event construction, routing, resilience |

### ADR-027 integration points

- **Primary write path**: `AuditTrail` → ClickHouse HTTP API (`CLICKHOUSE_HOST:8123`)
- **Fallback (ClickHouse unreachable or write fails)**: `BufferedAuditPort` → SQLite WAL ring-buffer (`AUDIT_BUFFER_PATH`, default `/tmp/banxe-audit-buffer.db`)
- **Script always exits 0** — audit emission errors are logged but never re-fail CI

### Failure signal definition

`CI_SMOKE_FAILURE` is emitted when `pytest tests/test_smoke/` fails inside `smoke-gate-full.yml`.

Event shape:
```json
{
  "event_type": "CI_SMOKE_FAILURE",
  "severity": "CRITICAL",
  "entity_id": "ci-smoke-{GITHUB_RUN_ID}",
  "actor": "smoke-gate-full / GitHub Actions",
  "payload": {
    "workflow": "smoke-gate-full.yml",
    "run_id": "<GITHUB_RUN_ID>",
    "run_url": "https://github.com/CarmiBanxe/banxe-emi-stack/actions/runs/<id>",
    "tier": "full",
    "occurred_at": "<ISO-8601 UTC>"
  }
}
```

### Routing / notification assumptions

**G-OBS-01 is NOT implemented** — no Slack, PagerDuty, or notification routing primitives exist in this repo. Routing is via **GitHub's built-in workflow failure notifications** (email + GitHub notification bell). This is documented as a constraint, not deferred work.

### Supersedes PR #103

PR #103 (`feat(adr-035): add nightly full smoke gate workflow [Step 4]`) contained `smoke-gate-full.yml` without the Step 5 failure hook. This PR includes the complete `smoke-gate-full.yml` (Step 4 + Step 5 combined). PR #103 should be closed as superseded.

### Infrastructure note

`api` service excluded from `docker compose up` — `docker/Dockerfile` does not yet exist. Test runner connects to infra (postgres, redis, clickhouse, frankfurter) directly via env vars.

### Tests

```
tests/test_ci_smoke_failure_emitter.py — 17 passed in 0.07s
```

All pre-commit gates passed: Spec-First Auditor, Ruff, Bandit, Semgrep, pytest-fast.

## Test plan
- [ ] Confirm `smoke-gate-full.yml` triggers on `workflow_dispatch` (manual run)
- [ ] Verify `if: failure()` step fires when smoke suite fails
- [ ] Confirm BufferedAuditPort SQLite fallback works without `CLICKHOUSE_HOST`
- [ ] Close PR #103 as superseded

🤖 Generated with [Claude Code](https://claude.com/claude-code)