### PR TITLE
feat(adr-034): Step 4 Redis adapter + HTTP delivery client + DLQ + Telegram alert

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -260,11 +260,15 @@ def get_webhook_reliability_port():
 
     WEBHOOK_RELIABILITY_ADAPTER env var:
       "in_memory" → InMemoryWebhookAdapter (default, dev/test)
-      "redis"     → RedisWebhookAdapter (ADR-034 Step 4, NotImplemented here)
+      "redis"     → RedisWebhookReliabilityAdapter (ADR-034 Step 4)
 
     Backoff/retry policy (ADR-034 §Webhook-reliability-matrix defaults):
-      WEBHOOK_MAX_ATTEMPTS    (int, default 3)
-      WEBHOOK_BACKOFF_SECONDS (csv floats, default "1.0,10.0,60.0")
+      WEBHOOK_MAX_ATTEMPTS       (int, default 3)
+      WEBHOOK_BACKOFF_SECONDS    (csv floats, default "1.0,10.0,60.0")
+
+    Redis-only env (ignored for in_memory):
+      REDIS_URL                  (default "redis://localhost:6379/0")
+      WEBHOOK_DEDUP_TTL_SECONDS  (int, default 86400 per ADR-034 §c)
     """
     from services.webhooks.in_memory_adapter import (
         DEFAULT_BACKOFF_SCHEDULE,
@@ -286,8 +290,27 @@ def get_webhook_reliability_port():
             max_attempts=max_attempts,
         )
 
-    # Production Redis adapter binding deferred to ADR-034 Step 4.
+    if adapter_name == "redis":
+        # ADR-034 Step 4: production Redis adapter + DLQ + Telegram alert hook.
+        import redis  # local import — heavy/unused for in_memory path
+
+        from services.alerting.di import get_alert_adapter
+        from services.webhooks.dlq_alert import TelegramDLQAlertHook
+        from services.webhooks.redis_adapter import RedisWebhookReliabilityAdapter
+
+        redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+        dedup_ttl_s = int(os.environ.get("WEBHOOK_DEDUP_TTL_SECONDS", "86400"))
+        redis_client = redis.Redis.from_url(redis_url, decode_responses=True)
+        alert_port = get_alert_adapter()
+        return RedisWebhookReliabilityAdapter(
+            redis_client=redis_client,
+            max_attempts=max_attempts,
+            backoff_schedule=backoff,
+            dlq_alert_hook=TelegramDLQAlertHook(alert_port=alert_port),
+            dedup_ttl_s=dedup_ttl_s,
+        )
+
     raise NotImplementedError(
-        f"WEBHOOK_RELIABILITY_ADAPTER={adapter_name!r}: only 'in_memory' is wired "
-        "in ADR-034 Step 2; Redis adapter pending Step 4."
+        f"WEBHOOK_RELIABILITY_ADAPTER={adapter_name!r}: supported values are "
+        "'in_memory' and 'redis'."
     )

--- a/services/webhooks/dlq_alert.py
+++ b/services/webhooks/dlq_alert.py
@@ -1,0 +1,76 @@
+"""
+dlq_alert.py — DLQ exhaustion alert hook (ADR-034 Step 4).
+
+Bridges the sync DLQ-exhaustion callback expected by the redis adapter to the
+async ADR-033 AlertRoutingPort. Builds a canonical CRITICAL alert and fires
+it on the running event loop (production worker) or via asyncio.run (sync
+test or one-shot caller).
+
+Failure behaviour: alert-send exceptions are swallowed. ADR-034 is silent on
+alert-sink failure semantics; default is "best-effort, never break delivery".
+
+Canonical message body:
+  "WEBHOOK_DLQ event_id=<id> target=<url> attempts=<n> last_error=<err>"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+from services.alerting.alert_port import (
+    Alert,
+    AlertCategory,
+    AlertRoutingPort,
+    AlertSeverity,
+)
+from services.webhooks.reliability_port import WebhookDeliveryRecord
+
+
+def format_dlq_message(record: WebhookDeliveryRecord) -> str:
+    """Canonical one-line DLQ alert body."""
+    return (
+        f"WEBHOOK_DLQ event_id={record.event_id} "
+        f"target={record.target_url} "
+        f"attempts={record.attempt} "
+        f"last_error={record.last_error}"
+    )
+
+
+def build_dlq_alert(record: WebhookDeliveryRecord) -> Alert:
+    return Alert(
+        category=AlertCategory.GENERIC,
+        severity=AlertSeverity.CRITICAL,
+        title=f"WEBHOOK_DLQ event_id={record.event_id}",
+        body=format_dlq_message(record),
+        metadata={
+            "event_id": record.event_id,
+            "target_url": record.target_url,
+            "attempts": record.attempt,
+            "last_error": record.last_error,
+        },
+        owner="CTIO",
+    )
+
+
+class TelegramDLQAlertHook:
+    """Sync hook → async AlertRoutingPort.send_alert.
+
+    If invoked from inside a running event loop, schedules a fire-and-forget
+    task. Otherwise creates a one-shot loop via asyncio.run and awaits.
+    """
+
+    def __init__(self, alert_port: AlertRoutingPort) -> None:
+        self._alert_port = alert_port
+
+    def __call__(self, record: WebhookDeliveryRecord) -> None:
+        alert = build_dlq_alert(record)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop — caller is fully synchronous.
+            with contextlib.suppress(Exception):
+                asyncio.run(self._alert_port.send_alert(alert))
+            return
+        with contextlib.suppress(Exception):
+            loop.create_task(self._alert_port.send_alert(alert))

