### PR TITLE
feat(adr-034): Step 1 WebhookReliabilityPort + InMemoryWebhookAdapter + 6 unit tests

### DIFF
--- a/services/webhooks/in_memory_adapter.py
+++ b/services/webhooks/in_memory_adapter.py
@@ -1,0 +1,106 @@
+"""
+in_memory_adapter.py — In-memory WebhookReliabilityPort adapter.
+
+Test/dev double for the production Redis+DLQ adapter (ADR-034 Step 4).
+Pure in-process: dict-backed storage, deterministic clock injection,
+no network, no DB, no logging side effects.
+
+Backoff policy (ADR-034 §Webhook reliability matrix):
+  default schedule [1.0, 10.0, 60.0]  (×3 attempts, non-EDD)
+  EDD caller overrides via constructor (e.g. ×5 for applicantActionPending)
+
+On mark_failed:
+  - increment attempt
+  - if attempt >= max_attempts → status = "dead"
+  - else → schedule next_retry_at = now() + schedule[attempt-1]
+
+next_due returns records with status == "pending" AND
+next_retry_at <= now_ts, ordered ascending by next_retry_at, capped.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import time
+
+from services.webhooks.reliability_port import (
+    WebhookDeliveryRecord,
+    WebhookReliabilityPort,
+)
+
+DEFAULT_BACKOFF_SCHEDULE: tuple[float, ...] = (1.0, 10.0, 60.0)
+DEFAULT_MAX_ATTEMPTS: int = 3
+
+
+class InMemoryWebhookAdapter(WebhookReliabilityPort):
+    """In-memory adapter for WebhookReliabilityPort.
+
+    Args:
+      backoff_schedule: seconds-to-wait per attempt index. The Nth retry
+          (1-based) waits `backoff_schedule[N-1]` seconds. If attempts
+          exceed schedule length, last entry repeats up to max_attempts.
+      max_attempts: total attempts allowed (initial + retries). After this,
+          status transitions to "dead".
+      clock: callable returning current epoch seconds. Defaults to time.time;
+          tests inject a deterministic closure.
+    """
+
+    def __init__(
+        self,
+        backoff_schedule: tuple[float, ...] = DEFAULT_BACKOFF_SCHEDULE,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+        if not backoff_schedule:
+            raise ValueError("backoff_schedule must be non-empty")
+        self._records: dict[str, WebhookDeliveryRecord] = {}
+        self._backoff = backoff_schedule
+        self._max_attempts = max_attempts
+        self._clock = clock
+
+    def enqueue(
+        self,
+        event_id: str,
+        payload: dict,
+        target_url: str,
+        attempt: int = 0,
+    ) -> None:
+        self._records[event_id] = WebhookDeliveryRecord(
+            event_id=event_id,
+            payload=payload,
+            target_url=target_url,
+            attempt=attempt,
+            next_retry_at=self._clock(),
+            status="pending",
+            last_error="",
+        )
+
+    def mark_delivered(self, event_id: str) -> None:
+        record = self._records.get(event_id)
+        if record is None:
+            return
+        record.status = "delivered"
+        record.last_error = ""
+
+    def mark_failed(self, event_id: str, error: str) -> None:
+        record = self._records.get(event_id)
+        if record is None:
+            return
+        record.attempt += 1
+        record.last_error = error
+        if record.attempt >= self._max_attempts:
+            record.status = "dead"
+            return
+        backoff_index = min(record.attempt - 1, len(self._backoff) - 1)
+        record.next_retry_at = self._clock() + self._backoff[backoff_index]
+
+    def next_due(self, now_ts: float, limit: int) -> list[WebhookDeliveryRecord]:
+        if limit <= 0:
+            return []
+        eligible = [
+            r for r in self._records.values() if r.status == "pending" and r.next_retry_at <= now_ts
+        ]
+        eligible.sort(key=lambda r: r.next_retry_at)
+        return eligible[:limit]

--- a/services/webhooks/reliability_port.py
+++ b/services/webhooks/reliability_port.py
@@ -1,0 +1,78 @@
+"""
+reliability_port.py — Webhook delivery reliability port (ADR-034 Step 1).
+
+Defines the abstract Port over webhook delivery reliability semantics:
+  - enqueue: register a delivery attempt
+  - mark_delivered: terminal success
+  - mark_failed: schedule next retry with exponential backoff, or mark dead
+  - next_due: list pending records eligible for redelivery at a given clock
+
+Per ADR-034 §Implementation Plan, the production adapter binds to Redis
+(SETNX idempotency + RPUSH/BLPOP queue) and the existing DLQ. This Port
+abstracts those semantics so the cron/worker layer (ADR-034 Steps 2-5)
+can be DI-wired and tested without Redis.
+
+Default retry policy follows ADR-034 §Webhook reliability matrix:
+  - Non-EDD events: max 3 attempts, backoff [1s, 10s, 60s]
+  - EDD critical (applicantActionPending): max 5 attempts (caller-supplied)
+
+No I/O. No side effects. Pure typing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+WebhookStatus = str  # one of: "pending", "delivered", "dead"
+
+
+@dataclass
+class WebhookDeliveryRecord:
+    """A single inbound/outbound webhook delivery attempt record.
+
+    Fields:
+      event_id:       provider-supplied or idempotency-key-derived identifier
+      payload:        opaque event body (provider-specific shape)
+      target_url:     destination for outbound; provider URL for inbound replay
+      attempt:        zero-based count of attempts already executed
+      next_retry_at:  epoch seconds when this record is eligible for redelivery
+      status:         "pending" | "delivered" | "dead"
+      last_error:     last failure message (empty string if none)
+    """
+
+    event_id: str
+    payload: dict
+    target_url: str
+    attempt: int = 0
+    next_retry_at: float = 0.0
+    status: WebhookStatus = "pending"
+    last_error: str = ""
+
+
+class WebhookReliabilityPort(Protocol):
+    """Port abstracting webhook delivery reliability (ADR-034)."""
+
+    def enqueue(
+        self,
+        event_id: str,
+        payload: dict,
+        target_url: str,
+        attempt: int = 0,
+    ) -> None:
+        """Register a delivery record in pending state."""
+        ...
+
+    def mark_delivered(self, event_id: str) -> None:
+        """Terminal success: mark record as delivered."""
+        ...
+
+    def mark_failed(self, event_id: str, error: str) -> None:
+        """Failure: increment attempt; schedule next retry per backoff
+        schedule; if attempts exhausted, transition to 'dead'."""
+        ...
+
+    def next_due(self, now_ts: float, limit: int) -> list[WebhookDeliveryRecord]:
+        """Return pending records with next_retry_at <= now_ts, ordered by
+        next_retry_at ascending, capped by `limit`."""
+        ...

