### PR TITLE
feat(adr-034): Step 2 DI wiring WebhookReliabilityPort -> InMemoryWebhookAdapter

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -249,3 +249,45 @@ def get_recon_engine() -> ReconciliationEngine:
         ledger = StubLedgerAdapter()
 
     return ReconciliationEngine(ledger=ledger, audit=get_buffered_audit_port())
+
+
+# ── ADR-034: Webhook delivery reliability (WebhookReliabilityPort) ───────────
+
+
+@lru_cache(maxsize=1)
+def get_webhook_reliability_port():
+    """WebhookReliabilityPort — webhook delivery retry/backoff/dead-letter (ADR-034).
+
+    WEBHOOK_RELIABILITY_ADAPTER env var:
+      "in_memory" → InMemoryWebhookAdapter (default, dev/test)
+      "redis"     → RedisWebhookAdapter (ADR-034 Step 4, NotImplemented here)
+
+    Backoff/retry policy (ADR-034 §Webhook-reliability-matrix defaults):
+      WEBHOOK_MAX_ATTEMPTS    (int, default 3)
+      WEBHOOK_BACKOFF_SECONDS (csv floats, default "1.0,10.0,60.0")
+    """
+    from services.webhooks.in_memory_adapter import (
+        DEFAULT_BACKOFF_SCHEDULE,
+        DEFAULT_MAX_ATTEMPTS,
+        InMemoryWebhookAdapter,
+    )
+
+    adapter_name = os.environ.get("WEBHOOK_RELIABILITY_ADAPTER", "in_memory")
+    max_attempts = int(os.environ.get("WEBHOOK_MAX_ATTEMPTS", str(DEFAULT_MAX_ATTEMPTS)))
+    backoff_raw = os.environ.get("WEBHOOK_BACKOFF_SECONDS", "")
+    if backoff_raw:
+        backoff = tuple(float(x.strip()) for x in backoff_raw.split(",") if x.strip())
+    else:
+        backoff = DEFAULT_BACKOFF_SCHEDULE
+
+    if adapter_name == "in_memory":
+        return InMemoryWebhookAdapter(
+            backoff_schedule=backoff,
+            max_attempts=max_attempts,
+        )
+
+    # Production Redis adapter binding deferred to ADR-034 Step 4.
+    raise NotImplementedError(
+        f"WEBHOOK_RELIABILITY_ADAPTER={adapter_name!r}: only 'in_memory' is wired "
+        "in ADR-034 Step 2; Redis adapter pending Step 4."
+    )

--- a/tests/unit/webhooks/test_di_wiring.py
+++ b/tests/unit/webhooks/test_di_wiring.py
@@ -1,0 +1,85 @@
+"""
+test_di_wiring.py — DI-resolution tests for WebhookReliabilityPort (ADR-034 Step 2).
+
+Verifies api.deps.get_webhook_reliability_port() resolves the dev/test binding
+to InMemoryWebhookAdapter with the documented env-var-driven configuration.
+
+The provider is @lru_cache(maxsize=1); each test calls cache_clear() and uses
+monkeypatch to vary env vars, so resolution is deterministic and isolated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from api.deps import get_webhook_reliability_port
+from services.webhooks.in_memory_adapter import (
+    DEFAULT_BACKOFF_SCHEDULE,
+    DEFAULT_MAX_ATTEMPTS,
+    InMemoryWebhookAdapter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_di_cache_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each test sees a fresh provider resolution under known env."""
+    monkeypatch.delenv("WEBHOOK_RELIABILITY_ADAPTER", raising=False)
+    monkeypatch.delenv("WEBHOOK_MAX_ATTEMPTS", raising=False)
+    monkeypatch.delenv("WEBHOOK_BACKOFF_SECONDS", raising=False)
+    get_webhook_reliability_port.cache_clear()
+    yield
+    get_webhook_reliability_port.cache_clear()
+
+
+def test_di_resolves_webhook_reliability_port_to_in_memory_adapter() -> None:
+    port = get_webhook_reliability_port()
+    assert isinstance(port, InMemoryWebhookAdapter)
+    # Structural Port conformance — method surface per ADR-034 Step 1.
+    # (Protocol is not @runtime_checkable by design; check by method names.)
+    for method in ("enqueue", "mark_delivered", "mark_failed", "next_due"):
+        assert callable(getattr(port, method)), f"port missing {method}"
+
+
+def test_di_adapter_uses_default_backoff_schedule_from_config() -> None:
+    port = get_webhook_reliability_port()
+    assert port._backoff == DEFAULT_BACKOFF_SCHEDULE  # type: ignore[attr-defined]
+    assert port._backoff == (1.0, 10.0, 60.0)  # type: ignore[attr-defined]
+
+
+def test_di_adapter_backoff_schedule_overridable_via_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WEBHOOK_BACKOFF_SECONDS", "2.5, 7.0, 30.0, 120.0")
+    get_webhook_reliability_port.cache_clear()
+    port = get_webhook_reliability_port()
+    assert port._backoff == (2.5, 7.0, 30.0, 120.0)  # type: ignore[attr-defined]
+
+
+def test_di_adapter_max_attempts_configurable_via_di(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Default
+    port_default = get_webhook_reliability_port()
+    assert port_default._max_attempts == DEFAULT_MAX_ATTEMPTS  # type: ignore[attr-defined]
+    assert port_default._max_attempts == 3  # type: ignore[attr-defined]
+
+    # EDD critical override (ADR-034 §matrix x5)
+    monkeypatch.setenv("WEBHOOK_MAX_ATTEMPTS", "5")
+    get_webhook_reliability_port.cache_clear()
+    port_edd = get_webhook_reliability_port()
+    assert port_edd._max_attempts == 5  # type: ignore[attr-defined]
+
+
+def test_di_singleton_scope_lru_cache_returns_same_instance() -> None:
+    a = get_webhook_reliability_port()
+    b = get_webhook_reliability_port()
+    assert a is b
+
+
+def test_di_unknown_adapter_raises_not_implemented(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WEBHOOK_RELIABILITY_ADAPTER", "redis")
+    get_webhook_reliability_port.cache_clear()
+    with pytest.raises(NotImplementedError, match="Step 4"):
+        get_webhook_reliability_port()


### PR DESCRIPTION
## ADR-034 Step 2 — DI wiring

### What
Bind WebhookReliabilityPort to InMemoryWebhookAdapter via canonical repo DI module (api/deps.py).

### Files (2 / +127 / -0)
- api/deps.py — appended DI section (same pattern as get_iam, get_payment_service, get_recon_engine, get_buffered_audit_port)
- tests/unit/webhooks/test_di_wiring.py — 6 deterministic DI tests

### Env-var contract (defaults per ADR-034 matrix)
- WEBHOOK_RELIABILITY_ADAPTER default in_memory; redis raises NotImplementedError until Step 4
- WEBHOOK_MAX_ATTEMPTS default 3
- WEBHOOK_BACKOFF_SECONDS default 1.0,10.0,60.0

### Tests
pytest tests/unit/webhooks/ -q --no-cov: 12 PASS / 0 FAIL (6 Step 1 + 6 Step 2 DI).
Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).

### Deviations from prompt
- Test count 6 instead of 3-4 (added redis-guard NotImplementedError + lru_cache singleton check).
- Protocol isinstance: WebhookReliabilityPort is plain Protocol, not runtime_checkable. Tests assert conformance by method surface; retrofit deferred (out of Step 2 bounded context).

### Out of scope
- Cron jobs, Redis adapter, smoke tests (Steps 3-5).
- INSTRUCTION-LEDGER / MEMORY.md / ADR docs sync (main terminal step).

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
