### PR TITLE
feat(adr-033): wire AlertRoutingPort into DI + ALERT_ENABLED flag + 5 integration tests [Step 2]

### DIFF
--- a/services/alerting/di.py
+++ b/services/alerting/di.py
@@ -1,0 +1,49 @@
+"""ADR-033 Step 2: DI wiring for AlertRoutingPort.
+
+AlertConfig.from_env() reads ALERT_ENABLED / ALERT_N8N_WEBHOOK_URL /
+ALERT_TIMEOUT. get_alert_adapter() returns the in-memory test double when
+disabled (safe default) and the real n8n+Telegram adapter when enabled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+from .alert_port import AlertRoutingPort
+from .in_memory_adapter import InMemoryAlertAdapter
+from .n8n_telegram_adapter import N8nTelegramAlertAdapter
+
+_DEFAULT_WEBHOOK_URL = "http://192.168.0.72:5678/webhook/kc-events"
+_DEFAULT_TIMEOUT = 10.0
+
+
+def _env_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class AlertConfig:
+    webhook_url: str
+    timeout: float = _DEFAULT_TIMEOUT
+    enabled: bool = False
+
+    @classmethod
+    def from_env(cls) -> AlertConfig:
+        webhook_url = os.environ.get("ALERT_N8N_WEBHOOK_URL", _DEFAULT_WEBHOOK_URL)
+        timeout = float(os.environ.get("ALERT_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+        enabled = _env_bool(os.environ.get("ALERT_ENABLED"))
+        return cls(webhook_url=webhook_url, timeout=timeout, enabled=enabled)
+
+
+def get_alert_adapter(config: AlertConfig | None = None) -> AlertRoutingPort:
+    if config is None:
+        config = AlertConfig.from_env()
+    if not config.enabled:
+        return InMemoryAlertAdapter()
+    return N8nTelegramAlertAdapter(
+        webhook_url=config.webhook_url,
+        timeout=config.timeout,
+    )

--- a/tests/unit/alerting/test_alert_di.py
+++ b/tests/unit/alerting/test_alert_di.py
@@ -1,0 +1,53 @@
+"""ADR-033 Step 2: 5 integration tests for AlertConfig + get_alert_adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.alerting.alert_port import AlertRoutingPort
+from services.alerting.di import AlertConfig, get_alert_adapter
+from services.alerting.in_memory_adapter import InMemoryAlertAdapter
+from services.alerting.n8n_telegram_adapter import N8nTelegramAlertAdapter
+
+_DEFAULT_WEBHOOK_URL = "http://192.168.0.72:5678/webhook/kc-events"
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("ALERT_ENABLED", "ALERT_N8N_WEBHOOK_URL", "ALERT_TIMEOUT"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_default_config_disabled(clean_env: None) -> None:
+    config = AlertConfig.from_env()
+    assert config.enabled is False
+    assert config.webhook_url == _DEFAULT_WEBHOOK_URL
+    assert config.timeout == 10.0
+
+
+def test_config_from_env_enabled(clean_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALERT_ENABLED", "true")
+    config = AlertConfig.from_env()
+    assert config.enabled is True
+    assert config.webhook_url == _DEFAULT_WEBHOOK_URL
+
+
+def test_get_adapter_disabled_returns_in_memory(clean_env: None) -> None:
+    config = AlertConfig(webhook_url=_DEFAULT_WEBHOOK_URL, enabled=False)
+    adapter: AlertRoutingPort = get_alert_adapter(config)
+    assert isinstance(adapter, InMemoryAlertAdapter)
+
+
+def test_get_adapter_enabled_returns_n8n(clean_env: None) -> None:
+    config = AlertConfig(webhook_url=_DEFAULT_WEBHOOK_URL, enabled=True)
+    adapter: AlertRoutingPort = get_alert_adapter(config)
+    assert isinstance(adapter, N8nTelegramAlertAdapter)
+
+
+def test_config_custom_values(clean_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    custom_url = "http://10.0.0.5:5678/webhook/custom-alerts"
+    monkeypatch.setenv("ALERT_N8N_WEBHOOK_URL", custom_url)
+    monkeypatch.setenv("ALERT_TIMEOUT", "25.5")
+    config = AlertConfig.from_env()
+    assert config.webhook_url == custom_url
+    assert config.timeout == 25.5


### PR DESCRIPTION
ADR-033 Step 2: AlertConfig.from_env() + get_alert_adapter() factory. ALERT_ENABLED=false default. 11 tests PASS (6+5).