### PR TITLE
feat(adr-029): Step 4 restore drill port + adapter + cron script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,14 @@ BACKUP_PG_PASSWORD=
 BACKUP_DIR=/data/banxe/backups
 BACKUP_RETENTION_COUNT=7
 
+# === PostgreSQL Restore Drill (ADR-029 §4) ===
+# Feature flag — set to "true" to enable weekly restore-drill operations
+RESTORE_DRILL_ENABLED=false
+# Table used by the row-count validation step (ADR-029 §4 default: "cases")
+RESTORE_DRILL_VALIDATION_TABLE=cases
+# Prefix for the throwaway drill DB (auto-suffixed with instance + epoch)
+RESTORE_DRILL_DB_PREFIX=postgres-restore-drill-
+
 # === Secret Rotation (ADR-032) ===
 # Feature flag — set to "true" to enable rotation operations
 SECRET_ROTATION_ENABLED=false

--- a/scripts/pg-restore-drill-run.py
+++ b/scripts/pg-restore-drill-run.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Postgres restore-drill cron entrypoint (ADR-029 §Implementation-Plan item 4).
+
+Runs a single restore drill against a supplied backup URI:
+  1. createdb {drill-db}
+  2. pg_restore -d {drill-db} {backup-uri}
+  3. psql -t -c "SELECT count(*) FROM {validation_table};"
+  4. dropdb {drill-db}        (best-effort)
+
+Emits a one-line JSON DrillResult to stdout. Designed for weekly cron.
+
+Cron (Sunday 04:00 per ADR-029 §4):
+    0 4 * * 0 cd /opt/banxe && python3 scripts/pg-restore-drill-run.py \\
+        --instance banxe-marble-postgres --backup-uri /data/banxe/backups/... \\
+        >> /var/log/banxe/restore-drill.log 2>&1
+
+Environment variables (see services/backup/factory.RestoreDrillConfig):
+    RESTORE_DRILL_ENABLED            "true" to enable (default: "false" — no-op)
+    RESTORE_DRILL_VALIDATION_TABLE   table for row-count check (default: "cases")
+    RESTORE_DRILL_DB_PREFIX          throwaway DB prefix (default: "postgres-restore-drill-")
+
+Exit codes:
+    0  success (or disabled — no-op)
+    1  drill failure
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import os
+import sys
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+logger = logging.getLogger("banxe.pg-restore-drill")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--instance", required=True, help="logical instance name")
+    parser.add_argument(
+        "--backup-uri",
+        required=True,
+        help="pg_restore-compatible backup URI (local path)",
+    )
+    parser.add_argument(
+        "--target-db",
+        default=None,
+        help="explicit throwaway DB name (default: auto-generated)",
+    )
+    args = parser.parse_args(argv)
+
+    enabled = os.environ.get("RESTORE_DRILL_ENABLED", "false").lower() == "true"
+    if not enabled:
+        logger.info("pg-restore-drill: RESTORE_DRILL_ENABLED != true, skipping (no-op)")
+        return 0
+
+    try:
+        from services.backup.factory import get_restore_drill_adapter
+    except ImportError as exc:
+        logger.error("Import failed — is PYTHONPATH set? %s", exc)
+        return 1
+
+    adapter = get_restore_drill_adapter()
+    result = adapter.run_drill(
+        instance_name=args.instance,
+        backup_uri=args.backup_uri,
+        target_db=args.target_db,
+    )
+
+    print(json.dumps(dataclasses.asdict(result), default=str))
+
+    if result.success:
+        logger.info(
+            "pg-restore-drill: OK instance=%s rows=%s table=%s",
+            result.instance,
+            result.row_count,
+            result.validation_table,
+        )
+        return 0
+
+    logger.error(
+        "pg-restore-drill: FAIL instance=%s error=%s",
+        result.instance,
+        result.error,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/backup/factory.py
+++ b/services/backup/factory.py
@@ -11,8 +11,10 @@ Usage:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 import os
 
+from services.backup.local_restore_drill_adapter import LocalRestoreDrillAdapter
 from services.backup.pg_backup_adapter import PgDumpBackupAdapter
 
 
@@ -67,4 +69,51 @@ def get_backup_adapter(config: BackupConfig | None = None) -> PgDumpBackupAdapte
         pg_password=cfg.pg_password,
         backup_dir=cfg.backup_dir,
         retention_count=cfg.retention_count,
+    )
+
+
+# ── ADR-029 Step 4 — Restore drill ──────────────────────────────────────────
+
+
+class RestoreDrillDisabledError(Exception):
+    """Raised when restore-drill operations are attempted while disabled."""
+
+
+@dataclass(frozen=True)
+class RestoreDrillConfig:
+    """Configuration for LocalRestoreDrillAdapter, loaded from environment."""
+
+    enabled: bool
+    validation_table: str
+    drill_db_prefix: str
+
+    @classmethod
+    def from_env(cls) -> RestoreDrillConfig:
+        return cls(
+            enabled=os.environ.get("RESTORE_DRILL_ENABLED", "false").lower() == "true",
+            validation_table=os.environ.get("RESTORE_DRILL_VALIDATION_TABLE", "cases"),
+            drill_db_prefix=os.environ.get("RESTORE_DRILL_DB_PREFIX", "postgres-restore-drill-"),
+        )
+
+
+@lru_cache(maxsize=1)
+def get_restore_drill_adapter(
+    config: RestoreDrillConfig | None = None,
+) -> LocalRestoreDrillAdapter:
+    """Create a configured LocalRestoreDrillAdapter from environment.
+
+    Raises:
+        RestoreDrillDisabledError: if RESTORE_DRILL_ENABLED is not "true".
+    """
+    cfg = config or RestoreDrillConfig.from_env()
+
+    if not cfg.enabled:
+        raise RestoreDrillDisabledError(
+            "Restore drill operations disabled (RESTORE_DRILL_ENABLED != 'true'). "
+            "Set RESTORE_DRILL_ENABLED=true in environment to enable."
+        )
+
+    return LocalRestoreDrillAdapter(
+        validation_table=cfg.validation_table,
+        drill_db_prefix=cfg.drill_db_prefix,
     )

