### PR TITLE
feat(adr-032): secret rotation port + adapter + unit tests [Step 1]

### DIFF
--- a/services/secrets/__init__.py
+++ b/services/secrets/__init__.py
@@ -1,0 +1,17 @@
+"""Secrets rotation subsystem (ADR-032, G-SEC-01)."""
+
+from services.secrets.env_secret_rotator import EnvSecretRotator
+from services.secrets.rotation_port import (
+    RotationResult,
+    RotationStatus,
+    SecretMetadata,
+    SecretRotationPort,
+)
+
+__all__ = [
+    "EnvSecretRotator",
+    "RotationResult",
+    "RotationStatus",
+    "SecretMetadata",
+    "SecretRotationPort",
+]

--- a/services/secrets/env_secret_rotator.py
+++ b/services/secrets/env_secret_rotator.py
@@ -1,0 +1,158 @@
+"""EnvSecretRotator — .env-based secret rotation (ADR-032, G-SEC-01).
+
+Rotates secrets stored in .env files by generating new values via
+secrets.token_urlsafe(32) and updating the file in place.
+
+Rotation metadata (timestamps) stored in a companion .rotation-state.json
+file alongside the .env to track last-rotated dates without exposing values.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+import logging
+from pathlib import Path
+import secrets
+
+from services.secrets.rotation_port import (
+    RotationResult,
+    RotationStatus,
+    SecretMetadata,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EnvSecretRotator:
+    """Concrete SecretRotationPort for .env file-based secrets."""
+
+    def __init__(
+        self,
+        *,
+        rotation_interval_days: int = 90,
+        env_file_path: str = ".env",
+        managed_keys: list[str] | None = None,
+    ) -> None:
+        self._interval_days = rotation_interval_days
+        self._env_path = Path(env_file_path)
+        self._managed_keys = managed_keys or []
+        self._state_path = self._env_path.parent / ".rotation-state.json"
+        self._state: dict[str, str] = self._load_state()
+
+    def _load_state(self) -> dict[str, str]:
+        """Load rotation state (last-rotated timestamps) from companion file."""
+        if self._state_path.exists():
+            return json.loads(self._state_path.read_text())
+        return {}
+
+    def _save_state(self) -> None:
+        """Persist rotation state."""
+        self._state_path.write_text(json.dumps(self._state, indent=2))
+
+    def _read_env(self) -> dict[str, str]:
+        """Parse .env file into key=value dict."""
+        if not self._env_path.exists():
+            return {}
+        result: dict[str, str] = {}
+        for line in self._env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            result[key.strip()] = value.strip()
+        return result
+
+    def _write_env(self, data: dict[str, str]) -> None:
+        """Write key=value pairs back to .env file, preserving comments."""
+        lines: list[str] = []
+        if self._env_path.exists():
+            for line in self._env_path.read_text().splitlines():
+                stripped = line.strip()
+                if stripped and not stripped.startswith("#") and "=" in stripped:
+                    key = stripped.partition("=")[0].strip()
+                    if key in data:
+                        lines.append(f"{key}={data[key]}")
+                        continue
+                lines.append(line)
+        else:
+            for key, value in data.items():
+                lines.append(f"{key}={value}")
+        self._env_path.write_text("\n".join(lines) + "\n")
+
+    def rotate(self, secret_id: str) -> RotationResult:
+        """Generate a new secret value and update the .env file."""
+        now = datetime.now(tz=UTC)
+
+        if secret_id not in self._managed_keys:
+            return RotationResult(
+                success=False,
+                secret_id=secret_id,
+                rotated_at=now,
+                next_due=now,
+                error=f"secret_id '{secret_id}' not in managed_keys",
+            )
+
+        env_data = self._read_env()
+        new_value = secrets.token_urlsafe(32)
+        env_data[secret_id] = new_value
+        self._write_env(env_data)
+
+        self._state[secret_id] = now.isoformat()
+        self._save_state()
+
+        next_due = now + timedelta(days=self._interval_days)
+        logger.info("rotated secret %s (next due: %s)", secret_id, next_due.date())
+        return RotationResult(success=True, secret_id=secret_id, rotated_at=now, next_due=next_due)
+
+    def get_rotation_status(self, secret_id: str) -> RotationStatus:
+        """Get rotation status for a specific secret."""
+        now = datetime.now(tz=UTC)
+        last_str = self._state.get(secret_id)
+        last_rotated = datetime.fromisoformat(last_str) if last_str else None
+
+        if last_rotated is None:
+            return RotationStatus(
+                secret_id=secret_id,
+                last_rotated=None,
+                next_due=None,
+                is_overdue=True,
+                days_until_due=0,
+            )
+
+        next_due = last_rotated + timedelta(days=self._interval_days)
+        days_until = (next_due - now).days
+        is_overdue = days_until < 0
+
+        return RotationStatus(
+            secret_id=secret_id,
+            last_rotated=last_rotated,
+            next_due=next_due,
+            is_overdue=is_overdue,
+            days_until_due=max(0, days_until),
+        )
+
+    def list_secrets(self) -> list[SecretMetadata]:
+        """List all managed secrets with metadata."""
+        result: list[SecretMetadata] = []
+        for key in self._managed_keys:
+            last_str = self._state.get(key)
+            last_rotated = datetime.fromisoformat(last_str) if last_str else None
+            result.append(
+                SecretMetadata(
+                    secret_id=key,
+                    managed=True,
+                    last_rotated=last_rotated,
+                    rotation_interval_days=self._interval_days,
+                )
+            )
+        return result
+
+    def check_overdue(self) -> list[SecretMetadata]:
+        """Return only secrets that are overdue for rotation."""
+        overdue: list[SecretMetadata] = []
+        for meta in self.list_secrets():
+            status = self.get_rotation_status(meta.secret_id)
+            if status.is_overdue:
+                overdue.append(meta)
+        return overdue

--- a/services/secrets/rotation_port.py
+++ b/services/secrets/rotation_port.py
@@ -1,0 +1,55 @@
+"""SecretRotationPort — abstract secret rotation interface (ADR-032, G-SEC-01).
+
+Defines the port for managed secret rotation. Concrete adapters
+(EnvSecretRotator) implement rotation for .env-based secrets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class RotationResult:
+    """Result of a secret rotation operation."""
+
+    success: bool
+    secret_id: str
+    rotated_at: datetime
+    next_due: datetime
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class RotationStatus:
+    """Current rotation status of a secret."""
+
+    secret_id: str
+    last_rotated: datetime | None
+    next_due: datetime | None
+    is_overdue: bool
+    days_until_due: int
+
+
+@dataclass(frozen=True)
+class SecretMetadata:
+    """Metadata for a managed secret."""
+
+    secret_id: str
+    managed: bool
+    last_rotated: datetime | None
+    rotation_interval_days: int
+
+
+class SecretRotationPort(Protocol):
+    """Abstract port for secret rotation operations (ADR-032)."""
+
+    def rotate(self, secret_id: str) -> RotationResult: ...
+
+    def get_rotation_status(self, secret_id: str) -> RotationStatus: ...
+
+    def list_secrets(self) -> list[SecretMetadata]: ...
+
+    def check_overdue(self) -> list[SecretMetadata]: ...