--- a/services/webhooks/http_delivery_client.py
+++ b/services/webhooks/http_delivery_client.py
@@ -1,0 +1,62 @@
+"""
+http_delivery_client.py — httpx-backed WebhookDeliveryClient (ADR-034 Step 4).
+
+Single HTTP POST per delivery attempt. Returns a DeliveryResult; never raises
+on transport failure — retry policy is the Port's responsibility, not the
+client's.
+
+Mapping:
+  2xx                 → DeliveryResult(success=True, status_code=<int>)
+  non-2xx             → DeliveryResult(success=False, status_code=<int>,
+                                       error="http <code>")
+  httpx.HTTPError     → DeliveryResult(success=False, status_code=None,
+                                       error="<exc-class>: <msg>")
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from services.webhooks.delivery_client import DeliveryResult, WebhookDeliveryClient
+
+
+class HttpWebhookDeliveryClient(WebhookDeliveryClient):
+    """Real HTTP delivery client backed by httpx.AsyncClient."""
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        self._client = client if client is not None else httpx.AsyncClient()
+        self._owns_client = client is None
+
+    async def deliver(
+        self,
+        target_url: str,
+        payload: dict,
+        timeout_s: float,
+    ) -> DeliveryResult:
+        try:
+            response = await self._client.post(
+                target_url,
+                json=payload,
+                timeout=timeout_s,
+            )
+        except httpx.HTTPError as exc:
+            return DeliveryResult(
+                success=False,
+                status_code=None,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        if 200 <= response.status_code < 300:
+            return DeliveryResult(
+                success=True,
+                status_code=response.status_code,
+                error=None,
+            )
+        return DeliveryResult(
+            success=False,
+            status_code=response.status_code,
+            error=f"http {response.status_code}",
+        )
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()

--- a/services/webhooks/redis_adapter.py
+++ b/services/webhooks/redis_adapter.py
@@ -1,0 +1,201 @@
+"""
+redis_adapter.py — Redis-backed WebhookReliabilityPort (ADR-034 Step 4).
+
+Storage layout (generic across providers; SumSub-specific topic naming
+from ADR-034 §Implementation-Plan item 3 applies at the route/handler
+layer when keys are populated, not in this Port abstraction):
+
+  webhook:dedup:{event_id}    String, SETNX guard with EX TTL (default 24h)
+  webhook:record:{event_id}   Hash:
+                                event_id, payload (json), target_url,
+                                attempt, next_retry_at, status, last_error
+  webhook:due                 SortedSet: member=event_id, score=next_retry_at
+  webhook:dlq                 List: LPUSH json-snapshot on exhaustion
+
+Exhaustion semantics:
+  attempt >= max_attempts → status = "dead":
+    * push JSON snapshot to webhook:dlq
+    * delete record hash + zrem from due
+    * fire dlq_alert_hook(record) — exceptions swallowed so alert failures
+      cannot break the delivery loop (ADR-034 silent on this; default = swallow)
+
+Pure Redis-protocol calls; no HTTP; no logging side effects.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import contextlib
+import json
+import time
+from typing import Any
+
+from services.webhooks.reliability_port import (
+    WebhookDeliveryRecord,
+    WebhookReliabilityPort,
+)
+
+RECORD_KEY_PREFIX = "webhook:record:"
+DUE_KEY = "webhook:due"
+DLQ_KEY = "webhook:dlq"
+DEDUP_KEY_PREFIX = "webhook:dedup:"
+
+DLQAlertHook = Callable[[WebhookDeliveryRecord], None]
+
+
+class RedisWebhookReliabilityAdapter(WebhookReliabilityPort):
+    """Redis-backed implementation of WebhookReliabilityPort.
+
+    Args:
+      redis_client:     a redis client supporting set/hset/hgetall/delete/
+                        zadd/zrem/zrangebyscore/lpush — typed loosely as Any
+                        to permit injection of fakes in tests.
+      max_attempts:     attempts allowed before transition to dead state.
+      backoff_schedule: per-attempt seconds-to-wait; last entry repeats.
+      dlq_alert_hook:   optional sync callable invoked on exhaustion. Exceptions
+                        from the hook are swallowed so a misfiring alert sink
+                        cannot break webhook delivery.
+      dedup_ttl_s:      SETNX dedup TTL (default 86400 per ADR-034 §c).
+      clock:            epoch-seconds source; injected for deterministic tests.
+    """
+
+    def __init__(
+        self,
+        redis_client: Any,
+        max_attempts: int = 3,
+        backoff_schedule: tuple[float, ...] = (1.0, 10.0, 60.0),
+        dlq_alert_hook: DLQAlertHook | None = None,
+        dedup_ttl_s: int = 86400,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+        if not backoff_schedule:
+            raise ValueError("backoff_schedule must be non-empty")
+        if dedup_ttl_s < 1:
+            raise ValueError("dedup_ttl_s must be >= 1")
+        self._r = redis_client
+        self._max_attempts = max_attempts
+        self._backoff = backoff_schedule
+        self._dlq_alert = dlq_alert_hook
+        self._dedup_ttl = dedup_ttl_s
+        self._clock = clock
+
+    def enqueue(
+        self,
+        event_id: str,
+        payload: dict,
+        target_url: str,
+        attempt: int = 0,
+    ) -> None:
+        # Idempotency guard (ADR-034 §c step 3): SETNX with TTL.
+        ok = self._r.set(
+            DEDUP_KEY_PREFIX + event_id,
+            "1",
+            nx=True,
+            ex=self._dedup_ttl,
+        )
+        if not ok:
+            return  # duplicate delivery — silently skip
+        now = self._clock()
+        self._r.hset(
+            RECORD_KEY_PREFIX + event_id,
+            mapping={
+                "event_id": event_id,
+                "payload": json.dumps(payload),
+                "target_url": target_url,
+                "attempt": str(attempt),
+                "next_retry_at": str(now),
+                "status": "pending",
+                "last_error": "",
+            },
+        )
+        self._r.zadd(DUE_KEY, {event_id: now})
+
+    def mark_delivered(self, event_id: str) -> None:
+        self._r.delete(RECORD_KEY_PREFIX + event_id)
+        self._r.zrem(DUE_KEY, event_id)
+
+    def mark_failed(self, event_id: str, error: str) -> None:
+        h = self._r.hgetall(RECORD_KEY_PREFIX + event_id)
+        if not h:
+            return
+        attempt = int(h.get("attempt", "0")) + 1
+        if attempt >= self._max_attempts:
+            # Build snapshot before deletion (for DLQ payload + alert).
+            record = self._to_record(
+                h,
+                override={
+                    "attempt": str(attempt),
+                    "status": "dead",
+                    "last_error": error,
+                },
+            )
+            self._r.lpush(
+                DLQ_KEY,
+                json.dumps(
+                    {
+                        "event_id": record.event_id,
+                        "payload": record.payload,
+                        "target_url": record.target_url,
+                        "attempt": record.attempt,
+                        "next_retry_at": record.next_retry_at,
+                        "status": "dead",
+                        "last_error": record.last_error,
+                    }
+                ),
+            )
+            self._r.delete(RECORD_KEY_PREFIX + event_id)
+            self._r.zrem(DUE_KEY, event_id)
+            if self._dlq_alert is not None:
+                # Swallow: a broken alert sink must not break delivery.
+                with contextlib.suppress(Exception):
+                    self._dlq_alert(record)
+            return
+        idx = min(attempt - 1, len(self._backoff) - 1)
+        next_retry = self._clock() + self._backoff[idx]
+        self._r.hset(
+            RECORD_KEY_PREFIX + event_id,
+            mapping={
+                "attempt": str(attempt),
+                "next_retry_at": str(next_retry),
+                "last_error": error,
+            },
+        )
+        self._r.zadd(DUE_KEY, {event_id: next_retry})
+
+    def next_due(self, now_ts: float, limit: int) -> list[WebhookDeliveryRecord]:
+        if limit <= 0:
+            return []
+        members = self._r.zrangebyscore(
+            DUE_KEY,
+            min=0,
+            max=now_ts,
+            start=0,
+            num=limit,
+        )
+        out: list[WebhookDeliveryRecord] = []
+        for event_id in members:
+            h = self._r.hgetall(RECORD_KEY_PREFIX + event_id)
+            if not h or h.get("status") != "pending":
+                continue
+            out.append(self._to_record(h))
+        return out
+
+    def _to_record(
+        self,
+        h: dict,
+        override: dict | None = None,
+    ) -> WebhookDeliveryRecord:
+        data = dict(h)
+        if override:
+            data.update(override)
+        return WebhookDeliveryRecord(
+            event_id=data["event_id"],
+            payload=json.loads(data.get("payload", "{}")),
+            target_url=data.get("target_url", ""),
+            attempt=int(data.get("attempt", "0")),
+            next_retry_at=float(data.get("next_retry_at", "0")),
+            status=data.get("status", "pending"),
+            last_error=data.get("last_error", ""),
+        )

--- a/tests/unit/webhooks/_fakes.py
+++ b/tests/unit/webhooks/_fakes.py
@@ -1,0 +1,162 @@
+"""
+_fakes.py — Hand-rolled minimal in-memory Redis double for webhook adapter tests.
+
+Implements only the operations used by RedisWebhookReliabilityAdapter, with
+the decode_responses=True flavour (strings in/out, not bytes). No new
+dependency on fakeredis is introduced (per Step 4 prompt constraint).
+
+Supported operations:
+  set(name, value, nx=False, ex=None) -> True | None   (None = NX guard hit)
+  hset(name, mapping)                  -> int (fields written)
+  hgetall(name)                        -> dict[str, str]
+  delete(*names)                       -> int
+  zadd(name, mapping)                  -> int
+  zrem(name, *members)                 -> int
+  zrangebyscore(name, min, max, start=0, num=None) -> list[str]
+  lpush(name, *values)                 -> int (new length)
+  lrange(name, start, end)             -> list[str]
+  exists(name)                         -> 0 | 1
+  ttl(name)                            -> int seconds (-2 missing, -1 no-TTL)
+
+Filename starts with "_" so pytest skips it during collection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import time
+
+
+class FakeRedis:
+    """Minimal Redis double for webhook adapter unit tests."""
+
+    def __init__(self, clock: Callable[[], float] | None = None) -> None:
+        self._kv: dict[str, str] = {}
+        self._hashes: dict[str, dict[str, str]] = {}
+        self._zsets: dict[str, dict[str, float]] = {}
+        self._lists: dict[str, list[str]] = {}
+        self._ttls: dict[str, float] = {}  # absolute expiry epoch seconds
+        self._clock = clock or time.time
+
+    def _purge_if_expired(self, name: str) -> None:
+        exp = self._ttls.get(name)
+        if exp is not None and self._clock() >= exp:
+            self._kv.pop(name, None)
+            self._hashes.pop(name, None)
+            self._zsets.pop(name, None)
+            self._lists.pop(name, None)
+            self._ttls.pop(name, None)
+
+    def set(
+        self,
+        name: str,
+        value: str,
+        nx: bool = False,
+        ex: int | None = None,
+    ) -> bool | None:
+        self._purge_if_expired(name)
+        if nx and name in self._kv:
+            return None
+        self._kv[name] = str(value)
+        if ex is not None:
+            self._ttls[name] = self._clock() + ex
+        return True
+
+    def hset(self, name: str, mapping: dict) -> int:
+        h = self._hashes.setdefault(name, {})
+        for k, v in mapping.items():
+            h[k] = str(v)
+        return len(mapping)
+
+    def hgetall(self, name: str) -> dict[str, str]:
+        self._purge_if_expired(name)
+        return dict(self._hashes.get(name, {}))
+
+    def delete(self, *names: str) -> int:
+        count = 0
+        for n in names:
+            removed = False
+            if n in self._kv:
+                del self._kv[n]
+                removed = True
+            if n in self._hashes:
+                del self._hashes[n]
+                removed = True
+            if n in self._zsets:
+                del self._zsets[n]
+                removed = True
+            if n in self._lists:
+                del self._lists[n]
+                removed = True
+            self._ttls.pop(n, None)
+            if removed:
+                count += 1
+        return count
+
+    def zadd(self, name: str, mapping: dict) -> int:
+        z = self._zsets.setdefault(name, {})
+        for member, score in mapping.items():
+            z[member] = float(score)
+        return len(mapping)
+
+    def zrem(self, name: str, *members: str) -> int:
+        z = self._zsets.get(name)
+        if not z:
+            return 0
+        cnt = 0
+        for m in members:
+            if m in z:
+                del z[m]
+                cnt += 1
+        return cnt
+
+    def zrangebyscore(
+        self,
+        name: str,
+        min: float,
+        max: float,
+        start: int = 0,
+        num: int | None = None,
+    ) -> list[str]:
+        z = self._zsets.get(name, {})
+        items = sorted(
+            ((score, member) for member, score in z.items() if min <= score <= max),
+            key=lambda pair: (pair[0], pair[1]),
+        )
+        ordered = [member for _, member in items]
+        if num is None:
+            return ordered[start:]
+        return ordered[start : start + num]
+
+    def lpush(self, name: str, *values: str) -> int:
+        lst = self._lists.setdefault(name, [])
+        for v in values:
+            lst.insert(0, str(v))
+        return len(lst)
+
+    def lrange(self, name: str, start: int, end: int) -> list[str]:
+        lst = self._lists.get(name, [])
+        if end == -1:
+            return list(lst[start:])
+        return list(lst[start : end + 1])
+
+    def exists(self, name: str) -> int:
+        self._purge_if_expired(name)
+        return (
+            1
+            if (
+                name in self._kv
+                or name in self._hashes
+                or name in self._zsets
+                or name in self._lists
+            )
+            else 0
+        )
+
+    def ttl(self, name: str) -> int:
+        self._purge_if_expired(name)
+        exp = self._ttls.get(name)
+        if exp is None:
+            return -1 if name in self._kv else -2
+        remaining = int(exp - self._clock())
+        return max(0, remaining)

--- a/tests/unit/webhooks/test_di_wiring.py
+++ b/tests/unit/webhooks/test_di_wiring.py
@@ -76,10 +76,26 @@ def test_di_singleton_scope_lru_cache_returns_same_instance() -> None:
     assert a is b
 
 
+def test_di_redis_adapter_resolves_after_step4(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADR-034 Step 4 wires the 'redis' branch — no more NotImplementedError."""
+    from services.webhooks.redis_adapter import RedisWebhookReliabilityAdapter
+
+    monkeypatch.setenv("WEBHOOK_RELIABILITY_ADAPTER", "redis")
+    # redis.Redis.from_url() does not connect until the first command, so this
+    # is safe with no real Redis available in the test environment.
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    get_webhook_reliability_port.cache_clear()
+    port = get_webhook_reliability_port()
+    assert isinstance(port, RedisWebhookReliabilityAdapter)
+
+
 def test_di_unknown_adapter_raises_not_implemented(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("WEBHOOK_RELIABILITY_ADAPTER", "redis")
+    """Genuinely unknown adapter values still raise NotImplementedError."""
+    monkeypatch.setenv("WEBHOOK_RELIABILITY_ADAPTER", "kafka")
     get_webhook_reliability_port.cache_clear()
-    with pytest.raises(NotImplementedError, match="Step 4"):
+    with pytest.raises(NotImplementedError, match="'in_memory' and 'redis'"):
         get_webhook_reliability_port()

--- a/tests/unit/webhooks/test_dlq_alert.py
+++ b/tests/unit/webhooks/test_dlq_alert.py
@@ -1,0 +1,94 @@
+"""
+test_dlq_alert.py — TelegramDLQAlertHook tests (ADR-034 Step 4).
+
+Verifies that the sync hook produces a CRITICAL Alert with the canonical
+message body and routes it through the ADR-033 AlertRoutingPort.
+
+ADR-034 is silent on alert-failure semantics; default (per Step 4 prompt)
+is "swallow + don't crash the worker".
+"""
+
+from __future__ import annotations
+
+from services.alerting.alert_port import (
+    Alert,
+    AlertCategory,
+    AlertRoutingPort,
+    AlertSeverity,
+)
+from services.alerting.in_memory_adapter import InMemoryAlertAdapter
+from services.webhooks.dlq_alert import (
+    TelegramDLQAlertHook,
+    build_dlq_alert,
+    format_dlq_message,
+)
+from services.webhooks.reliability_port import WebhookDeliveryRecord
+
+
+def _make_dead_record() -> WebhookDeliveryRecord:
+    return WebhookDeliveryRecord(
+        event_id="ev-1",
+        payload={"applicantId": "a1"},
+        target_url="https://kc/hook",
+        attempt=3,
+        next_retry_at=1234.5,
+        status="dead",
+        last_error="upstream 500",
+    )
+
+
+def test_format_dlq_message_canonical_layout() -> None:
+    msg = format_dlq_message(_make_dead_record())
+    assert "WEBHOOK_DLQ" in msg
+    assert "event_id=ev-1" in msg
+    assert "target=https://kc/hook" in msg
+    assert "attempts=3" in msg
+    assert "last_error=upstream 500" in msg
+
+
+def test_build_dlq_alert_is_critical_generic_with_metadata() -> None:
+    alert: Alert = build_dlq_alert(_make_dead_record())
+    assert alert.category == AlertCategory.GENERIC
+    assert alert.severity == AlertSeverity.CRITICAL
+    assert alert.title == "WEBHOOK_DLQ event_id=ev-1"
+    assert alert.body == format_dlq_message(_make_dead_record())
+    assert alert.metadata == {
+        "event_id": "ev-1",
+        "target_url": "https://kc/hook",
+        "attempts": 3,
+        "last_error": "upstream 500",
+    }
+    assert alert.owner == "CTIO"
+
+
+async def test_dlq_hook_invokes_sender_in_async_context() -> None:
+    """When called from inside a running loop, the hook schedules a task that
+    eventually delivers the alert to the sink."""
+    import asyncio
+
+    sink = InMemoryAlertAdapter()
+    hook = TelegramDLQAlertHook(alert_port=sink)
+    hook(_make_dead_record())
+    # Yield to let the scheduled task run.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert len(sink.alerts) == 1
+    delivered = sink.alerts[0]
+    assert delivered.severity == AlertSeverity.CRITICAL
+    assert delivered.category == AlertCategory.GENERIC
+    assert "event_id=ev-1" in delivered.body
+
+
+def test_dlq_hook_swallows_sender_exceptions_no_crash_to_worker() -> None:
+    """A broken async alert sink must not raise into the worker."""
+
+    class BrokenSink(AlertRoutingPort):
+        async def send_alert(self, alert: Alert) -> bool:
+            raise RuntimeError("sink kaput")
+
+        async def health_check(self) -> bool:
+            return False
+
+    hook = TelegramDLQAlertHook(alert_port=BrokenSink())
+    # No running loop here → hook takes the asyncio.run branch + swallow.
+    hook(_make_dead_record())  # must not raise

--- a/tests/unit/webhooks/test_http_delivery_client.py
+++ b/tests/unit/webhooks/test_http_delivery_client.py
@@ -1,0 +1,75 @@
+"""
+test_http_delivery_client.py — HttpWebhookDeliveryClient tests (ADR-034 Step 4).
+
+Uses httpx.MockTransport — no real network. Each test owns a transport that
+returns a programmed response (or raises) for the single POST under test.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from services.webhooks.http_delivery_client import HttpWebhookDeliveryClient
+
+
+def _client_with(transport: httpx.MockTransport) -> HttpWebhookDeliveryClient:
+    async_client = httpx.AsyncClient(transport=transport)
+    return HttpWebhookDeliveryClient(client=async_client)
+
+
+async def test_deliver_2xx_returns_success() -> None:
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["json"] = request.read().decode()
+        return httpx.Response(200)
+
+    client = _client_with(httpx.MockTransport(handler))
+    res = await client.deliver("https://kc/hook", {"applicantId": "a1"}, 5.0)
+    assert res.success is True
+    assert res.status_code == 200
+    assert res.error is None
+    assert seen["url"] == "https://kc/hook"
+    assert '"applicantId"' in seen["json"]
+
+
+async def test_deliver_4xx_returns_failure_with_status() -> None:
+    transport = httpx.MockTransport(lambda req: httpx.Response(401))
+    client = _client_with(transport)
+    res = await client.deliver("https://x", {}, 5.0)
+    assert res.success is False
+    assert res.status_code == 401
+    assert "http 401" in (res.error or "")
+
+
+async def test_deliver_5xx_returns_failure_with_status() -> None:
+    transport = httpx.MockTransport(lambda req: httpx.Response(503))
+    client = _client_with(transport)
+    res = await client.deliver("https://x", {}, 5.0)
+    assert res.success is False
+    assert res.status_code == 503
+    assert "http 503" in (res.error or "")
+
+
+async def test_deliver_timeout_returns_failure_no_status() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("connect timeout")
+
+    client = _client_with(httpx.MockTransport(handler))
+    res = await client.deliver("https://x", {}, 0.1)
+    assert res.success is False
+    assert res.status_code is None
+    assert "ConnectTimeout" in (res.error or "")
+
+
+async def test_deliver_network_exception_returns_failure_no_status() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("dns failure")
+
+    client = _client_with(httpx.MockTransport(handler))
+    res = await client.deliver("https://x", {}, 5.0)
+    assert res.success is False
+    assert res.status_code is None
+    assert "ConnectError" in (res.error or "")
+    assert "dns failure" in (res.error or "")

--- a/tests/unit/webhooks/test_redis_adapter.py
+++ b/tests/unit/webhooks/test_redis_adapter.py
@@ -1,0 +1,201 @@
+"""
+test_redis_adapter.py — RedisWebhookReliabilityAdapter tests (ADR-034 Step 4).
+
+Uses the hand-rolled FakeRedis double from tests/unit/webhooks/_fakes.py
+to keep tests deterministic without a real Redis instance or fakeredis dep.
+"""
+
+from __future__ import annotations
+
+import json
+
+from services.webhooks.redis_adapter import (
+    DEDUP_KEY_PREFIX,
+    DLQ_KEY,
+    DUE_KEY,
+    RECORD_KEY_PREFIX,
+    RedisWebhookReliabilityAdapter,
+)
+from services.webhooks.reliability_port import WebhookDeliveryRecord
+from tests.unit.webhooks._fakes import FakeRedis
+
+
+def _build(
+    start_time: float = 1000.0,
+    backoff: tuple[float, ...] = (1.0, 10.0, 60.0),
+    max_attempts: int = 3,
+    dedup_ttl_s: int = 86400,
+):
+    clock = [start_time]
+    fake = FakeRedis(clock=lambda: clock[0])
+    captured: list[WebhookDeliveryRecord] = []
+
+    def hook(record: WebhookDeliveryRecord) -> None:
+        captured.append(record)
+
+    adapter = RedisWebhookReliabilityAdapter(
+        redis_client=fake,
+        max_attempts=max_attempts,
+        backoff_schedule=backoff,
+        dlq_alert_hook=hook,
+        dedup_ttl_s=dedup_ttl_s,
+        clock=lambda: clock[0],
+    )
+    return adapter, fake, clock, captured
+
+
+def test_enqueue_creates_record_and_adds_to_due() -> None:
+    adapter, fake, _clock, _captured = _build(start_time=1000.0)
+    adapter.enqueue("ev-1", {"k": "v"}, "https://x")
+    h = fake.hgetall(RECORD_KEY_PREFIX + "ev-1")
+    assert h["event_id"] == "ev-1"
+    assert json.loads(h["payload"]) == {"k": "v"}
+    assert h["target_url"] == "https://x"
+    assert h["status"] == "pending"
+    assert h["attempt"] == "0"
+    assert h["next_retry_at"] == "1000.0"
+    # Due zset has the event at score=1000
+    assert fake._zsets[DUE_KEY] == {"ev-1": 1000.0}
+
+
+def test_enqueue_setnx_dedup_skips_duplicate_event_id() -> None:
+    adapter, fake, _clock, _captured = _build()
+    adapter.enqueue("ev-1", {"a": 1}, "https://x")
+    # Mutate via second enqueue with different payload — should be IGNORED.
+    adapter.enqueue("ev-1", {"a": 999}, "https://x")
+    h = fake.hgetall(RECORD_KEY_PREFIX + "ev-1")
+    assert json.loads(h["payload"]) == {"a": 1}
+
+
+def test_dedup_key_ttl_set_on_enqueue() -> None:
+    adapter, fake, _clock, _captured = _build(dedup_ttl_s=3600)
+    adapter.enqueue("ev-1", {}, "https://x")
+    assert fake.exists(DEDUP_KEY_PREFIX + "ev-1") == 1
+    assert fake.ttl(DEDUP_KEY_PREFIX + "ev-1") == 3600
+
+
+def test_mark_delivered_removes_record_and_due_entry() -> None:
+    adapter, fake, _clock, _captured = _build()
+    adapter.enqueue("ev-1", {}, "https://x")
+    adapter.mark_delivered("ev-1")
+    assert fake.hgetall(RECORD_KEY_PREFIX + "ev-1") == {}
+    assert fake._zsets.get(DUE_KEY, {}) == {}
+
+
+def test_mark_failed_increments_attempt_and_reschedules_with_backoff() -> None:
+    adapter, fake, clock, _captured = _build(start_time=1000.0)
+    adapter.enqueue("ev-1", {}, "https://x")
+    clock[0] = 1000.0
+    adapter.mark_failed("ev-1", "upstream 500")
+    h = fake.hgetall(RECORD_KEY_PREFIX + "ev-1")
+    assert h["attempt"] == "1"
+    assert h["status"] == "pending"
+    assert float(h["next_retry_at"]) == 1001.0  # backoff[0] = 1.0
+    assert h["last_error"] == "upstream 500"
+    # Due zset rescheduled
+    assert fake._zsets[DUE_KEY]["ev-1"] == 1001.0
+
+
+def test_mark_failed_at_max_attempts_pushes_to_dlq_and_fires_alert() -> None:
+    adapter, fake, clock, captured = _build(start_time=0.0, backoff=(1.0, 1.0), max_attempts=2)
+    adapter.enqueue("ev-1", {"applicantId": "a1"}, "https://x")
+    adapter.mark_failed("ev-1", "first")  # attempt=1, still pending
+    assert fake._lists.get(DLQ_KEY) is None
+    assert captured == []
+    adapter.mark_failed("ev-1", "second")  # attempt=2 == max → dead
+
+    # Record removed from active storage
+    assert fake.hgetall(RECORD_KEY_PREFIX + "ev-1") == {}
+    assert fake._zsets.get(DUE_KEY, {}).get("ev-1") is None
+
+    # DLQ has snapshot
+    dlq = fake.lrange(DLQ_KEY, 0, -1)
+    assert len(dlq) == 1
+    snap = json.loads(dlq[0])
+    assert snap["event_id"] == "ev-1"
+    assert snap["status"] == "dead"
+    assert snap["attempt"] == 2
+    assert snap["last_error"] == "second"
+    assert snap["target_url"] == "https://x"
+    assert snap["payload"] == {"applicantId": "a1"}
+
+    # Alert hook fired exactly once with the dead-state record
+    assert len(captured) == 1
+    rec = captured[0]
+    assert rec.event_id == "ev-1"
+    assert rec.status == "dead"
+    assert rec.attempt == 2
+    assert rec.last_error == "second"
+
+
+def test_next_due_returns_only_records_with_score_le_now() -> None:
+    adapter, fake, clock, _captured = _build(start_time=100.0)
+    adapter.enqueue("ev-a", {}, "https://x")  # score=100
+    clock[0] = 100.0
+    adapter.mark_failed("ev-a", "err")  # → next_retry_at=101
+    # Add a fresh one due at t=100
+    clock[0] = 100.0
+    adapter.enqueue("ev-b", {}, "https://x")  # score=100
+
+    # At t=100: only ev-b is due (ev-a is at 101)
+    due_now = adapter.next_due(now_ts=100.0, limit=10)
+    assert [r.event_id for r in due_now] == ["ev-b"]
+    # At t=101: both due, ev-b first (score 100) then ev-a (score 101)
+    due_later = adapter.next_due(now_ts=101.0, limit=10)
+    assert [r.event_id for r in due_later] == ["ev-b", "ev-a"]
+
+
+def test_next_due_respects_batch_limit_and_order() -> None:
+    adapter, fake, clock, _captured = _build(start_time=100.0)
+    # 5 records all due at t=100; FakeRedis sorts by (score, member),
+    # so order ties break alphabetically.
+    for i in range(5):
+        adapter.enqueue(f"ev-{i}", {}, "https://x")
+    capped = adapter.next_due(now_ts=100.0, limit=2)
+    assert [r.event_id for r in capped] == ["ev-0", "ev-1"]
+    full = adapter.next_due(now_ts=100.0, limit=10)
+    assert [r.event_id for r in full] == [f"ev-{i}" for i in range(5)]
+
+
+def test_dead_record_excluded_from_next_due() -> None:
+    adapter, _fake, _clock, _captured = _build(start_time=0.0, backoff=(1.0,), max_attempts=1)
+    adapter.enqueue("ev-1", {}, "https://x")
+    adapter.mark_failed("ev-1", "exhausted immediately")  # attempt=1 == max → dead
+    # No live record remains → next_due empty even at far-future now
+    assert adapter.next_due(now_ts=10_000.0, limit=10) == []
+
+
+def test_dlq_alert_hook_receives_canonical_record() -> None:
+    adapter, _fake, _clock, captured = _build(start_time=0.0, backoff=(1.0,), max_attempts=1)
+    adapter.enqueue("ev-1", {"hello": "world"}, "https://example/hook")
+    adapter.mark_failed("ev-1", "boom")
+    assert len(captured) == 1
+    rec = captured[0]
+    assert rec.event_id == "ev-1"
+    assert rec.payload == {"hello": "world"}
+    assert rec.target_url == "https://example/hook"
+    assert rec.last_error == "boom"
+    assert rec.status == "dead"
+
+
+def test_alert_hook_exception_does_not_break_mark_failed() -> None:
+    # If the alert sink raises, mark_failed must still complete; the record
+    # must still be DLQ'd and removed from the active set.
+    from tests.unit.webhooks._fakes import FakeRedis
+
+    fake = FakeRedis()
+
+    def broken_hook(_record: WebhookDeliveryRecord) -> None:
+        raise RuntimeError("alert sink down")
+
+    adapter = RedisWebhookReliabilityAdapter(
+        redis_client=fake,
+        max_attempts=1,
+        backoff_schedule=(1.0,),
+        dlq_alert_hook=broken_hook,
+        dedup_ttl_s=60,
+    )
+    adapter.enqueue("ev-1", {}, "https://x")
+    adapter.mark_failed("ev-1", "boom")
+    assert fake.hgetall(RECORD_KEY_PREFIX + "ev-1") == {}
+    assert len(fake.lrange(DLQ_KEY, 0, -1)) == 1


### PR DESCRIPTION
## ADR-034 Step 4 — Redis adapter + HTTP client + DLQ + alert

### What
Production-grade Redis-backed WebhookReliabilityPort adapter, real HTTP delivery client, DLQ with Telegram alert on exhaustion. DI redis branch wired (replaces NotImplementedError from Step 2).

### Files (9 / +918 / -8)
- services/webhooks/redis_adapter.py — RedisWebhookReliabilityAdapter (SETNX dedup, due zset, DLQ list, alert hook)
- services/webhooks/http_delivery_client.py — HttpWebhookDeliveryClient (httpx-based, no internal retry)
- services/webhooks/dlq_alert.py — TelegramDLQAlertHook (reuses ADR-033 AlertRoutingPort)
- api/deps.py — wired redis branch with WEBHOOK_DEDUP_TTL_SECONDS (default 86400)
- tests/unit/webhooks/_fakes.py — hand-rolled FakeRedis (11 ops only, no fakeredis dep)
- tests/unit/webhooks/test_redis_adapter.py
- tests/unit/webhooks/test_http_delivery_client.py
- tests/unit/webhooks/test_dlq_alert.py
- tests/unit/webhooks/test_di_wiring.py — updated (split redis test into positive resolution + kafka unknown)

### Spec adherence + deviations
- Key-naming deviation noted in commit body: spec uses SumSub-specific kc:webhooks:sumsub:queue / sumsub:idempotent:{key}. Adapter uses generic webhook:* naming because it is provider-agnostic. SumSub-specific binding wraps this adapter at route layer (later step), preserving Port boundary.
- No new fakeredis dependency (constraint honored). Hand-rolled FakeRedis covers only the 11 ops used (set/hset/hgetall/delete/zadd/zrem/zrangebyscore/lpush/lrange/exists/ttl).
- Reused existing factories: services.alerting.di.get_alert_adapter() (ADR-033); redis.Redis.from_url(REDIS_URL, decode_responses=True) pattern from elsewhere in repo. No new connection management.
- Alert-sink-failure semantics: ADR-034 silent. Default = contextlib.suppress(Exception) so broken alert sink never breaks delivery loop. Covered by 2 tests.
- Lint: 3 SIM105 try/except Exception: pass → contextlib.suppress(Exception). No behavioural change.

### Tests
pytest tests/unit/webhooks/ -q --no-cov: 41 PASS / 0 FAIL (6 Step1 + 7 Step2 + 8 Step3 + 20 Step4).
Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).

### Out of scope
- Step 5: smoke tests.
- SumSub-specific topic naming binding (route layer / later step).
- INSTRUCTION-LEDGER / MEMORY.md / ADR docs sync (main terminal §74).

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
