### PR TITLE
feat(adr-032): Step 5 gitleaks coverage audit + emitter smoke

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,7 +1,85 @@
 title = "banxe-emi-stack gitleaks config"
 
 [allowlist]
-description = "Test HMAC keys in test files"
+description = "Test fixtures + sample/example/template env files"
 paths = [
-  '''tests/.*'''
+  '''tests/.*''',
+  '''\.env\.example''',
+  '''\.env\.sample''',
+  '''\.env\.template''',
+  '''\.env\.test''',
+  '''\.env\.dev''',
 ]
+
+# ── ADR-032 §Cadence-and-ownership matrix coverage ──────────────────────────
+# Each rule below is anchored on an env-var name from the matrix in
+# ADR-032 §Cadence-and-ownership and matches a non-empty value. Rules are
+# intentionally narrow — they only fire when the env-var name appears with
+# an assignment to a non-trivial value (8+ chars). The full matrix is
+# also encoded in scripts/secret-rotation-gitleaks-audit.py (single source
+# of truth for CI coverage gate).
+
+[[rules]]
+id = "banxe-kc-client-secret"
+description = "ADR-032 matrix — KC_CLIENT_SECRET_* (×4, 90d cadence, CTIO approval)"
+regex = '''KC_CLIENT_SECRET_[A-Z0-9_]+\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-kc-boot-admin-password"
+description = "ADR-032 matrix — KC_BOOT_ADMIN_PASSWORD (180d cadence, CEO approval)"
+regex = '''KC_BOOT_ADMIN_PASSWORD\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-kc-db-password"
+description = "ADR-032 matrix — KC_DB_PASSWORD (365d cadence, CTIO approval)"
+regex = '''KC_DB_PASSWORD\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-auth-secret-key"
+description = "ADR-032 matrix — AUTH_SECRET_KEY (JWT, 90d cadence, CTIO approval)"
+regex = '''AUTH_SECRET_KEY\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-postgres-password"
+description = "ADR-032 matrix — POSTGRES_PASSWORD (365d cadence, CTIO approval)"
+regex = '''POSTGRES_PASSWORD\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-clickhouse-password"
+description = "ADR-032 matrix — CLICKHOUSE_PASSWORD (365d cadence, CTIO approval)"
+regex = '''CLICKHOUSE_PASSWORD\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-github-pat"
+description = "ADR-032 matrix — GitHub Actions PATs (GITHUB_PAT_*, 30d cadence, CEO approval)"
+regex = '''GITHUB_PAT_[A-Z0-9_]+\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-marble-api-key"
+description = "ADR-032 matrix — MARBLE_API_KEY (180d cadence, CTIO approval)"
+regex = '''MARBLE_API_KEY\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-jube-password"
+description = "ADR-032 matrix — JUBE_PASSWORD (180d cadence, CTIO approval)"
+regex = '''JUBE_PASSWORD\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-sumsub-app-token"
+description = "ADR-032 matrix — SUMSUB_APP_TOKEN (180d cadence, CTIO approval)"
+regex = '''SUMSUB_APP_TOKEN\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-sumsub-webhook-secret"
+description = "ADR-032 matrix — SUMSUB_WEBHOOK_SECRET (180d cadence, CTIO approval)"
+regex = '''SUMSUB_WEBHOOK_SECRET\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-telegram-bot-token"
+description = "ADR-032 matrix — TELEGRAM_BOT_TOKEN (on-incident cadence, CEO approval)"
+regex = '''TELEGRAM_BOT_TOKEN\s*=\s*['"]?([A-Za-z0-9_\-=+/.:]{8,})['"]?'''
+
+[[rules]]
+id = "banxe-fca-regdata-password"
+description = "ADR-032 matrix — FCA_REGDATA_PASSWORD (90d cadence, CEO approval)"
+regex = '''FCA_REGDATA_PASSWORD\s*=\s*['"]?([A-Za-z0-9_\-=+/.]{8,})['"]?'''

--- a/scripts/secret-rotation-gitleaks-audit.py
+++ b/scripts/secret-rotation-gitleaks-audit.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+secret-rotation-gitleaks-audit.py — ADR-032 Step 5 coverage audit.
+
+Verifies that .gitleaks.toml contains at least one rule whose regex would
+match the canonical env-var form of each secret type listed in ADR-032
+§Cadence-and-ownership matrix. Designed for CI use as a coverage gate.
+
+Pure read of .gitleaks.toml (tomllib). No modification.
+
+Exit codes:
+  0  all matrix entries are covered
+  1  one or more matrix entries are uncovered (full list printed)
+
+Usage:
+    python3 scripts/secret-rotation-gitleaks-audit.py
+    python3 scripts/secret-rotation-gitleaks-audit.py --config path/to/.gitleaks.toml
+
+Refs: ADR-032 §Implementation-Plan item 4 (Gitleaks enforcement).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+import tomllib
+
+# ── ADR-032 §Cadence-and-ownership matrix — single source of truth ───────────
+# Each entry below is one canonical env-var name used to verify gitleaks
+# rule coverage. Glob entries are represented by one example name; the
+# corresponding rule regex must match the glob shape.
+ADR_032_MATRIX_SECRET_NAMES: list[str] = [
+    "KC_CLIENT_SECRET_BANXE_COMPLIANCE_API",  # KC_CLIENT_SECRET_* (×4)
+    "KC_BOOT_ADMIN_PASSWORD",
+    "KC_DB_PASSWORD",
+    "AUTH_SECRET_KEY",
+    "POSTGRES_PASSWORD",
+    "CLICKHOUSE_PASSWORD",
+    "GITHUB_PAT_RELEASE_BOT",  # GitHub Actions PATs (named GITHUB_PAT_*)
+    "MARBLE_API_KEY",
+    "JUBE_PASSWORD",
+    "SUMSUB_APP_TOKEN",
+    "SUMSUB_WEBHOOK_SECRET",
+    "TELEGRAM_BOT_TOKEN",
+    "FCA_REGDATA_PASSWORD",
+]
+
+
+def _secret_env_sample(secret_name: str) -> str:
+    """A representative env-var line gitleaks would scan for this secret."""
+    return f"{secret_name}=AbCd1234efghIJKLmnopQRSTuvwx9012yz"
+
+
+def load_rules(config_path: Path) -> list[dict]:
+    """Parse .gitleaks.toml and return its [[rules]] list (empty if missing)."""
+    if not config_path.exists():
+        return []
+    data = tomllib.loads(config_path.read_text())
+    rules = data.get("rules", [])
+    if not isinstance(rules, list):
+        return []
+    return rules
+
+
+def is_covered(secret_name: str, rules: list[dict]) -> bool:
+    """True iff at least one rule's regex matches the env-var sample."""
+    sample = _secret_env_sample(secret_name)
+    for rule in rules:
+        regex = rule.get("regex")
+        if not regex:
+            continue
+        try:
+            if re.search(regex, sample):
+                return True
+        except re.error:
+            continue
+    return False
+
+
+def audit(config_path: Path) -> tuple[int, list[tuple[str, bool]]]:
+    """Run the audit. Returns (exit_code, [(name, covered_bool), ...])."""
+    rules = load_rules(config_path)
+    report = [(name, is_covered(name, rules)) for name in ADR_032_MATRIX_SECRET_NAMES]
+    missing = [name for name, ok in report if not ok]
+    return (0 if not missing else 1, report)
+
+
+def _print_report(report: list[tuple[str, bool]]) -> None:
+    print(f"ADR-032 gitleaks coverage audit — {len(report)} matrix entries")
+    print("-" * 60)
+    for name, ok in report:
+        mark = "OK " if ok else "MISS"
+        print(f"  [{mark}] {name}")
+    missing = [n for n, ok in report if not ok]
+    if missing:
+        print(f"\nMISSING coverage for {len(missing)} entries:")
+        for name in missing:
+            print(f"  - {name}")
+        print("\nAdd rule patterns to .gitleaks.toml to cover these.")
+    else:
+        print("\nAll matrix entries are covered.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path(".gitleaks.toml"),
+        help="Path to gitleaks toml config (default: .gitleaks.toml)",
+    )
+    args = parser.parse_args(argv)
+    exit_code, report = audit(args.config)
+    _print_report(report)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/smoke/test_secret_rotation_emitter_smoke.py
+++ b/tests/smoke/test_secret_rotation_emitter_smoke.py
@@ -1,0 +1,126 @@
+"""
+test_secret_rotation_emitter_smoke.py — End-to-end smoke for ADR-032 Step 4
+RotationAuditEmitter wired through ADR-027 BufferedAuditPort (Step 5).
+
+Exercises the canonical event lifecycle (ROTATION_DUE → ROTATION_COMPLETED)
+without real SQLite, real ClickHouse, or real network. Validates that the
+factory singleton + emitter glue keep the contract stable end-to-end.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from services.secrets.factory import get_rotation_audit_emitter
+from services.secrets.rotation_audit_emitter import (
+    EVENT_ROTATION_COMPLETED,
+    EVENT_ROTATION_DUE,
+    RotationAuditEmitter,
+)
+
+pytestmark = pytest.mark.smoke
+
+
+class FakeBufferedAuditPort:
+    """In-memory test double matching BufferedAuditPort.record(entry) shape."""
+
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+
+    def record(self, entry: Any) -> None:
+        self.records.append(entry)
+
+
+def _emitter():
+    fake = FakeBufferedAuditPort()
+    clock = [1714000000.0]
+    return (
+        RotationAuditEmitter(audit_port=fake, clock=lambda: clock[0]),
+        fake,
+        clock,
+    )
+
+
+def test_smoke_emit_rotation_due_lands_in_buffered_audit_port() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit_rotation_due(
+        secret_type="KC_CLIENT_SECRET_BANXE_COMPLIANCE_API",
+        owner="CTIO",
+        previous_rotation_date="2026-02-11",
+        next_due_date="2026-05-11",
+        cadence_days=90,
+    )
+    assert len(fake.records) == 1
+    ev = fake.records[0]
+    assert ev.event_type == EVENT_ROTATION_DUE
+    assert ev.severity == "WARNING"
+    assert ev.entity_id == "KC_CLIENT_SECRET_BANXE_COMPLIANCE_API"
+    assert ev.payload["cadence_days"] == 90
+
+
+def test_smoke_emit_rotation_completed_lands_in_buffered_audit_port() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit_rotation_completed(
+        secret_type="GITHUB_PAT_RELEASE_BOT",
+        owner="CTIO",
+        approved_by="moriel.carmi",
+        previous_rotation_date="2026-04-11",
+        completed_at="2026-05-11T08:00:00+00:00",
+        cadence_days=30,
+    )
+    assert len(fake.records) == 1
+    ev = fake.records[0]
+    assert ev.event_type == EVENT_ROTATION_COMPLETED
+    assert ev.severity == "INFO"
+    assert ev.entity_id == "GITHUB_PAT_RELEASE_BOT"
+    assert ev.payload["approved_by"] == "moriel.carmi"
+
+
+def test_smoke_emit_full_cycle_due_then_completed_for_same_secret_type() -> None:
+    emitter, fake, _clock = _emitter()
+    secret = "SUMSUB_WEBHOOK_SECRET"
+    emitter.emit_rotation_due(
+        secret_type=secret,
+        owner="CTIO",
+        previous_rotation_date="2025-11-12",
+        next_due_date="2026-05-11",
+        cadence_days=180,
+    )
+    emitter.emit_rotation_completed(
+        secret_type=secret,
+        owner="CTIO",
+        approved_by="ops",
+        previous_rotation_date="2025-11-12",
+        completed_at="2026-05-11T08:00:00+00:00",
+        cadence_days=180,
+    )
+    assert [r.event_type for r in fake.records] == [
+        EVENT_ROTATION_DUE,
+        EVENT_ROTATION_COMPLETED,
+    ]
+    # Both events share entity_id == secret_type for ClickHouse partitioning by entity.
+    assert all(r.entity_id == secret for r in fake.records)
+
+
+def test_smoke_factory_emitter_uses_shared_audit_port_singleton(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Two factory invocations resolve to the SAME emitter (lru_cache) and that
+    emitter holds the shared BufferedAuditPort singleton from api.deps."""
+    monkeypatch.setenv("AUDIT_BUFFER_PATH", str(tmp_path / "audit.db"))
+    from api.deps import get_buffered_audit_port
+
+    get_rotation_audit_emitter.cache_clear()
+    get_buffered_audit_port.cache_clear()
+    try:
+        a = get_rotation_audit_emitter()
+        b = get_rotation_audit_emitter()
+        assert a is b
+        # Underlying audit_port is the api.deps singleton
+        assert a._audit is get_buffered_audit_port()  # type: ignore[attr-defined]
+    finally:
+        get_rotation_audit_emitter.cache_clear()
+        get_buffered_audit_port.cache_clear()

--- a/tests/unit/secrets/test_gitleaks_audit_script.py
+++ b/tests/unit/secrets/test_gitleaks_audit_script.py
@@ -1,0 +1,123 @@
+"""
+test_gitleaks_audit_script.py — Unit tests for the ADR-032 gitleaks
+coverage audit helper (scripts/secret-rotation-gitleaks-audit.py).
+
+Verifies the parsing + matching + exit-code logic against in-memory toml
+fixtures. No dependency on the live .gitleaks.toml file or gitleaks itself.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+
+
+def _load_audit_module() -> ModuleType:
+    """Load scripts/secret-rotation-gitleaks-audit.py as a module.
+
+    The script file uses hyphens in its name, so it cannot be imported
+    directly via `import scripts.secret-rotation-gitleaks-audit`. We load
+    it via importlib spec.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = repo_root / "scripts" / "secret-rotation-gitleaks-audit.py"
+    spec = importlib.util.spec_from_file_location("_gitleaks_audit_module", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_gitleaks_audit_module"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_toml(tmp_path: Path, body: str) -> Path:
+    cfg = tmp_path / ".gitleaks.toml"
+    cfg.write_text(body)
+    return cfg
+
+
+def test_audit_reports_covered_for_pattern_matching_matrix_entry(tmp_path: Path) -> None:
+    audit_mod = _load_audit_module()
+    cfg = _write_toml(
+        tmp_path,
+        """
+title = "test"
+
+[[rules]]
+id = "test-marble"
+description = "test"
+regex = """
+        + "'''MARBLE_API_KEY\\s*=\\s*[A-Za-z0-9]{8,}'''"
+        + "\n",
+    )
+    exit_code, report = audit_mod.audit(cfg)
+    by_name = dict(report)
+    assert by_name["MARBLE_API_KEY"] is True
+    # And entries not covered remain False
+    assert by_name["FCA_REGDATA_PASSWORD"] is False
+    assert exit_code == 1  # at least one missing
+
+
+def test_audit_reports_missing_for_unmatched_matrix_entry(tmp_path: Path) -> None:
+    audit_mod = _load_audit_module()
+    # Empty config — no rules
+    cfg = _write_toml(tmp_path, 'title = "empty"\n')
+    exit_code, report = audit_mod.audit(cfg)
+    assert exit_code == 1
+    assert all(covered is False for _name, covered in report)
+
+
+def test_audit_exit_code_zero_when_all_covered(tmp_path: Path) -> None:
+    audit_mod = _load_audit_module()
+    # Build a config with one broad regex that matches every matrix entry.
+    cfg = _write_toml(
+        tmp_path,
+        """
+title = "all-covered"
+
+[[rules]]
+id = "catch-all"
+description = "matches any uppercase env-var assignment"
+regex = """
+        + "'''[A-Z_][A-Z0-9_]+\\s*=\\s*[A-Za-z0-9_\\-]{8,}'''"
+        + "\n",
+    )
+    exit_code, report = audit_mod.audit(cfg)
+    assert exit_code == 0
+    assert all(covered for _name, covered in report)
+
+
+def test_audit_handles_missing_config_file_gracefully(tmp_path: Path) -> None:
+    audit_mod = _load_audit_module()
+    missing = tmp_path / "does-not-exist.toml"
+    exit_code, report = audit_mod.audit(missing)
+    # All entries missing → exit 1, but no crash
+    assert exit_code == 1
+    assert len(report) == len(audit_mod.ADR_032_MATRIX_SECRET_NAMES)
+    assert all(covered is False for _name, covered in report)
+
+
+def test_audit_matrix_list_includes_all_adr032_canonical_secret_types() -> None:
+    """Guard: ensure the matrix list in the audit script matches the
+    set of secret types ADR-032 §Cadence-and-ownership matrix declares."""
+    audit_mod = _load_audit_module()
+    expected_substrings = {
+        "KC_CLIENT_SECRET_",
+        "KC_BOOT_ADMIN_PASSWORD",
+        "KC_DB_PASSWORD",
+        "AUTH_SECRET_KEY",
+        "POSTGRES_PASSWORD",
+        "CLICKHOUSE_PASSWORD",
+        "GITHUB_PAT_",
+        "MARBLE_API_KEY",
+        "JUBE_PASSWORD",
+        "SUMSUB_APP_TOKEN",
+        "SUMSUB_WEBHOOK_SECRET",
+        "TELEGRAM_BOT_TOKEN",
+        "FCA_REGDATA_PASSWORD",
+    }
+    matrix_text = " ".join(audit_mod.ADR_032_MATRIX_SECRET_NAMES)
+    for sub in expected_substrings:
+        assert sub in matrix_text, f"missing matrix coverage for {sub}"


### PR DESCRIPTION
## ADR-032 Step 5 — Gitleaks coverage audit + emitter smoke

### What
Closes ADR-032 Implementation Plan item 4 (gitleaks enforcement audit) in code, plus integration smoke scenarios for the Step 4 ROTATION_DUE / ROTATION_COMPLETED emitter. Gitleaks coverage state after this PR: FULL 13/13 ADR-032 §matrix entries covered.

### Files (4 / +450 / -2)
- scripts/secret-rotation-gitleaks-audit.py — CLI coverage report against ADR-032 §matrix; exit 0 = full, 1 = gaps
- tests/unit/secrets/test_gitleaks_audit_script.py — 5 audit script logic tests
- tests/smoke/test_secret_rotation_emitter_smoke.py — 4 deterministic smoke scenarios (DUE / COMPLETED / full cycle / singleton)
- .gitleaks.toml — added 13 narrow detection rules (was allowlist-only baseline) + 5 false-positive guards for .env.example/.sample/.template/.test/.dev

### Coverage state
Baseline: .gitleaks.toml had ZERO detection rules; audit reported 13/13 gaps.
After patch: 13 narrow rules, one per matrix entry (KC_CLIENT_SECRET_*, GITHUB_PAT_* use [A-Z0-9_]+ glob to cover 4 KC clients and N PATs). Audit script exit 0.

### Architectural notes
- Audit script: hyphenated filename matches scripts/secret-rotation-check.py, scripts/audit-buffer-drain.py convention. Test loads via importlib.util.spec_from_file_location.
- Single source of truth: ADR_032_MATRIX_SECRET_NAMES constant in audit script. Rename-guard test (test_audit_matrix_list_includes_all_adr032_canonical_secret_types) protects drift between matrix and rules.
- CI impact zero (non-blocking): existing quality-gate.yml runs gitleaks --exit-code 0 (audit-only). New rules emit SARIF findings but cannot block PRs. Per "prefer zero-edit if possible" — no workflow change. If gating required, register audit script as separate step at §74.

### Tests
pytest tests/unit/secrets/ -q --no-cov: 18 PASS / 0 FAIL (6 rotation_port + 7 emitter Step 4 + 5 audit script).
pytest tests/smoke/test_secret_rotation_emitter_smoke.py -q --no-cov -m smoke: 4 PASS / 0 FAIL.
Total: 22 PASS / 0 FAIL.
Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).

### Repo quirks flagged
- .gitignore secrets/ rule still matches services/secrets/ + tests/unit/secrets/. New test file needed git add -f (same as Step 4). Long-term fix scope = /secrets/ or **/.secrets/ — repo-wide, out of bounded context, flag for §74.
- .claude/memory/commit-log.jsonl harness post-commit hook touches this file every commit; not part of deliverable.

### Out of scope (deferred to operator / §74)
- ADR-032 Implementation Plan item 1 (n8n workflow JSON) — infra/operator zone.
- ADR-032 Implementation Plan item 3 (rotation dry-run drill) — operator zone.
- ADR-032 canon status transition Proposed → Accepted — operator confirms Option (b) in Decision section.
- INSTRUCTION-LEDGER / MEMORY.md sync.
- .gitignore secrets/ rule scoping (repo-wide).
- CI gating of audit script (register as new step in quality-gate.yml if desired).

### ADR-032 implementation chain in code
- Step 1 (PR #110): SecretRotationPort + EnvSecretRotator + 6 unit tests
- Step 2 (PR #111): DI wiring + SECRET_ROTATION_ENABLED + 4 integration tests
- Step 3 (PR #112): rotation check script + 4 smoke tests
- Step 4 (PR #122): rotation audit event emitter (ROTATION_DUE + ROTATION_COMPLETED) + 7 tests
- Step 5 (this PR): gitleaks coverage audit + 5 audit tests + 4 emitter smoke

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