--- a/services/backup/local_restore_drill_adapter.py
+++ b/services/backup/local_restore_drill_adapter.py
@@ -1,0 +1,169 @@
+"""LocalRestoreDrillAdapter — subprocess-driven restore drill (ADR-029 Step 4).
+
+Implements RestoreDrillPort by orchestrating:
+
+  1. createdb        → throwaway drill DB
+  2. pg_restore -d   → restore the supplied backup URI into the drill DB
+  3. psql -t -c      → SELECT count(*) FROM <validation_table>
+  4. dropdb          → tear down the drill DB (best-effort, never raises)
+
+All subprocesses are routed through an injected callable so unit tests
+can supply a FakeSubprocessRunner. The default runner wraps
+`subprocess.run` with capture_output=True, text=True.
+
+Per ADR-029 §Implementation-Plan item 4: validation_table defaults to
+"cases" (banxe-marble-postgres canonical table). Drill DB name pattern:
+  f"{drill_db_prefix}{instance_name}-{int(clock())}"
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import contextlib
+import re
+import subprocess
+import time
+
+from services.backup.restore_drill_port import DrillResult, RestoreDrillPort
+
+SubprocessRunner = Callable[..., subprocess.CompletedProcess]
+
+# Operator-supplied table identifier must match a strict shape before being
+# interpolated into a SQL string. ADR-029 §4 only requires simple table names
+# ("cases", "applicants", etc.); this rejects anything that could break out.
+_VALID_TABLE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _default_subprocess_runner(args: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+    # capture_output + text default on so the adapter can inspect stdout/stderr.
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    return subprocess.run(args, check=False, **kwargs)  # noqa: S603 — explicit check=False; caller inspects returncode
+
+
+class LocalRestoreDrillAdapter(RestoreDrillPort):
+    """RestoreDrillPort backed by createdb/pg_restore/psql/dropdb."""
+
+    def __init__(
+        self,
+        *,
+        subprocess_runner: SubprocessRunner | None = None,
+        clock: Callable[[], float] = time.time,
+        validation_table: str = "cases",
+        psql_path: str = "psql",
+        pg_restore_path: str = "pg_restore",
+        createdb_path: str = "createdb",
+        dropdb_path: str = "dropdb",
+        drill_db_prefix: str = "postgres-restore-drill-",
+    ) -> None:
+        if not _VALID_TABLE_IDENT.match(validation_table):
+            raise ValueError(
+                f"validation_table must be a simple SQL identifier "
+                f"(letters/digits/underscore, starting non-digit); got "
+                f"{validation_table!r}"
+            )
+        self._run = subprocess_runner or _default_subprocess_runner
+        self._clock = clock
+        self._validation_table = validation_table
+        self._psql = psql_path
+        self._pg_restore = pg_restore_path
+        self._createdb = createdb_path
+        self._dropdb = dropdb_path
+        self._db_prefix = drill_db_prefix
+
+    def run_drill(
+        self,
+        instance_name: str,
+        backup_uri: str,
+        target_db: str | None = None,
+    ) -> DrillResult:
+        drill_db = target_db or f"{self._db_prefix}{instance_name}-{int(self._clock())}"
+
+        # Step 1 — createdb
+        cr = self._run([self._createdb, drill_db])
+        if cr.returncode != 0:
+            self._best_effort_dropdb(drill_db)
+            return DrillResult(
+                success=False,
+                instance=instance_name,
+                backup_uri=backup_uri,
+                restored_at=self._clock(),
+                row_count=None,
+                validation_table=None,
+                error=f"createdb failed (exit {cr.returncode}): {(cr.stderr or '')[:200]}",
+            )
+
+        # Step 2 — pg_restore
+        rr = self._run([self._pg_restore, "--dbname", drill_db, backup_uri])
+        if rr.returncode != 0:
+            self._best_effort_dropdb(drill_db)
+            return DrillResult(
+                success=False,
+                instance=instance_name,
+                backup_uri=backup_uri,
+                restored_at=self._clock(),
+                row_count=None,
+                validation_table=None,
+                error=f"pg_restore failed (exit {rr.returncode}): {(rr.stderr or '')[:200]}",
+            )
+
+        # Step 3 — validation row count.
+        # validation_table is asserted to match _VALID_TABLE_IDENT at __init__,
+        # so direct interpolation here is safe (no user-controlled input).
+        query = f"SELECT count(*) FROM {self._validation_table};"  # noqa: S608  # nosec B608 — identifier validated against _VALID_TABLE_IDENT at construction
+        vr = self._run([self._psql, "-d", drill_db, "-t", "-c", query])
+        if vr.returncode != 0:
+            self._best_effort_dropdb(drill_db)
+            return DrillResult(
+                success=False,
+                instance=instance_name,
+                backup_uri=backup_uri,
+                restored_at=self._clock(),
+                row_count=None,
+                validation_table=self._validation_table,
+                error=f"psql count failed (exit {vr.returncode}): {(vr.stderr or '')[:200]}",
+            )
+
+        row_count = _parse_count(vr.stdout or "")
+        if row_count is None:
+            self._best_effort_dropdb(drill_db)
+            return DrillResult(
+                success=False,
+                instance=instance_name,
+                backup_uri=backup_uri,
+                restored_at=self._clock(),
+                row_count=None,
+                validation_table=self._validation_table,
+                error=f"could not parse row count from psql stdout: {(vr.stdout or '')[:100]!r}",
+            )
+
+        # Step 4 — best-effort cleanup
+        self._best_effort_dropdb(drill_db)
+
+        return DrillResult(
+            success=True,
+            instance=instance_name,
+            backup_uri=backup_uri,
+            restored_at=self._clock(),
+            row_count=row_count,
+            validation_table=self._validation_table,
+            error=None,
+        )
+
+    def _best_effort_dropdb(self, drill_db: str) -> None:
+        with contextlib.suppress(Exception):
+            self._run([self._dropdb, "--if-exists", drill_db])
+
+
+def _parse_count(stdout: str) -> int | None:
+    """psql -t emits a single value with leading/trailing whitespace.
+
+    Returns None when the stdout is empty or not an int.
+    """
+    stripped = stdout.strip()
+    if not stripped:
+        return None
+    try:
+        return int(stripped.splitlines()[0].strip())
+    except (ValueError, IndexError):
+        return None

--- a/services/backup/restore_drill_port.py
+++ b/services/backup/restore_drill_port.py
@@ -1,0 +1,63 @@
+"""RestoreDrillPort — abstract restore-drill interface (ADR-029, G-OPS-02).
+
+Defines the port for weekly automated restore-drill operations: pull a
+known backup, restore it into a throwaway database, count rows in the
+canonical validation table, and report the outcome.
+
+Per ADR-029 §Implementation-Plan item 4: validate restores by row-count
+on the `cases` table for banxe-marble-postgres. Concrete adapters wrap
+pg_restore/psql/dropdb subprocesses (LocalRestoreDrillAdapter) or
+container-based drill targets (future).
+
+Pure typing; no I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class DrillResult:
+    """Outcome of a single restore-drill cycle.
+
+    Fields:
+      success:           True if restore + validation completed without error.
+      instance:          logical instance name (e.g. "banxe-marble-postgres").
+      backup_uri:        the URI that was restored (local path or s3://...).
+      restored_at:       epoch seconds when restore completed.
+      row_count:         row count from validation_table query, None if
+                         validation step was not reached.
+      validation_table:  table queried for row count (None on early failure).
+      error:             human-readable error if !success; None on success.
+    """
+
+    success: bool
+    instance: str
+    backup_uri: str
+    restored_at: float
+    row_count: int | None = None
+    validation_table: str | None = None
+    error: str | None = None
+
+
+class RestoreDrillPort(Protocol):
+    """Port for weekly restore drill (ADR-029 §4 / G-OPS-02)."""
+
+    def run_drill(
+        self,
+        instance_name: str,
+        backup_uri: str,
+        target_db: str | None = None,
+    ) -> DrillResult:
+        """Restore `backup_uri` into a throwaway DB and validate by row count.
+
+        Args:
+          instance_name: logical source instance (for the result label).
+          backup_uri:    pg_restore-compatible URI (local path).
+          target_db:     optional explicit throwaway DB name; if None, the
+                         adapter generates one based on its drill_db_prefix
+                         + injected clock.
+        """
+        ...

