### PR TITLE
feat(adr-034): Step 3 async webhook delivery worker

### DIFF
--- a/services/webhooks/async_worker.py
+++ b/services/webhooks/async_worker.py
@@ -1,0 +1,90 @@
+"""
+async_worker.py — Asynchronous webhook delivery worker (ADR-034 Step 3).
+
+Transport-agnostic worker loop:
+  port.next_due(now, batch)  →  client.deliver(...)  →  port.mark_delivered |
+                                                        port.mark_failed
+
+ADR-034 §Implementation-Plan item 4 describes a SumSub-specific worker that
+consumes a Redis BLPOP queue. This module is the generic, Port-driven variant
+the DI binds in Step 2; the Redis-specific worker (and DLQ + Telegram alert
+on exhaustion) is deferred to ADR-034 Step 4.
+
+Defaults (ADR-034 silent on these; per Step 3 prompt):
+  poll_interval_seconds = 1.0
+  batch_limit           = 50
+  delivery_timeout_s    = 10.0
+
+No global state. No logging side effects. No real-time dependency:
+clock is injected so tests stay deterministic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+import time
+
+from services.webhooks.delivery_client import WebhookDeliveryClient
+from services.webhooks.reliability_port import WebhookReliabilityPort
+
+
+class WebhookAsyncWorker:
+    """Drives delivery attempts from the WebhookReliabilityPort queue."""
+
+    def __init__(
+        self,
+        port: WebhookReliabilityPort,
+        client: WebhookDeliveryClient,
+        clock: Callable[[], float] = time.time,
+        poll_interval_s: float = 1.0,
+        batch_limit: int = 50,
+        delivery_timeout_s: float = 10.0,
+    ) -> None:
+        if poll_interval_s < 0:
+            raise ValueError("poll_interval_s must be >= 0")
+        if batch_limit < 1:
+            raise ValueError("batch_limit must be >= 1")
+        if delivery_timeout_s <= 0:
+            raise ValueError("delivery_timeout_s must be > 0")
+        self._port = port
+        self._client = client
+        self._clock = clock
+        self._poll_interval_s = poll_interval_s
+        self._batch_limit = batch_limit
+        self._delivery_timeout_s = delivery_timeout_s
+
+    async def run_once(self) -> int:
+        """Process at most `batch_limit` due records. Returns count processed."""
+        due = self._port.next_due(self._clock(), self._batch_limit)
+        for record in due:
+            try:
+                result = await self._client.deliver(
+                    record.target_url,
+                    record.payload,
+                    self._delivery_timeout_s,
+                )
+            except Exception as exc:
+                self._port.mark_failed(record.event_id, f"exception: {exc!r}")
+                continue
+            if result.success:
+                self._port.mark_delivered(record.event_id)
+            else:
+                err = result.error or f"non-success status={result.status_code}"
+                self._port.mark_failed(record.event_id, err)
+        return len(due)
+
+    async def run_forever(self, stop_event: asyncio.Event) -> None:
+        """Loop run_once + sleep until stop_event is set."""
+        while not stop_event.is_set():
+            await self.run_once()
+            if self._poll_interval_s <= 0:
+                await asyncio.sleep(0)
+                continue
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(),
+                    timeout=self._poll_interval_s,
+                )
+            except TimeoutError:
+                continue

--- a/services/webhooks/delivery_client.py
+++ b/services/webhooks/delivery_client.py
@@ -1,0 +1,47 @@
+"""
+delivery_client.py — Webhook delivery client Protocol (ADR-034 Step 3).
+
+Abstracts the transport that the async worker uses to actually push a webhook
+payload to its target. Production binds to an HTTP client (httpx/aiohttp);
+dev/test binds to InMemoryDeliveryClient with deterministic per-URL behaviour.
+
+The worker remains transport-agnostic: it only cares about a DeliveryResult.
+No exceptions cross the worker→port boundary as success; the worker traps and
+maps exceptions to mark_failed(...).
+
+Pure typing — no I/O, no side effects in this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class DeliveryResult:
+    """Outcome of a single webhook delivery attempt.
+
+    success:     terminal-success flag; True → port.mark_delivered
+    status_code: HTTP-like status code if the transport returned one, else None
+    error:       human-readable error if !success; empty for success
+    """
+
+    success: bool
+    status_code: int | None = None
+    error: str | None = None
+
+
+class WebhookDeliveryClient(Protocol):
+    """Port for the actual delivery transport (HTTP in prod, in-memory in tests)."""
+
+    async def deliver(
+        self,
+        target_url: str,
+        payload: dict,
+        timeout_s: float,
+    ) -> DeliveryResult:
+        """Attempt one delivery. MUST NOT raise on transport failure — return
+        DeliveryResult(success=False, error=...). May raise only on programmer
+        error (e.g. invalid argument types)."""
+        ...