--- a/tests/unit/webhooks/test_in_memory_adapter.py
+++ b/tests/unit/webhooks/test_in_memory_adapter.py
@@ -1,0 +1,137 @@
+"""
+test_in_memory_adapter.py — Unit tests for InMemoryWebhookAdapter (ADR-034 Step 1).
+
+All tests are deterministic: clock is injected as a closure over a mutable list
+so we can advance "now" explicitly without time.sleep.
+"""
+
+from __future__ import annotations
+
+from services.webhooks.in_memory_adapter import (
+    DEFAULT_BACKOFF_SCHEDULE,
+    DEFAULT_MAX_ATTEMPTS,
+    InMemoryWebhookAdapter,
+)
+
+
+def _make_adapter(
+    start_time: float = 1000.0,
+    backoff: tuple[float, ...] = DEFAULT_BACKOFF_SCHEDULE,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> tuple[InMemoryWebhookAdapter, list[float]]:
+    """Build an adapter with a mutable clock list; tests mutate `clock[0]`."""
+    clock = [start_time]
+    adapter = InMemoryWebhookAdapter(
+        backoff_schedule=backoff,
+        max_attempts=max_attempts,
+        clock=lambda: clock[0],
+    )
+    return adapter, clock
+
+
+def test_enqueue_creates_pending_record() -> None:
+    adapter, clock = _make_adapter(start_time=1000.0)
+    adapter.enqueue(
+        event_id="ev-1",
+        payload={"applicantId": "a1", "type": "applicantReviewed"},
+        target_url="https://kc.internal/webhooks/sumsub",
+    )
+    due = adapter.next_due(now_ts=1000.0, limit=10)
+    assert len(due) == 1
+    r = due[0]
+    assert r.event_id == "ev-1"
+    assert r.status == "pending"
+    assert r.attempt == 0
+    assert r.next_retry_at == 1000.0
+    assert r.last_error == ""
+    assert r.payload == {"applicantId": "a1", "type": "applicantReviewed"}
+
+
+def test_mark_delivered_sets_status_and_removes_from_due() -> None:
+    adapter, _ = _make_adapter(start_time=1000.0)
+    adapter.enqueue("ev-1", {"k": "v"}, "https://x")
+    assert len(adapter.next_due(now_ts=1000.0, limit=10)) == 1
+    adapter.mark_delivered("ev-1")
+    assert adapter.next_due(now_ts=1000.0, limit=10) == []
+
+
+def test_mark_failed_increments_attempt_and_schedules_backoff() -> None:
+    adapter, clock = _make_adapter(start_time=1000.0)
+    adapter.enqueue("ev-1", {}, "https://x")
+    adapter.mark_failed("ev-1", error="upstream 500")
+    # First failure: attempt -> 1, next_retry_at = now + backoff[0] = 1000 + 1
+    due_now = adapter.next_due(now_ts=1000.0, limit=10)
+    assert due_now == [], "should not be eligible immediately after backoff"
+    due_later = adapter.next_due(now_ts=1001.0, limit=10)
+    assert len(due_later) == 1
+    r = due_later[0]
+    assert r.attempt == 1
+    assert r.status == "pending"
+    assert r.last_error == "upstream 500"
+    assert r.next_retry_at == 1001.0
+
+
+def test_exponential_backoff_schedule_matches_expected() -> None:
+    # ADR-034 default schedule: [1.0, 10.0, 60.0], max_attempts=3.
+    adapter, clock = _make_adapter(start_time=0.0)
+    adapter.enqueue("ev-1", {}, "https://x")
+
+    # Attempt 1 fails @ t=0 → next_retry_at = 0 + 1 = 1
+    adapter.mark_failed("ev-1", "err1")
+    r1 = adapter.next_due(now_ts=1.0, limit=1)[0]
+    assert r1.attempt == 1
+    assert r1.next_retry_at == 1.0
+
+    # Attempt 2 fails @ t=1 → next_retry_at = 1 + 10 = 11
+    clock[0] = 1.0
+    adapter.mark_failed("ev-1", "err2")
+    r2 = adapter.next_due(now_ts=11.0, limit=1)[0]
+    assert r2.attempt == 2
+    assert r2.next_retry_at == 11.0
+
+    # Attempt 3 fails @ t=11 → exhausted (max_attempts=3) → status=dead
+    clock[0] = 11.0
+    adapter.mark_failed("ev-1", "err3")
+    assert adapter.next_due(now_ts=10_000.0, limit=10) == []
+
+
+def test_max_attempts_marks_dead_and_excluded_from_due() -> None:
+    adapter, clock = _make_adapter(
+        start_time=0.0,
+        backoff=(1.0, 1.0),
+        max_attempts=2,
+    )
+    adapter.enqueue("ev-1", {}, "https://x")
+    adapter.mark_failed("ev-1", "first")
+    # Not dead yet: attempt=1 < max=2
+    assert len(adapter.next_due(now_ts=10.0, limit=10)) == 1
+    adapter.mark_failed("ev-1", "second")
+    # attempt=2 == max → dead, excluded
+    due = adapter.next_due(now_ts=10_000.0, limit=10)
+    assert due == []
+    # Underlying record reflects dead state with last_error
+    rec = adapter._records["ev-1"]  # type: ignore[attr-defined]
+    assert rec.status == "dead"
+    assert rec.last_error == "second"
+    assert rec.attempt == 2
+
+
+def test_next_due_returns_only_eligible_records_ordered() -> None:
+    adapter, clock = _make_adapter(start_time=100.0)
+    # Three records, all enqueued at t=100 → eligible immediately
+    adapter.enqueue("ev-a", {}, "https://x")
+    adapter.enqueue("ev-b", {}, "https://x")
+    adapter.enqueue("ev-c", {}, "https://x")
+    # Fail ev-a at t=100 → next_retry_at = 101
+    adapter.mark_failed("ev-a", "boom")
+    # Mark ev-b delivered (excluded)
+    adapter.mark_delivered("ev-b")
+    # At t=100.5: ev-c is eligible (next_retry_at=100), ev-a not yet (101)
+    due_mid = adapter.next_due(now_ts=100.5, limit=10)
+    assert [r.event_id for r in due_mid] == ["ev-c"]
+    # At t=101: ev-c (100) then ev-a (101); ev-b excluded (delivered)
+    due_full = adapter.next_due(now_ts=101.0, limit=10)
+    assert [r.event_id for r in due_full] == ["ev-c", "ev-a"]
+    # Limit caps result
+    due_capped = adapter.next_due(now_ts=101.0, limit=1)
+    assert [r.event_id for r in due_capped] == ["ev-c"]


### PR DESCRIPTION
## ADR-034 Step 1 — Webhook Reliability Port + In-Memory Adapter

### What

Implements ADR-034 Step 1 (Port + Tests). DI / Cron / Smoke deferred to Steps 2–5.

### Files (4 / +321 / -0)

| File | Purpose |
|------|---------|
| services/webhooks/reliability_port.py | Abstract WebhookReliabilityPort + WebhookDeliveryRecord dataclass |
| services/webhooks/in_memory_adapter.py | InMemoryWebhookAdapter: dict-backed, deterministic clock, configurable backoff/max_attempts |
| tests/unit/webhooks/__init__.py | package marker |
| tests/unit/webhooks/test_in_memory_adapter.py | 6 deterministic unit tests, no time.sleep |

### Spec adherence

- Defaults: max_attempts=3, backoff_schedule=(1.0, 10.0, 60.0) per ADR-034 §Webhook-reliability-matrix.
- Configurable via constructor for EDD ×5 use case (applicantActionPending).

### Test results

- pytest tests/unit/webhooks/ -q: **6 PASS / 0 FAIL**
- Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).

### Out of scope (this PR)

- DI wiring, cron jobs, smoke tests (Steps 2–5).
- INSTRUCTION-LEDGER / MEMORY.md / ADR update in banxe-architecture (main terminal §74).

### Operator merge command

\`\`\`bash
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook delivery reliability system with automatic retry logic and exponential backoff scheduling
  * Webhooks now tracked with delivery states: pending, delivered, or dead
  * Support for configurable retry attempts and backoff schedules

* **Tests**
  * Comprehensive test suite covering webhook reliability adapter, retry behavior, and state transitions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CarmiBanxe/banxe-emi-stack/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->