--- a/tests/integration/test_restore_drill_integration.py
+++ b/tests/integration/test_restore_drill_integration.py
@@ -1,0 +1,74 @@
+"""Integration tests for the restore-drill factory wiring (ADR-029 Step 4).
+
+These verify the env-driven factory + RestoreDrillConfig contract without
+ever invoking a real subprocess: each test uses monkeypatch.setenv to control
+RESTORE_DRILL_* env vars and asserts the resulting adapter shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.backup.factory import (
+    RestoreDrillConfig,
+    RestoreDrillDisabledError,
+    get_restore_drill_adapter,
+)
+from services.backup.local_restore_drill_adapter import LocalRestoreDrillAdapter
+
+
+@pytest.fixture(autouse=True)
+def _clear_factory_cache_and_env(monkeypatch: pytest.MonkeyPatch):
+    for key in (
+        "RESTORE_DRILL_ENABLED",
+        "RESTORE_DRILL_VALIDATION_TABLE",
+        "RESTORE_DRILL_DB_PREFIX",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    get_restore_drill_adapter.cache_clear()
+    yield
+    get_restore_drill_adapter.cache_clear()
+
+
+def test_factory_raises_when_RESTORE_DRILL_ENABLED_false() -> None:
+    # Default (no env) → disabled → raise
+    with pytest.raises(RestoreDrillDisabledError):
+        get_restore_drill_adapter()
+
+
+def test_factory_returns_adapter_when_RESTORE_DRILL_ENABLED_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RESTORE_DRILL_ENABLED", "true")
+    get_restore_drill_adapter.cache_clear()
+    adapter = get_restore_drill_adapter()
+    assert isinstance(adapter, LocalRestoreDrillAdapter)
+
+
+def test_factory_adapter_uses_validation_table_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RESTORE_DRILL_ENABLED", "true")
+    monkeypatch.setenv("RESTORE_DRILL_VALIDATION_TABLE", "applicants")
+    get_restore_drill_adapter.cache_clear()
+    adapter = get_restore_drill_adapter()
+    # private attr surfaced for assertion purposes only
+    assert adapter._validation_table == "applicants"  # type: ignore[attr-defined]
+
+
+def test_factory_adapter_uses_db_prefix_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RESTORE_DRILL_ENABLED", "true")
+    monkeypatch.setenv("RESTORE_DRILL_DB_PREFIX", "drill-")
+    get_restore_drill_adapter.cache_clear()
+    adapter = get_restore_drill_adapter()
+    assert adapter._db_prefix == "drill-"  # type: ignore[attr-defined]
+
+
+def test_restore_drill_config_defaults_when_env_absent() -> None:
+    """Configuration sanity: defaults align with ADR-029 §4 (table=cases)."""
+    cfg = RestoreDrillConfig.from_env()
+    assert cfg.enabled is False
+    assert cfg.validation_table == "cases"
+    assert cfg.drill_db_prefix == "postgres-restore-drill-"

--- a/tests/unit/backup/test_restore_drill_adapter.py
+++ b/tests/unit/backup/test_restore_drill_adapter.py
@@ -1,0 +1,225 @@
+"""Unit tests for LocalRestoreDrillAdapter (ADR-029 Step 4).
+
+FakeSubprocessRunner is an in-memory subprocess.run stand-in: records every
+invocation (args + kwargs) and returns programmable CompletedProcess. No real
+subprocess, no real database.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+import pytest
+
+from services.backup.factory import (
+    RestoreDrillConfig,
+    RestoreDrillDisabledError,
+    get_restore_drill_adapter,
+)
+from services.backup.local_restore_drill_adapter import LocalRestoreDrillAdapter
+
+
+class FakeSubprocessRunner:
+    """subprocess.run-shaped fake. Programmable per-command (first arg)."""
+
+    def __init__(
+        self,
+        returncodes: dict[str, int] | None = None,
+        stdouts: dict[str, str] | None = None,
+        stderrs: dict[str, str] | None = None,
+    ) -> None:
+        self._rcs = returncodes or {}
+        self._outs = stdouts or {}
+        self._errs = stderrs or {}
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
+        self.calls.append(list(args))
+        key = args[0]
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=self._rcs.get(key, 0),
+            stdout=self._outs.get(key, ""),
+            stderr=self._errs.get(key, ""),
+        )
+
+    def commands_invoked(self) -> list[str]:
+        return [c[0] for c in self.calls]
+
+
+def _adapter(
+    runner: FakeSubprocessRunner,
+    *,
+    clock_value: float = 1714000000.0,
+    validation_table: str = "cases",
+    drill_db_prefix: str = "postgres-restore-drill-",
+) -> LocalRestoreDrillAdapter:
+    return LocalRestoreDrillAdapter(
+        subprocess_runner=runner,
+        clock=lambda: clock_value,
+        validation_table=validation_table,
+        drill_db_prefix=drill_db_prefix,
+    )
+
+
+def test_run_drill_invokes_pg_restore_with_backup_uri() -> None:
+    runner = FakeSubprocessRunner(stdouts={"psql": "42\n"})
+    adapter = _adapter(runner)
+    adapter.run_drill("banxe-marble-postgres", "/data/x.dump")
+    # pg_restore was invoked with --dbname <drill_db> <backup_uri>
+    pg_restore_calls = [c for c in runner.calls if c[0] == "pg_restore"]
+    assert len(pg_restore_calls) == 1
+    assert "--dbname" in pg_restore_calls[0]
+    assert "/data/x.dump" in pg_restore_calls[0]
+
+
+def test_run_drill_invokes_psql_count_on_validation_table() -> None:
+    runner = FakeSubprocessRunner(stdouts={"psql": "100\n"})
+    adapter = _adapter(runner, validation_table="cases")
+    adapter.run_drill("inst", "/x")
+    psql_calls = [c for c in runner.calls if c[0] == "psql"]
+    assert len(psql_calls) == 1
+    # The query string is the last -c argument
+    assert any("SELECT count(*) FROM cases;" in arg for arg in psql_calls[0])
+
+
+def test_run_drill_returns_success_with_row_count_on_clean_subprocess_chain() -> None:
+    runner = FakeSubprocessRunner(stdouts={"psql": "  1234  \n"})
+    adapter = _adapter(runner)
+    res = adapter.run_drill("inst", "/x")
+    assert res.success is True
+    assert res.row_count == 1234
+    assert res.error is None
+    assert res.validation_table == "cases"
+    assert res.instance == "inst"
+    assert res.backup_uri == "/x"
+
+
+def test_run_drill_returns_failure_when_pg_restore_subprocess_errors() -> None:
+    runner = FakeSubprocessRunner(
+        returncodes={"pg_restore": 1},
+        stderrs={"pg_restore": "could not connect"},
+    )
+    adapter = _adapter(runner)
+    res = adapter.run_drill("inst", "/x")
+    assert res.success is False
+    assert res.row_count is None
+    assert res.validation_table is None
+    assert "pg_restore failed" in (res.error or "")
+    assert "could not connect" in (res.error or "")
+
+
+def test_run_drill_returns_failure_when_psql_count_fails() -> None:
+    runner = FakeSubprocessRunner(
+        returncodes={"psql": 2}, stderrs={"psql": "relation does not exist"}
+    )
+    adapter = _adapter(runner)
+    res = adapter.run_drill("inst", "/x")
+    assert res.success is False
+    assert res.row_count is None
+    assert res.validation_table == "cases"
+    assert "psql count failed" in (res.error or "")
+    assert "relation does not exist" in (res.error or "")
+
+
+def test_run_drill_returns_failure_when_createdb_fails() -> None:
+    runner = FakeSubprocessRunner(
+        returncodes={"createdb": 1}, stderrs={"createdb": "permission denied"}
+    )
+    adapter = _adapter(runner)
+    res = adapter.run_drill("inst", "/x")
+    assert res.success is False
+    assert "createdb failed" in (res.error or "")
+    assert "pg_restore" not in runner.commands_invoked()
+
+
+def test_run_drill_drops_drill_db_after_success_best_effort() -> None:
+    runner = FakeSubprocessRunner(stdouts={"psql": "5\n"})
+    adapter = _adapter(runner)
+    res = adapter.run_drill("inst", "/x")
+    assert res.success is True
+    assert "dropdb" in runner.commands_invoked()
+    dropdb_call = next(c for c in runner.calls if c[0] == "dropdb")
+    assert "--if-exists" in dropdb_call
+
+
+def test_run_drill_drops_drill_db_after_failure_best_effort() -> None:
+    runner = FakeSubprocessRunner(returncodes={"pg_restore": 1})
+    adapter = _adapter(runner)
+    res = adapter.run_drill("inst", "/x")
+    assert res.success is False
+    # Cleanup must still attempt dropdb even on the failure path
+    assert "dropdb" in runner.commands_invoked()
+
+
+def test_run_drill_uses_injected_clock_for_unique_db_name() -> None:
+    runner = FakeSubprocessRunner(stdouts={"psql": "0\n"})
+    adapter = _adapter(runner, clock_value=1700000000.0)
+    adapter.run_drill("inst", "/x")
+    createdb_call = next(c for c in runner.calls if c[0] == "createdb")
+    db_name = createdb_call[1]
+    assert db_name == "postgres-restore-drill-inst-1700000000"
+
+
+def test_run_drill_honours_explicit_target_db_argument() -> None:
+    runner = FakeSubprocessRunner(stdouts={"psql": "0\n"})
+    adapter = _adapter(runner)
+    adapter.run_drill("inst", "/x", target_db="custom-drill-db")
+    createdb_call = next(c for c in runner.calls if c[0] == "createdb")
+    assert createdb_call[1] == "custom-drill-db"
+
+
+def test_run_drill_uses_custom_validation_table_when_overridden() -> None:
+    runner = FakeSubprocessRunner(stdouts={"psql": "7\n"})
+    adapter = _adapter(runner, validation_table="customers")
+    res = adapter.run_drill("inst", "/x")
+    psql_call = next(c for c in runner.calls if c[0] == "psql")
+    assert any("SELECT count(*) FROM customers;" in arg for arg in psql_call)
+    assert res.validation_table == "customers"
+
+
+def test_factory_disabled_raises_restore_drill_disabled_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RESTORE_DRILL_ENABLED", "false")
+    get_restore_drill_adapter.cache_clear()
+    try:
+        with pytest.raises(RestoreDrillDisabledError):
+            get_restore_drill_adapter()
+    finally:
+        get_restore_drill_adapter.cache_clear()
+
+
+def test_factory_returns_singleton_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RESTORE_DRILL_ENABLED", "true")
+    get_restore_drill_adapter.cache_clear()
+    try:
+        a = get_restore_drill_adapter()
+        b = get_restore_drill_adapter()
+        assert a is b
+        assert isinstance(a, LocalRestoreDrillAdapter)
+    finally:
+        get_restore_drill_adapter.cache_clear()
+
+
+def test_run_drill_returns_failure_when_psql_stdout_unparsable() -> None:
+    runner = FakeSubprocessRunner(stdouts={"psql": "not-a-number\n"})
+    adapter = _adapter(runner)
+    res = adapter.run_drill("inst", "/x")
+    assert res.success is False
+    assert "could not parse row count" in (res.error or "")
+
+
+def test_run_drill_uses_config_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RESTORE_DRILL_ENABLED", "true")
+    monkeypatch.setenv("RESTORE_DRILL_VALIDATION_TABLE", "applicants")
+    monkeypatch.setenv("RESTORE_DRILL_DB_PREFIX", "drill-")
+    cfg = RestoreDrillConfig.from_env()
+    assert cfg.enabled is True
+    assert cfg.validation_table == "applicants"
+    assert cfg.drill_db_prefix == "drill-"