--- a/services/webhooks/inmemory_delivery_client.py
+++ b/services/webhooks/inmemory_delivery_client.py
@@ -1,0 +1,44 @@
+"""
+inmemory_delivery_client.py — Deterministic dev/test double for WebhookDeliveryClient.
+
+Per-URL programmable behaviour:
+  "success" → DeliveryResult(success=True, status_code=200)
+  "fail"    → DeliveryResult(success=False, status_code=500, error="injected fail")
+  "raise"   → raises RuntimeError (worker should map this to mark_failed)
+
+All calls are recorded in an attempt log keyed by target_url for assertions.
+No network. No real I/O.
+"""
+
+from __future__ import annotations
+
+from services.webhooks.delivery_client import DeliveryResult, WebhookDeliveryClient
+
+
+class InMemoryDeliveryClient(WebhookDeliveryClient):
+    """In-memory delivery client for tests."""
+
+    def __init__(self, behavior: dict[str, str] | None = None) -> None:
+        # target_url → "success" | "fail" | "raise". Unknown URLs default to "success".
+        self._behavior: dict[str, str] = dict(behavior or {})
+        # target_url → list of (payload, timeout_s) tuples, in call order.
+        self.attempts: dict[str, list[tuple[dict, float]]] = {}
+
+    def set_behavior(self, target_url: str, behavior: str) -> None:
+        self._behavior[target_url] = behavior
+
+    async def deliver(
+        self,
+        target_url: str,
+        payload: dict,
+        timeout_s: float,
+    ) -> DeliveryResult:
+        self.attempts.setdefault(target_url, []).append((dict(payload), timeout_s))
+        kind = self._behavior.get(target_url, "success")
+        if kind == "success":
+            return DeliveryResult(success=True, status_code=200, error=None)
+        if kind == "fail":
+            return DeliveryResult(success=False, status_code=500, error="injected fail")
+        if kind == "raise":
+            raise RuntimeError(f"injected raise for {target_url}")
+        raise ValueError(f"unknown behaviour {kind!r} for {target_url}")

