### PR TITLE
feat(adr-032): Step 4 rotation audit event emitter (ROTATION_DUE + ROTATION_COMPLETED)

### DIFF
--- a/services/secrets/factory.py
+++ b/services/secrets/factory.py
@@ -11,9 +11,11 @@ Usage:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 import os
 
 from services.secrets.env_secret_rotator import EnvSecretRotator
+from services.secrets.rotation_audit_emitter import RotationAuditEmitter
 
 
 class SecretRotationDisabledError(Exception):
@@ -62,3 +64,17 @@ def get_secret_rotator(config: SecretRotationConfig | None = None) -> EnvSecretR
         env_file_path=cfg.env_file_path,
         managed_keys=cfg.managed_keys,
     )
+
+
+@lru_cache(maxsize=1)
+def get_rotation_audit_emitter() -> RotationAuditEmitter:
+    """Singleton RotationAuditEmitter wired to the shared ADR-027 BufferedAuditPort.
+
+    Reuses api.deps.get_buffered_audit_port() so all rotation events flow into
+    the same SQLite ring-buffer that the drain cron consumes. The audit port
+    factory itself is lazily resolved to avoid the api.deps import chain when
+    rotation audit emission is not in use.
+    """
+    from api.deps import get_buffered_audit_port
+
+    return RotationAuditEmitter(audit_port=get_buffered_audit_port())