### PR DESCRIPTION
## ADR-029 Step 4 — Restore drill

### What
Closes ADR-029 Implementation Plan item 4 in code: RestoreDrillPort abstraction + LocalRestoreDrillAdapter (subprocess-injected) + factory singleton + CLI cron script + tests. G-OPS-02 closed at code level; operational cron registration on evo2 = operator zone.

### Files (7 / +689 / -0)
- services/backup/restore_drill_port.py — RestoreDrillPort Protocol + DrillResult dataclass
- services/backup/local_restore_drill_adapter.py — subprocess-driven pg_restore + psql validation, fully injected for testability
- services/backup/factory.py — extended with get_restore_drill_adapter() lru_cache singleton + RESTORE_DRILL_ENABLED flag
- scripts/pg-restore-drill-run.py — CLI wrapper for weekly cron per ADR-029 §4
- .env.example — RESTORE_DRILL_ENABLED, RESTORE_DRILL_VALIDATION_TABLE (default "cases"), RESTORE_DRILL_DB_PREFIX (default "postgres-restore-drill-")
- tests/unit/backup/test_restore_drill_adapter.py — 15 unit tests with FakeSubprocessRunner
- tests/integration/test_restore_drill_integration.py — 5 integration tests for factory + flag wiring

### Architectural notes
- Implementation pattern deviation: ADR-029 §4 mentions banxe-pg-restore-drill.sh (bash). This PR uses Python Port + Adapter + script to match what Steps 1-3 already established for pg-backup-run.py + PgDumpBackupAdapter. Noted in commit body.
- SQL injection defence: validation_table is operator-supplied env, but f"SELECT count(*) FROM {table};" interpolation tripped Ruff S608 and Bandit B608. Added _VALID_TABLE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$") regex check at __init__ (raises ValueError on invalid identifier) + dual-tool suppression (# noqa: S608  # nosec B608). Defence in depth.
- Subprocess injection: LocalRestoreDrillAdapter accepts subprocess_runner callable (default wraps subprocess.run with capture_output=True, text=True, check=False). Tests inject FakeSubprocessRunner with programmable CompletedProcess. No real subprocess in tests.
- Cleanup always runs: _best_effort_dropdb on success and every failure path, wrapped in contextlib.suppress(Exception). dropdb --if-exists handles missing-DB cleanly. createdb-fail path skips pg_restore (asserted by test).
- psql -t output parsing: _parse_count strips whitespace, returns int or None. Unparsable stdout → DrillResult(success=False, error="could not parse row count ..."). Covered by test.
- CLI manually verified: --help renders; RESTORE_DRILL_ENABLED=false → no-op exit 0.

### Tests
pytest tests/unit/backup/ tests/integration/test_restore_drill_integration.py -q --no-cov: 31 PASS / 0 FAIL.
Breakdown: 6 existing backup unit (Step 1) + 5 existing backup integration (Step 2) + 15 new drill unit + 5 new drill integration.
Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).

### Commit retries
- 1st: Ruff auto-formatted; re-staged.
- 2nd: Bandit B608 not accepting ruff-only # noqa: S608; added # nosec B608 alongside.
- 3rd: clean.

### Out of scope (operator / infra / §74)
- Implementation Plan item 1 (MinIO setup on evo2 + bucket banxe-pg-backups).
- Implementation Plan item 3 (WAL-G config for banxe_compliance: wal_level=replica, archive_mode=on, archive_command, pg_basebackup weekly).
- Implementation Plan item 6 (INSTRUCTION-LEDGER update; G-OPS-01/02 evidence binding).
- Operational cron registration of pg-restore-drill-run.py on evo2 (0 4 * * 0).

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