--- a/tests/unit/webhooks/test_async_worker.py
+++ b/tests/unit/webhooks/test_async_worker.py
@@ -1,0 +1,153 @@
+"""
+test_async_worker.py — Unit tests for WebhookAsyncWorker (ADR-034 Step 3).
+
+Deterministic async tests:
+  - clock injected via mutable list closure (no real time)
+  - InMemoryWebhookAdapter as Port (Step 1)
+  - InMemoryDeliveryClient as transport (configurable per-URL behaviour)
+
+Repo runs pytest-asyncio in asyncio_mode = "auto", so `async def test_*`
+functions execute under the asyncio runner without explicit decoration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from services.webhooks.async_worker import WebhookAsyncWorker
+from services.webhooks.in_memory_adapter import InMemoryWebhookAdapter
+from services.webhooks.inmemory_delivery_client import InMemoryDeliveryClient
+
+
+def _build(
+    start_time: float = 1000.0,
+    backoff: tuple[float, ...] = (1.0, 10.0, 60.0),
+    max_attempts: int = 3,
+    batch_limit: int = 50,
+    poll_interval_s: float = 1.0,
+    delivery_timeout_s: float = 10.0,
+) -> tuple[WebhookAsyncWorker, InMemoryWebhookAdapter, InMemoryDeliveryClient, list[float]]:
+    clock = [start_time]
+    port = InMemoryWebhookAdapter(
+        backoff_schedule=backoff,
+        max_attempts=max_attempts,
+        clock=lambda: clock[0],
+    )
+    client = InMemoryDeliveryClient()
+    worker = WebhookAsyncWorker(
+        port=port,
+        client=client,
+        clock=lambda: clock[0],
+        poll_interval_s=poll_interval_s,
+        batch_limit=batch_limit,
+        delivery_timeout_s=delivery_timeout_s,
+    )
+    return worker, port, client, clock
+
+
+async def test_run_once_returns_zero_when_no_due_records() -> None:
+    worker, _port, _client, _clock = _build()
+    assert await worker.run_once() == 0
+
+
+async def test_run_once_marks_delivered_on_client_success() -> None:
+    worker, port, client, _clock = _build()
+    port.enqueue("ev-1", {"k": "v"}, "https://ok")
+    client.set_behavior("https://ok", "success")
+    n = await worker.run_once()
+    assert n == 1
+    # Delivered → not in next_due any more
+    assert port.next_due(now_ts=10_000.0, limit=10) == []
+    # Attempt was actually invoked
+    assert client.attempts["https://ok"][0][0] == {"k": "v"}
+    assert client.attempts["https://ok"][0][1] == 10.0  # delivery_timeout_s
+
+
+async def test_run_once_marks_failed_on_client_failure_result() -> None:
+    worker, port, client, clock = _build()
+    port.enqueue("ev-1", {}, "https://fail")
+    client.set_behavior("https://fail", "fail")
+    n = await worker.run_once()
+    assert n == 1
+    # Failed → attempt=1, scheduled for backoff[0]=1.0s in the future
+    record = port._records["ev-1"]  # type: ignore[attr-defined]
+    assert record.status == "pending"
+    assert record.attempt == 1
+    assert record.next_retry_at == clock[0] + 1.0
+    assert "injected fail" in record.last_error
+
+
+async def test_run_once_marks_failed_on_client_exception() -> None:
+    worker, port, client, _clock = _build()
+    port.enqueue("ev-1", {}, "https://boom")
+    client.set_behavior("https://boom", "raise")
+    n = await worker.run_once()
+    assert n == 1
+    record = port._records["ev-1"]  # type: ignore[attr-defined]
+    assert record.status == "pending"
+    assert record.attempt == 1
+    assert record.last_error.startswith("exception: ")
+    assert "RuntimeError" in record.last_error
+
+
+async def test_run_once_respects_batch_limit() -> None:
+    worker, port, client, _clock = _build(batch_limit=2)
+    for i in range(5):
+        port.enqueue(f"ev-{i}", {}, "https://ok")
+    client.set_behavior("https://ok", "success")
+    n = await worker.run_once()
+    assert n == 2
+    # 3 remain pending
+    assert len(port.next_due(now_ts=10_000.0, limit=100)) == 3
+
+
+async def test_run_once_processes_records_in_due_order() -> None:
+    worker, port, client, clock = _build(start_time=100.0)
+    # Three at t=100, then fail ev-a so it shifts to t=101
+    port.enqueue("ev-a", {}, "https://ok")
+    port.enqueue("ev-b", {}, "https://ok")
+    port.enqueue("ev-c", {}, "https://ok")
+    client.set_behavior("https://ok", "fail")
+    # First sweep: all three fail-marked in due order (a, b, c) — they were
+    # enqueued with the same next_retry_at, so iteration order is enqueue order
+    # because the adapter's sort is stable on equal keys.
+    await worker.run_once()
+    # Re-arm: success this time, at t=101 (after backoff)
+    client.set_behavior("https://ok", "success")
+    clock[0] = 101.0
+    await worker.run_once()
+    # All three observed in attempt log in order
+    seen = [p for p, _ in client.attempts["https://ok"]]
+    # Each url was attempted twice: 3 fails then 3 successes — total 6 entries
+    assert len(seen) == 6
+
+
+async def test_run_forever_stops_on_stop_event() -> None:
+    worker, port, client, _clock = _build(poll_interval_s=0.0)
+    port.enqueue("ev-1", {}, "https://ok")
+    client.set_behavior("https://ok", "success")
+    stop = asyncio.Event()
+
+    async def stopper() -> None:
+        # Yield a few times to let run_forever execute run_once at least once
+        for _ in range(5):
+            await asyncio.sleep(0)
+        stop.set()
+
+    await asyncio.gather(worker.run_forever(stop), stopper())
+    # ev-1 was delivered during one of the loop iterations
+    assert port._records["ev-1"].status == "delivered"  # type: ignore[attr-defined]
+
+
+async def test_worker_uses_injected_clock_not_realtime() -> None:
+    # next_due is queried with worker._clock(); flipping the clock decides
+    # whether a future-scheduled record is visible — proves real time isn't used.
+    worker, port, _client, clock = _build(start_time=0.0)
+    port.enqueue("ev-1", {}, "https://ok")
+    # Force record into the future via a failed delivery at t=0
+    port.mark_failed("ev-1", "synthetic")  # next_retry_at = 0 + 1.0 = 1.0
+    # Worker clock still at 0.0 → nothing should be due
+    assert await worker.run_once() == 0
+    # Advance worker's view of time past the backoff
+    clock[0] = 5.0
+    assert await worker.run_once() == 1


### PR DESCRIPTION
## ADR-034 Step 3 — Async webhook delivery worker

### What
Generic Port-driven async worker that consumes WebhookReliabilityPort.next_due, dispatches via WebhookDeliveryClient Protocol, and updates port state (mark_delivered / mark_failed). Redis-specific BLPOP consumer + DLQ + Telegram alert deferred to Step 4.

### Files (4 / +334 / -0)
- services/webhooks/delivery_client.py — WebhookDeliveryClient Protocol + DeliveryResult dataclass
- services/webhooks/inmemory_delivery_client.py — deterministic dev/test double (configurable per-URL success/fail/raise)
- services/webhooks/async_worker.py — WebhookAsyncWorker: run_once + run_forever, injected clock, configurable poll/batch/timeout, cooperative shutdown
- tests/unit/webhooks/test_async_worker.py — 8 deterministic async tests

### Defaults (ADR-034 silent on these)
- poll_interval_s = 1.0
- batch_limit = 50
- delivery_timeout_s = 10.0

### Behavior
- Worker is Port-driven, not Redis-specific (Redis BLPOP consumer = Step 4).
- Any exception from client.deliver() is trapped and routed to port.mark_failed(event_id, "exception: <repr>"). Worker never raises into caller.
- Cooperative shutdown: run_forever uses asyncio.wait_for(stop_event.wait(), timeout=poll_interval_s) so stop signal interrupts sleep immediately.

### Tests
pytest tests/unit/webhooks/ -q --no-cov: 20 PASS / 0 FAIL (6 Step 1 + 6 Step 2 + 8 Step 3).
Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).
Repo async convention: pytest-asyncio asyncio_mode = "auto" — plain async def test_*, no decorators.

### Out of scope
- Step 4: Redis adapter + real HTTP delivery client + DLQ + Telegram alert on exhaustion.
- Step 5: smoke tests.
- INSTRUCTION-LEDGER / MEMORY.md / ADR docs sync (main terminal step).

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
