### PR TITLE
feat(adr-033): alert routing operational script + 4 smoke tests [Step 3]

### DIFF
--- a/scripts/alert-routing-check.py
+++ b/scripts/alert-routing-check.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""ADR-033 Step 3: operational smoke check for alert routing.
+
+Health-checks the configured AlertRoutingPort and sends one benign test
+Alert. Exits 0 on success, 1 on failure. Safe to run from cron / CI.
+When ALERT_ENABLED=false (default) the in-memory adapter is exercised
+instead of the live n8n+Telegram pipe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from services.alerting.alert_port import (  # noqa: E402
+    Alert,
+    AlertCategory,
+    AlertSeverity,
+)
+from services.alerting.di import get_alert_adapter  # noqa: E402
+
+
+async def _run() -> int:
+    adapter = get_alert_adapter()
+    try:
+        healthy = await adapter.health_check()
+        print(f"health_check: {healthy}")
+
+        alert = Alert(
+            category=AlertCategory.GENERIC,
+            severity=AlertSeverity.INFO,
+            title="Alert routing smoke test",
+            body="Operational check from alert-routing-check.py",
+        )
+        delivered = await adapter.send_alert(alert)
+    finally:
+        close = getattr(adapter, "close", None)
+        if callable(close):
+            await close()
+
+    if delivered:
+        print("PASS: alert delivered")
+        return 0
+    print("FAIL: delivery failed")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_run()))

--- a/services/alerting/di.py
+++ b/services/alerting/di.py
@@ -33,7 +33,8 @@ class AlertConfig:
     @classmethod
     def from_env(cls) -> AlertConfig:
         webhook_url = os.environ.get("ALERT_N8N_WEBHOOK_URL", _DEFAULT_WEBHOOK_URL)
-        timeout = float(os.environ.get("ALERT_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+        raw_timeout = os.environ.get("ALERT_TIMEOUT", str(_DEFAULT_TIMEOUT))
+        timeout = float(raw_timeout)  # nosemgrep: banxe-float-money — seconds, not money
         enabled = _env_bool(os.environ.get("ALERT_ENABLED"))
         return cls(webhook_url=webhook_url, timeout=timeout, enabled=enabled)
 

--- a/tests/smoke/test_alert_routing_smoke.py
+++ b/tests/smoke/test_alert_routing_smoke.py
@@ -1,0 +1,56 @@
+"""Smoke tests for ADR-033 Step 3: alert routing operational readiness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import py_compile
+
+import pytest
+
+from services.alerting.alert_port import (
+    Alert,
+    AlertCategory,
+    AlertRoutingPort,
+    AlertSeverity,
+)
+from services.alerting.di import AlertConfig, get_alert_adapter
+from services.alerting.in_memory_adapter import InMemoryAlertAdapter
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("ALERT_ENABLED", "ALERT_N8N_WEBHOOK_URL", "ALERT_TIMEOUT"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_alert_config_loads_from_env(clean_env: None) -> None:
+    config = AlertConfig.from_env()
+    assert isinstance(config, AlertConfig)
+    assert isinstance(config.webhook_url, str) and config.webhook_url
+    assert isinstance(config.timeout, float)
+    assert isinstance(config.enabled, bool)
+
+
+def test_get_adapter_returns_port_instance(clean_env: None) -> None:
+    adapter = get_alert_adapter()
+    assert isinstance(adapter, AlertRoutingPort)
+
+
+@pytest.mark.asyncio
+async def test_in_memory_adapter_send_and_retrieve() -> None:
+    adapter = InMemoryAlertAdapter(healthy=True)
+    alert = Alert(
+        category=AlertCategory.GENERIC,
+        severity=AlertSeverity.INFO,
+        title="smoke",
+        body="smoke body",
+    )
+    ok = await adapter.send_alert(alert)
+    assert ok is True
+    assert adapter.alerts == [alert]
+
+
+def test_alert_script_exists_and_executable() -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "alert-routing-check.py"
+    assert script.exists(), f"script not found: {script}"
+    py_compile.compile(str(script), doraise=True)


### PR DESCRIPTION
ADR-033 Step 3: alert-routing-check.py + 4 smoke tests. 15 total PASS (6+5+4). Closes G-OBS-01 partial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operational smoke-check script that validates alert routing health and delivers test alerts.

* **Improvements**
  * Enhanced alert configuration handling for more robust timeout parsing.

* **Tests**
  * Added comprehensive smoke tests to verify alert routing configuration and operational readiness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CarmiBanxe/banxe-emi-stack/pull/119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->