--- a/tests/unit/secrets/test_rotation_port.py
+++ b/tests/unit/secrets/test_rotation_port.py
@@ -1,0 +1,140 @@
+"""Unit tests for ADR-032 Step 1: SecretRotationPort + EnvSecretRotator.
+
+Gap ref: G-SEC-01 (secret rotation not defined)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+from pathlib import Path
+
+from services.secrets.env_secret_rotator import EnvSecretRotator
+
+
+def _make_env_file(tmp_path: Path, content: str) -> Path:
+    env_file = tmp_path / ".env"
+    env_file.write_text(content)
+    return env_file
+
+
+def test_rotate_generates_new_secret(tmp_path: Path) -> None:
+    """Rotation generates a new value different from original."""
+    env_file = _make_env_file(tmp_path, "MY_SECRET=old-value-123\nOTHER=keep\n")
+
+    rotator = EnvSecretRotator(
+        env_file_path=str(env_file),
+        managed_keys=["MY_SECRET"],
+        rotation_interval_days=90,
+    )
+    result = rotator.rotate("MY_SECRET")
+
+    assert result.success is True
+    assert result.secret_id == "MY_SECRET"
+    assert result.error is None
+
+    # Verify file was updated with new value
+    new_content = env_file.read_text()
+    assert "old-value-123" not in new_content
+    assert "MY_SECRET=" in new_content
+
+
+def test_rotate_preserves_other_vars(tmp_path: Path) -> None:
+    """Rotation of one key does not affect other env vars."""
+    env_file = _make_env_file(
+        tmp_path, "SECRET_A=aaa\nSECRET_B=bbb\n# comment\nUNMANAGED=keep-me\n"
+    )
+
+    rotator = EnvSecretRotator(
+        env_file_path=str(env_file),
+        managed_keys=["SECRET_A", "SECRET_B"],
+        rotation_interval_days=90,
+    )
+    rotator.rotate("SECRET_A")
+
+    new_content = env_file.read_text()
+    assert "SECRET_B=bbb" in new_content
+    assert "UNMANAGED=keep-me" in new_content
+    assert "# comment" in new_content
+
+
+def test_rotation_status_not_overdue(tmp_path: Path) -> None:
+    """Fresh rotation shows is_overdue=False."""
+    env_file = _make_env_file(tmp_path, "KEY=val\n")
+
+    rotator = EnvSecretRotator(
+        env_file_path=str(env_file),
+        managed_keys=["KEY"],
+        rotation_interval_days=90,
+    )
+    rotator.rotate("KEY")
+
+    status = rotator.get_rotation_status("KEY")
+    assert status.is_overdue is False
+    assert status.days_until_due > 80
+    assert status.last_rotated is not None
+
+
+def test_rotation_status_overdue(tmp_path: Path) -> None:
+    """Secret rotated 91 days ago is overdue."""
+    env_file = _make_env_file(tmp_path, "OLD_KEY=val\n")
+    state_file = tmp_path / ".rotation-state.json"
+
+    # Write state showing rotation 91 days ago
+    old_date = datetime.now(tz=UTC) - timedelta(days=91)
+    state_file.write_text(json.dumps({"OLD_KEY": old_date.isoformat()}))
+
+    rotator = EnvSecretRotator(
+        env_file_path=str(env_file),
+        managed_keys=["OLD_KEY"],
+        rotation_interval_days=90,
+    )
+
+    status = rotator.get_rotation_status("OLD_KEY")
+    assert status.is_overdue is True
+    assert status.days_until_due == 0
+
+
+def test_list_secrets_returns_managed(tmp_path: Path) -> None:
+    """list_secrets returns only managed_keys."""
+    env_file = _make_env_file(tmp_path, "A=1\nB=2\nC=3\n")
+
+    rotator = EnvSecretRotator(
+        env_file_path=str(env_file),
+        managed_keys=["A", "B"],
+        rotation_interval_days=90,
+    )
+
+    secrets_list = rotator.list_secrets()
+    assert len(secrets_list) == 2
+    ids = [s.secret_id for s in secrets_list]
+    assert "A" in ids
+    assert "B" in ids
+    assert "C" not in ids
+    assert all(s.managed is True for s in secrets_list)
+
+
+def test_check_overdue_returns_only_overdue(tmp_path: Path) -> None:
+    """check_overdue filters to only overdue secrets."""
+    env_file = _make_env_file(tmp_path, "FRESH=x\nSTALE=y\n")
+    state_file = tmp_path / ".rotation-state.json"
+
+    now = datetime.now(tz=UTC)
+    state_file.write_text(
+        json.dumps(
+            {
+                "FRESH": now.isoformat(),  # just rotated
+                "STALE": (now - timedelta(days=100)).isoformat(),  # overdue
+            }
+        )
+    )
+
+    rotator = EnvSecretRotator(
+        env_file_path=str(env_file),
+        managed_keys=["FRESH", "STALE"],
+        rotation_interval_days=90,
+    )
+
+    overdue = rotator.check_overdue()
+    assert len(overdue) == 1
+    assert overdue[0].secret_id == "STALE"


### PR DESCRIPTION
## Summary

ADR-032 Step 1/4 — SecretRotationPort + EnvSecretRotator + 6 unit tests.

- `services/secrets/rotation_port.py` — Protocol with 4 methods: rotate, get_rotation_status, list_secrets, check_overdue
- `services/secrets/env_secret_rotator.py` — .env-based rotation with token_urlsafe(32) + companion state file
- `tests/unit/secrets/test_rotation_port.py` — 6 unit tests (tmp_path fixtures, no real secrets)

## Gap ref

- G-SEC-01 (secret rotation policy not defined)

## Tests

- 6 new unit tests, all PASS
- Lint clean (ruff check + ruff format)
- All pre-commit hooks PASS

## ADR-032 progress

| Step | Description | Status |
|------|-------------|--------|
| **1** | **SecretRotationPort + EnvSecretRotator + 6 tests** | **This PR** |
| 2 | DI wiring + integration tests | Next |
| 3 | Rotation check script + CI smoke | Next |
| 4 | Flip ADR Proposed→Accepted + close G-SEC-01 | Next |

## Инструкция оператору после merge (§7)

```bash
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
```