--- a/services/secrets/rotation_audit_emitter.py
+++ b/services/secrets/rotation_audit_emitter.py
@@ -1,0 +1,104 @@
+"""
+rotation_audit_emitter.py — ROTATION_DUE / ROTATION_COMPLETED event emitter.
+
+ADR-032 §Implementation-Plan item 2: emit canonical audit events for secret
+rotation lifecycle into the ADR-027 BufferedAuditPort ring-buffer, from where
+the existing drain cron flushes to ClickHouse safeguarding_audit.
+
+Event shape (per ADR-032 §matrix):
+  event_type:                  ROTATION_DUE | ROTATION_COMPLETED
+  entity_id (audit_trail key): secret_type
+  actor:                       "SecretRotation"
+  payload:                     {secret_type, owner, previous_rotation_date,
+                                next_due_date | completed_at, approved_by*,
+                                cadence_days}
+                              * COMPLETED only
+
+severity:
+  ROTATION_DUE       → WARNING (overdue rotation indicates compliance risk)
+  ROTATION_COMPLETED → INFO    (terminal success record)
+
+Pure delegation: this module builds AuditEvent dataclasses and forwards them
+to BufferedAuditPort.record(). The buffer port already swallows internal
+errors (ADR-027 §record never raises), so no additional exception handling
+is layered here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+import time
+from typing import TYPE_CHECKING
+
+from src.safeguarding.audit_trail import AuditEvent
+
+if TYPE_CHECKING:
+    from src.safeguarding.buffered_audit_port import BufferedAuditPort
+
+
+EVENT_ROTATION_DUE = "ROTATION_DUE"
+EVENT_ROTATION_COMPLETED = "ROTATION_COMPLETED"
+_ACTOR = "SecretRotation"
+
+
+class RotationAuditEmitter:
+    """Build and forward ROTATION_DUE / ROTATION_COMPLETED audit events."""
+
+    def __init__(
+        self,
+        audit_port: BufferedAuditPort,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._audit = audit_port
+        self._clock = clock
+
+    def emit_rotation_due(
+        self,
+        secret_type: str,
+        owner: str,
+        previous_rotation_date: str | None,
+        next_due_date: str,
+        cadence_days: int,
+    ) -> None:
+        event = AuditEvent(
+            event_type=EVENT_ROTATION_DUE,
+            entity_id=secret_type,
+            actor=_ACTOR,
+            payload={
+                "secret_type": secret_type,
+                "owner": owner,
+                "previous_rotation_date": previous_rotation_date,
+                "next_due_date": next_due_date,
+                "cadence_days": cadence_days,
+            },
+            severity="WARNING",
+            occurred_at=datetime.fromtimestamp(self._clock(), tz=UTC),
+        )
+        self._audit.record(event)
+
+    def emit_rotation_completed(
+        self,
+        secret_type: str,
+        owner: str,
+        approved_by: str,
+        previous_rotation_date: str | None,
+        completed_at: str,
+        cadence_days: int,
+    ) -> None:
+        event = AuditEvent(
+            event_type=EVENT_ROTATION_COMPLETED,
+            entity_id=secret_type,
+            actor=_ACTOR,
+            payload={
+                "secret_type": secret_type,
+                "owner": owner,
+                "approved_by": approved_by,
+                "previous_rotation_date": previous_rotation_date,
+                "completed_at": completed_at,
+                "cadence_days": cadence_days,
+            },
+            severity="INFO",
+            occurred_at=datetime.fromtimestamp(self._clock(), tz=UTC),
+        )
+        self._audit.record(event)

--- a/tests/unit/secrets/test_rotation_audit_emitter.py
+++ b/tests/unit/secrets/test_rotation_audit_emitter.py
@@ -1,0 +1,178 @@
+"""
+test_rotation_audit_emitter.py — RotationAuditEmitter tests (ADR-032 Step 4).
+
+Verifies that ROTATION_DUE / ROTATION_COMPLETED events are built per the
+ADR-032 §matrix shape and forwarded to BufferedAuditPort.record() unchanged.
+
+Uses a FakeBufferedAuditPort that captures the entry list. No real SQLite,
+no real ClickHouse, no network.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from src.safeguarding.audit_trail import AuditEvent
+
+from services.secrets.factory import get_rotation_audit_emitter
+from services.secrets.rotation_audit_emitter import (
+    EVENT_ROTATION_COMPLETED,
+    EVENT_ROTATION_DUE,
+    RotationAuditEmitter,
+)
+
+
+class FakeBufferedAuditPort:
+    """In-memory test double: captures every entry passed to record()."""
+
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+
+    def record(self, entry: Any) -> None:
+        self.records.append(entry)
+
+
+def _make_emitter(start_time: float = 1714000000.0):
+    clock = [start_time]
+    fake = FakeBufferedAuditPort()
+    emitter = RotationAuditEmitter(audit_port=fake, clock=lambda: clock[0])
+    return emitter, fake, clock
+
+
+def test_emit_rotation_due_builds_canonical_event_with_payload_fields() -> None:
+    emitter, fake, _clock = _make_emitter()
+    emitter.emit_rotation_due(
+        secret_type="KC_CLIENT_SECRET_BANXE_COMPLIANCE_API",
+        owner="CTIO",
+        previous_rotation_date="2026-02-11",
+        next_due_date="2026-05-11",
+        cadence_days=90,
+    )
+    assert len(fake.records) == 1
+    ev: AuditEvent = fake.records[0]
+    assert ev.event_type == EVENT_ROTATION_DUE
+    assert ev.entity_id == "KC_CLIENT_SECRET_BANXE_COMPLIANCE_API"
+    assert ev.actor == "SecretRotation"
+    assert ev.severity == "WARNING"
+    assert ev.payload == {
+        "secret_type": "KC_CLIENT_SECRET_BANXE_COMPLIANCE_API",
+        "owner": "CTIO",
+        "previous_rotation_date": "2026-02-11",
+        "next_due_date": "2026-05-11",
+        "cadence_days": 90,
+    }
+
+
+def test_emit_rotation_completed_builds_canonical_event_with_approved_by() -> None:
+    emitter, fake, _clock = _make_emitter()
+    emitter.emit_rotation_completed(
+        secret_type="GITHUB_PAT_RELEASE_BOT",
+        owner="CTIO",
+        approved_by="moriel.carmi",
+        previous_rotation_date="2026-04-11",
+        completed_at="2026-05-11T08:00:00+00:00",
+        cadence_days=30,
+    )
+    assert len(fake.records) == 1
+    ev: AuditEvent = fake.records[0]
+    assert ev.event_type == EVENT_ROTATION_COMPLETED
+    assert ev.entity_id == "GITHUB_PAT_RELEASE_BOT"
+    assert ev.actor == "SecretRotation"
+    assert ev.severity == "INFO"
+    assert ev.payload == {
+        "secret_type": "GITHUB_PAT_RELEASE_BOT",
+        "owner": "CTIO",
+        "approved_by": "moriel.carmi",
+        "previous_rotation_date": "2026-04-11",
+        "completed_at": "2026-05-11T08:00:00+00:00",
+        "cadence_days": 30,
+    }
+
+
+def test_emit_rotation_due_handles_none_previous_rotation_date() -> None:
+    """First-time rotation has no prior date — must serialise as None."""
+    emitter, fake, _clock = _make_emitter()
+    emitter.emit_rotation_due(
+        secret_type="NEW_SECRET",
+        owner="CTIO",
+        previous_rotation_date=None,
+        next_due_date="2026-05-11",
+        cadence_days=90,
+    )
+    assert fake.records[0].payload["previous_rotation_date"] is None
+
+
+def test_emit_uses_injected_clock_for_occurred_at_not_realtime() -> None:
+    """The event timestamp must reflect the injected clock, not wall time."""
+    fixed_ts = 1714000000.0  # 2024-04-24T22:13:20+00:00
+    emitter, fake, _clock = _make_emitter(start_time=fixed_ts)
+    emitter.emit_rotation_due(
+        secret_type="X",
+        owner="O",
+        previous_rotation_date=None,
+        next_due_date="2026-05-11",
+        cadence_days=30,
+    )
+    expected = datetime.fromtimestamp(fixed_ts, tz=UTC)
+    assert fake.records[0].occurred_at == expected
+
+
+def test_emit_rotation_due_and_completed_can_coexist_for_same_secret() -> None:
+    """Lifecycle: DUE event then COMPLETED — both land in audit buffer in order."""
+    emitter, fake, _clock = _make_emitter()
+    emitter.emit_rotation_due(
+        secret_type="K",
+        owner="O",
+        previous_rotation_date="2026-02-11",
+        next_due_date="2026-05-11",
+        cadence_days=90,
+    )
+    emitter.emit_rotation_completed(
+        secret_type="K",
+        owner="O",
+        approved_by="ops",
+        previous_rotation_date="2026-02-11",
+        completed_at="2026-05-11T08:00:00+00:00",
+        cadence_days=90,
+    )
+    assert [r.event_type for r in fake.records] == [
+        EVENT_ROTATION_DUE,
+        EVENT_ROTATION_COMPLETED,
+    ]
+    assert fake.records[0].severity == "WARNING"
+    assert fake.records[1].severity == "INFO"
+
+
+def test_emitter_constants_match_adr032_event_type_names() -> None:
+    """Guard against accidental rename — these strings appear in ClickHouse
+    queries and operator runbooks per ADR-032 §Implementation-Plan item 2."""
+    assert EVENT_ROTATION_DUE == "ROTATION_DUE"
+    assert EVENT_ROTATION_COMPLETED == "ROTATION_COMPLETED"
+
+
+def test_factory_get_rotation_audit_emitter_returns_singleton(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """@lru_cache singleton: two calls return the same instance.
+
+    Redirect the buffered-audit SQLite path to tmp_path so the test does not
+    touch the production default /tmp/banxe-audit-buffer.db.
+    """
+    monkeypatch.setenv("AUDIT_BUFFER_PATH", str(tmp_path / "audit.db"))
+    # Clear both caches: the secrets emitter factory and the underlying
+    # api.deps.get_buffered_audit_port singleton it resolves through.
+    get_rotation_audit_emitter.cache_clear()
+    from api.deps import get_buffered_audit_port
+
+    get_buffered_audit_port.cache_clear()
+    try:
+        a = get_rotation_audit_emitter()
+        b = get_rotation_audit_emitter()
+        assert a is b
+        assert isinstance(a, RotationAuditEmitter)
+    finally:
+        get_rotation_audit_emitter.cache_clear()
+        get_buffered_audit_port.cache_clear()


### PR DESCRIPTION
## ADR-032 Step 4 — Rotation audit event emitter

### What
Closes ADR-032 Implementation Plan item 2: emit canonical ROTATION_DUE + ROTATION_COMPLETED audit events through existing ADR-027 BufferedAuditPort. Pure delegator; no fork of the audit subsystem.

### Files (3 / +298 / -0)
- services/secrets/rotation_audit_emitter.py — RotationAuditEmitter + EVENT_ROTATION_DUE / EVENT_ROTATION_COMPLETED constants
- services/secrets/factory.py — extended with get_rotation_audit_emitter() lru_cache singleton
- tests/unit/secrets/test_rotation_audit_emitter.py — 7 deterministic tests with FakeBufferedAuditPort

### Event shape
- ADR-027 BufferedAuditPort.record(entry) consumes any dataclass (dataclasses.asdict).
- Events built as src.safeguarding.audit_trail.AuditEvent:
  - event_type = "ROTATION_DUE" / "ROTATION_COMPLETED" (constants for rename safety)
  - entity_id = secret_type
  - actor = "SecretRotation"
  - severity = WARNING (DUE) / INFO (COMPLETED)
  - payload: secret_type, owner, previous_rotation_date, next_due_date | completed_at, approved_by (COMPLETED only), cadence_days (per ADR-032 §matrix)
  - occurred_at = datetime.fromtimestamp(injected_clock(), tz=UTC)

### Architectural notes
- No layered exception handling: BufferedAuditPort.record already swallows internal errors via logger.error (lines 82-83). Emitter is a pure delegator.
- Factory shares the SAME BufferedAuditPort singleton with the rest of the app via api.deps.get_buffered_audit_port — rotation events land in the same SQLite buffer the drain cron flushes.
- @lru_cache(maxsize=1) on get_rotation_audit_emitter matches api/deps.py convention.

### Tests
pytest tests/unit/secrets/ tests/integration/test_secret_rotation_integration.py -q --no-cov: 17 PASS / 0 FAIL (6 existing unit + 4 existing integration + 7 new emitter).
Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).
Singleton test isolates filesystem: redirects AUDIT_BUFFER_PATH to tmp_path, clears both lru_caches in try/finally so production /tmp/banxe-audit-buffer.db is never touched.

### Repo quirk flagged
- .gitignore line 45 (secrets/) accidentally matches services/secrets/ and tests/unit/secrets/. Pre-existing tracked files predate the rule. New files required git add -f. Long-term fix = scope the ignore rule (e.g. /secrets/ or **/.secrets/) — repo-wide change, out of bounded context, flag for §74.

### Out of scope (deferred to operator / §74)
- ADR-032 Implementation Plan items: 1 (n8n workflow JSON), 3 (rotation dry-run drill), 4 (gitleaks audit), 5 (placeholder ADR — already exists as ADR-038).
- ADR-032 canon status: still Proposed; ACCEPTED requires operator confirm Option (b) per Decision section.
- INSTRUCTION-LEDGER / MEMORY.md sync.

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive audit event logging for secret rotation workflows. The system now captures when secret rotations become due and when rotations are completed, providing a detailed audit trail of all rotation activities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CarmiBanxe/banxe-emi-stack/pull/122)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->