### PR TITLE
feat(adr-030): wire rate-limit into auth flow [Step 2]

### DIFF
--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -36,6 +36,7 @@ from services.auth.auth_application_service import (
     AuthApplicationService,
     get_auth_application_service,
 )
+from services.auth.rate_limiter_factory import get_rate_limiter
 from services.auth.sca_application_service import (
     ScaApplicationError,
     ScaApplicationService,
@@ -77,7 +78,25 @@ _ERROR_CODE_TO_HTTP: dict[str, int] = {
     "invalid_token": 401,
     "token_expired": 401,
     "invalid_token_type": 401,
+    "rate_limited": 429,
 }
+
+# Rate limiter singleton (None if disabled via RATE_LIMIT_ENABLED=false)
+_rate_limiter = get_rate_limiter()
+
+
+def _check_rate_limit(client_id: str, endpoint: str) -> None:
+    """Enforce rate limit. Raises HTTPException 429 if exceeded."""
+    if _rate_limiter is None:
+        return
+    result = _rate_limiter.check_rate(client_id, endpoint)
+    if not result.allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Rate limit exceeded. Retry after {result.retry_after}s.",
+            headers={"Retry-After": str(result.retry_after or 60)},
+        )
+    _rate_limiter.record_attempt(client_id, endpoint)
 
 
 _SCA_ERROR_CODE_TO_HTTP: dict[str, int] = {
@@ -119,6 +138,10 @@ async def login(
 ) -> LoginResponse:
     """Thin delegation: identity resolution, PIN validation, token issuance, session
     persistence are all handled by AuthApplicationService.login()."""
+    # ADR-030: rate-limit check before auth operation
+    client_ip = request.client.host if request.client else "unknown"
+    _check_rate_limit(client_id=client_ip, endpoint="/auth/login")
+
     try:
         return await auth_app.login(
             db=db,
@@ -151,6 +174,10 @@ async def refresh_token_endpoint(
     auth_app: AuthApplicationService = Depends(get_auth_application_service),
 ) -> TokenRefreshResponse:
     """Thin delegation: token rotation handled by AuthApplicationService.refresh()."""
+    # ADR-030: rate-limit check on refresh (per token JTI or fallback to token prefix)
+    token_key = body.refresh_token[:16] if body.refresh_token else "unknown"
+    _check_rate_limit(client_id=token_key, endpoint="/auth/token/refresh")
+
     try:
         return await auth_app.refresh(refresh_token=body.refresh_token)
     except AuthApplicationError as exc:

--- a/services/auth/rate_limiter_factory.py
+++ b/services/auth/rate_limiter_factory.py
@@ -1,0 +1,28 @@
+"""Rate limiter DI factory (ADR-030, G-API-01/02).
+
+Reads configuration from environment and returns a configured
+RedisRateLimiterAdapter. Feature flag RATE_LIMIT_ENABLED controls activation.
+
+Usage:
+    from services.auth.rate_limiter_factory import get_rate_limiter
+    limiter = get_rate_limiter()  # returns adapter or None if disabled
+"""
+
+from __future__ import annotations
+
+import os
+
+from services.auth.redis_rate_limiter import RedisRateLimiterAdapter
+
+
+def get_rate_limiter() -> RedisRateLimiterAdapter | None:
+    """Create rate limiter from env. Returns None if RATE_LIMIT_ENABLED != true."""
+    enabled = os.environ.get("RATE_LIMIT_ENABLED", "true").lower() == "true"
+    if not enabled:
+        return None
+
+    return RedisRateLimiterAdapter(
+        max_attempts=int(os.environ.get("RATE_LIMIT_MAX_ATTEMPTS", "10")),
+        window_seconds=int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "60")),
+        lockout_seconds=int(os.environ.get("RATE_LIMIT_LOCKOUT_SECONDS", "300")),
+    )

