### PR TITLE
feat(adr-032): wire EnvSecretRotator into DI + integration tests [Step 2]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,3 +115,11 @@ BACKUP_PG_USER=banxe
 BACKUP_PG_PASSWORD=
 BACKUP_DIR=/data/banxe/backups
 BACKUP_RETENTION_COUNT=7
+
+# === Secret Rotation (ADR-032) ===
+# Feature flag — set to "true" to enable rotation operations
+SECRET_ROTATION_ENABLED=false
+SECRET_ROTATION_INTERVAL_DAYS=90
+# Comma-separated list of env var names to manage
+SECRET_ROTATION_MANAGED_KEYS=KC_BOOT_ADMIN_PASSWORD,KC_DB_PASSWORD,AUTH_SECRET_KEY
+SECRET_ROTATION_ENV_FILE=.env

--- a/services/secrets/__init__.py
+++ b/services/secrets/__init__.py
@@ -1,6 +1,11 @@
 """Secrets rotation subsystem (ADR-032, G-SEC-01)."""
 
 from services.secrets.env_secret_rotator import EnvSecretRotator
+from services.secrets.factory import (
+    SecretRotationConfig,
+    SecretRotationDisabledError,
+    get_secret_rotator,
+)
 from services.secrets.rotation_port import (
     RotationResult,
     RotationStatus,
@@ -13,5 +18,8 @@ __all__ = [
     "RotationResult",
     "RotationStatus",
     "SecretMetadata",
+    "SecretRotationConfig",
+    "SecretRotationDisabledError",
     "SecretRotationPort",
+    "get_secret_rotator",
 ]

--- a/services/secrets/factory.py
+++ b/services/secrets/factory.py
@@ -1,0 +1,64 @@
+"""Secret rotation DI factory (ADR-032, G-SEC-01).
+
+Reads configuration from environment and returns a configured
+EnvSecretRotator. Feature flag SECRET_ROTATION_ENABLED controls activation.
+
+Usage:
+    from services.secrets.factory import get_secret_rotator
+    rotator = get_secret_rotator()  # raises SecretRotationDisabledError if disabled
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+from services.secrets.env_secret_rotator import EnvSecretRotator
+
+
+class SecretRotationDisabledError(Exception):
+    """Raised when rotation operations are attempted while disabled."""
+
+
+@dataclass(frozen=True)
+class SecretRotationConfig:
+    """Configuration for EnvSecretRotator, loaded from environment."""
+
+    enabled: bool
+    interval_days: int
+    managed_keys: list[str]
+    env_file_path: str
+
+    @classmethod
+    def from_env(cls) -> SecretRotationConfig:
+        """Load secret rotation config from environment variables."""
+        keys_raw = os.environ.get("SECRET_ROTATION_MANAGED_KEYS", "")
+        managed_keys = [k.strip() for k in keys_raw.split(",") if k.strip()]
+
+        return cls(
+            enabled=os.environ.get("SECRET_ROTATION_ENABLED", "false").lower() == "true",
+            interval_days=int(os.environ.get("SECRET_ROTATION_INTERVAL_DAYS", "90")),
+            managed_keys=managed_keys,
+            env_file_path=os.environ.get("SECRET_ROTATION_ENV_FILE", ".env"),
+        )
+
+
+def get_secret_rotator(config: SecretRotationConfig | None = None) -> EnvSecretRotator:
+    """Create a configured EnvSecretRotator from environment.
+
+    Raises:
+        SecretRotationDisabledError: if SECRET_ROTATION_ENABLED != 'true'.
+    """
+    cfg = config or SecretRotationConfig.from_env()
+
+    if not cfg.enabled:
+        raise SecretRotationDisabledError(
+            "Secret rotation disabled (SECRET_ROTATION_ENABLED != 'true'). "
+            "Set SECRET_ROTATION_ENABLED=true to enable."
+        )
+
+    return EnvSecretRotator(
+        rotation_interval_days=cfg.interval_days,
+        env_file_path=cfg.env_file_path,
+        managed_keys=cfg.managed_keys,
+    )

--- a/tests/integration/test_secret_rotation_integration.py
+++ b/tests/integration/test_secret_rotation_integration.py
@@ -1,0 +1,85 @@
+"""Integration tests for ADR-032 Step 2: DI wiring + rotation roundtrip.
+
+Gap ref: G-SEC-01 (secret rotation not defined)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from services.secrets.env_secret_rotator import EnvSecretRotator
+from services.secrets.factory import SecretRotationDisabledError, get_secret_rotator
+
+
+def test_factory_creates_rotator_from_env() -> None:
+    """Factory returns configured EnvSecretRotator from env vars."""
+    env = {
+        "SECRET_ROTATION_ENABLED": "true",
+        "SECRET_ROTATION_INTERVAL_DAYS": "30",
+        "SECRET_ROTATION_MANAGED_KEYS": "KEY_A,KEY_B,KEY_C",
+        "SECRET_ROTATION_ENV_FILE": "/tmp/test-secrets.env",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        rotator = get_secret_rotator()
+
+    assert isinstance(rotator, EnvSecretRotator)
+    assert rotator._interval_days == 30
+    assert rotator._managed_keys == ["KEY_A", "KEY_B", "KEY_C"]
+    assert str(rotator._env_path) == "/tmp/test-secrets.env"
+
+
+def test_factory_disabled_raises() -> None:
+    """SECRET_ROTATION_ENABLED=false raises SecretRotationDisabledError."""
+    env = {"SECRET_ROTATION_ENABLED": "false"}
+    with patch.dict(os.environ, env, clear=False):
+        with pytest.raises(SecretRotationDisabledError, match="disabled"):
+            get_secret_rotator()
+
+
+def test_rotate_and_check_status_roundtrip(tmp_path: Path) -> None:
+    """Rotate a secret then check status shows fresh (not overdue)."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("DB_PASSWORD=old-fake-value\n")
+
+    rotator = EnvSecretRotator(
+        rotation_interval_days=90,
+        env_file_path=str(env_file),
+        managed_keys=["DB_PASSWORD"],
+    )
+
+    result = rotator.rotate("DB_PASSWORD")
+    assert result.success is True
+
+    status = rotator.get_rotation_status("DB_PASSWORD")
+    assert status.is_overdue is False
+    assert status.last_rotated is not None
+    assert status.days_until_due > 80
+
+
+def test_check_overdue_after_interval(tmp_path: Path) -> None:
+    """Secret past interval is detected as overdue."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=fake-key\nOTHER=val\n")
+
+    state_file = tmp_path / ".rotation-state.json"
+    old_date = datetime.now(tz=UTC) - timedelta(days=95)
+    state_file.write_text(json.dumps({"API_KEY": old_date.isoformat()}))
+
+    rotator = EnvSecretRotator(
+        rotation_interval_days=90,
+        env_file_path=str(env_file),
+        managed_keys=["API_KEY"],
+    )
+
+    overdue = rotator.check_overdue()
+    assert len(overdue) == 1
+    assert overdue[0].secret_id == "API_KEY"
+
+    status = rotator.get_rotation_status("API_KEY")
+    assert status.is_overdue is True


### PR DESCRIPTION
## Summary

ADR-032 Step 2/4 — DI factory + SECRET_ROTATION_ENABLED flag + 4 integration tests.

- `services/secrets/factory.py` — `SecretRotationConfig.from_env()` + `get_secret_rotator()` + `SecretRotationDisabledError`
- `tests/integration/test_secret_rotation_integration.py` — 4 integration tests
- `.env.example` — new SECRET_ROTATION_* env vars
- `services/secrets/__init__.py` — updated exports

## Gap ref

- G-SEC-01 (secret rotation not defined)

## Tests

- 4 new integration + 6 existing unit = 10 total, all PASS
- Lint clean (ruff check + ruff format)
- All pre-commit hooks PASS

## ADR-032 progress

| Step | Description | Status |
|------|-------------|--------|
| 1 | SecretRotationPort + EnvSecretRotator + 6 tests | ✅ on main (PR #110) |
| **2** | **DI wiring + SECRET_ROTATION_ENABLED + 4 integration tests** | **This PR** |
| 3 | Rotation check script + CI smoke | Next |
| 4 | Flip ADR Proposed→Accepted + close G-SEC-01 | Next |

## Инструкция оператору после merge (§7)

```bash
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
```