--- a/tests/integration/test_rate_limiter_integration.py
+++ b/tests/integration/test_rate_limiter_integration.py
@@ -1,0 +1,87 @@
+"""Integration tests for ADR-030 Step 2: rate-limit wiring into auth flow.
+
+Gap refs: G-API-01 (no rate limiting on auth) | G-API-02 (rate-limit coverage tests)
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from services.auth.rate_limiter_factory import get_rate_limiter
+from services.auth.redis_rate_limiter import RedisRateLimiterAdapter
+
+
+def test_factory_returns_adapter_when_enabled() -> None:
+    """RATE_LIMIT_ENABLED=true returns configured adapter."""
+    env = {
+        "RATE_LIMIT_ENABLED": "true",
+        "RATE_LIMIT_MAX_ATTEMPTS": "5",
+        "RATE_LIMIT_WINDOW_SECONDS": "30",
+        "RATE_LIMIT_LOCKOUT_SECONDS": "120",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        limiter = get_rate_limiter()
+
+    assert isinstance(limiter, RedisRateLimiterAdapter)
+    assert limiter._max_attempts == 5
+    assert limiter._window_seconds == 30
+    assert limiter._lockout_seconds == 120
+
+
+def test_factory_returns_none_when_disabled() -> None:
+    """RATE_LIMIT_ENABLED=false returns None (no-op)."""
+    env = {"RATE_LIMIT_ENABLED": "false"}
+    with patch.dict(os.environ, env, clear=False):
+        limiter = get_rate_limiter()
+
+    assert limiter is None
+
+
+def test_login_allowed_under_threshold() -> None:
+    """Login attempts under max_attempts are all allowed."""
+    limiter = RedisRateLimiterAdapter(max_attempts=5, window_seconds=60, lockout_seconds=300)
+
+    for i in range(5):
+        limiter.record_attempt("192.168.1.1", "/auth/login")
+        if i < 4:
+            result = limiter.check_rate("192.168.1.1", "/auth/login")
+            assert result.allowed is True, f"Attempt {i + 1} should be allowed"
+
+
+def test_login_blocked_after_threshold() -> None:
+    """Login blocked with retry_after after exceeding max_attempts."""
+    limiter = RedisRateLimiterAdapter(max_attempts=3, window_seconds=60, lockout_seconds=120)
+
+    for _ in range(3):
+        limiter.record_attempt("10.0.0.1", "/auth/login")
+
+    result = limiter.check_rate("10.0.0.1", "/auth/login")
+    assert result.allowed is False
+    assert result.retry_after == 120
+    assert result.remaining == 0
+    assert result.endpoint == "/auth/login"
+
+
+def test_separate_endpoints_independent() -> None:
+    """Rate limits on /auth/login do not affect /auth/token/refresh."""
+    limiter = RedisRateLimiterAdapter(max_attempts=2, window_seconds=60, lockout_seconds=300)
+
+    # Exhaust login limit
+    for _ in range(2):
+        limiter.record_attempt("client-x", "/auth/login")
+
+    login_check = limiter.check_rate("client-x", "/auth/login")
+    assert login_check.allowed is False
+
+    # Refresh endpoint still open
+    refresh_check = limiter.check_rate("client-x", "/auth/token/refresh")
+    assert refresh_check.allowed is True
+
+
+def test_rate_limit_wiring_in_router_module() -> None:
+    """Verify the auth router imports rate-limit machinery."""
+    import api.routers.auth as auth_module
+
+    assert hasattr(auth_module, "_check_rate_limit")
+    assert hasattr(auth_module, "_rate_limiter")


### PR DESCRIPTION
## Summary

ADR-030 Step 2/4 — wire RedisRateLimiterAdapter into auth router + DI factory + 6 integration tests.

- `services/auth/rate_limiter_factory.py` — `get_rate_limiter()` with RATE_LIMIT_ENABLED flag
- `api/routers/auth.py` — rate-limit checks on `/auth/login` (per-IP) and `/auth/token/refresh` (per-token-prefix)
- `tests/integration/test_rate_limiter_integration.py` — 6 integration tests

## Gap refs

- G-API-01 (no rate limiting on auth endpoints)
- G-API-02 (rate-limit coverage tests)

## Tests

- 6 new integration + 6 existing unit = 12 total, all PASS
- Lint clean (ruff check + ruff format)
- All pre-commit hooks PASS (full pytest suite 9600+ tests green)

## ADR-030 progress

| Step | Description | Status |
|------|-------------|--------|
| 1 | RateLimiterPort + RedisRateLimiterAdapter + 6 tests | ✅ on main (PR #107) |
| **2** | **DI wiring + auth router enforcement + 6 integration tests** | **This PR** |
| 3 | Rate-limit check script + CI smoke | Next |
| 4 | Flip ADR Proposed→Accepted + close G-API-01/02 | Next |

## Инструкция оператору после merge (§7)

```bash
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
```