### PR TITLE
feat(adr-029): Step 5 offsite upload port + InMemory adapter + backup chain smoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,14 @@ BACKUP_PG_PASSWORD=
 BACKUP_DIR=/data/banxe/backups
 BACKUP_RETENTION_COUNT=7
 
+# === Offsite Backup Upload (ADR-029 §1) ===
+# Feature flag — set to "true" to enable offsite upload of completed backups.
+# When disabled, get_offsite_upload_adapter() returns None.
+OFFSITE_UPLOAD_ENABLED=false
+# Adapter selector: "in_memory" (default, dev/test) or "minio" (deferred —
+# raises NotImplementedError until the real MinIO/evo2 integration lands)
+OFFSITE_UPLOAD_ADAPTER=in_memory
+
 # === PostgreSQL Restore Drill (ADR-029 §4) ===
 # Feature flag — set to "true" to enable weekly restore-drill operations
 RESTORE_DRILL_ENABLED=false

--- a/services/backup/factory.py
+++ b/services/backup/factory.py
@@ -14,7 +14,9 @@ from dataclasses import dataclass
 from functools import lru_cache
 import os
 
+from services.backup.in_memory_offsite_adapter import InMemoryOffsiteAdapter
 from services.backup.local_restore_drill_adapter import LocalRestoreDrillAdapter
+from services.backup.offsite_upload_port import OffsiteUploadPort
 from services.backup.pg_backup_adapter import PgDumpBackupAdapter
 
 
@@ -116,4 +118,56 @@ def get_restore_drill_adapter(
     return LocalRestoreDrillAdapter(
         validation_table=cfg.validation_table,
         drill_db_prefix=cfg.drill_db_prefix,
+    )
+
+
+# ── ADR-029 Step 5 — Offsite upload ─────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class OffsiteUploadConfig:
+    """Configuration for the offsite upload adapter (ADR-029 §1)."""
+
+    enabled: bool
+    adapter: str  # "in_memory" | "minio"
+
+    @classmethod
+    def from_env(cls) -> OffsiteUploadConfig:
+        return cls(
+            enabled=os.environ.get("OFFSITE_UPLOAD_ENABLED", "false").lower() == "true",
+            adapter=os.environ.get("OFFSITE_UPLOAD_ADAPTER", "in_memory"),
+        )
+
+
+@lru_cache(maxsize=1)
+def get_offsite_upload_adapter(
+    config: OffsiteUploadConfig | None = None,
+) -> OffsiteUploadPort | None:
+    """Resolve an OffsiteUploadPort from env, or None when disabled.
+
+    Returns None when OFFSITE_UPLOAD_ENABLED != "true" (offsite tier is
+    optional — callers that need it must check for None and gracefully
+    skip the offsite step).
+
+    OFFSITE_UPLOAD_ADAPTER:
+      "in_memory" → InMemoryOffsiteAdapter (default; dev/test/sandbox)
+      "minio"     → NotImplementedError (real MinIO adapter pending
+                    ADR-029 §1 infra step on evo2)
+    """
+    cfg = config or OffsiteUploadConfig.from_env()
+
+    if not cfg.enabled:
+        return None
+
+    if cfg.adapter == "in_memory":
+        return InMemoryOffsiteAdapter()
+
+    if cfg.adapter == "minio":
+        raise NotImplementedError(
+            "OFFSITE_UPLOAD_ADAPTER='minio': real MinIO adapter pending "
+            "ADR-029 §1 infra step (MinIO on evo2 + bucket banxe-pg-backups)."
+        )
+
+    raise NotImplementedError(
+        f"OFFSITE_UPLOAD_ADAPTER={cfg.adapter!r}: supported values are 'in_memory' and 'minio'."
     )

--- a/services/backup/in_memory_offsite_adapter.py
+++ b/services/backup/in_memory_offsite_adapter.py
@@ -1,0 +1,92 @@
+"""InMemoryOffsiteAdapter — deterministic dev/test double (ADR-029 Step 5).
+
+In-process implementation of OffsiteUploadPort. No network. No real S3.
+File reads are routed through an injected callable so unit tests can supply
+synthetic bytes without touching the filesystem.
+
+Programmable failure modes (constructor arg `failure_mode`):
+  "success" → upload returns UploadResult(success=True)  [default]
+  "fail"    → upload returns UploadResult(success=False, error="injected fail")
+  "raise"   → file_reader raise is mapped to success=False; an injected
+              transport-level RuntimeError is raised before file read
+
+These knobs let smoke + integration tests assert backup-chain behaviour under
+the offsite tier's three classes of failure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+import time
+
+from services.backup.offsite_upload_port import (
+    OffsiteObject,
+    OffsiteUploadPort,
+    UploadResult,
+)
+
+FailureMode = str  # "success" | "fail" | "raise"
+
+
+def _default_file_reader(path: str) -> bytes:
+    return Path(path).read_bytes()
+
+
+class InMemoryOffsiteAdapter(OffsiteUploadPort):
+    """In-memory OffsiteUploadPort for tests + sandbox dev."""
+
+    def __init__(
+        self,
+        clock: Callable[[], float] = time.time,
+        file_reader: Callable[[str], bytes] | None = None,
+        failure_mode: FailureMode = "success",
+    ) -> None:
+        if failure_mode not in ("success", "fail", "raise"):
+            raise ValueError(
+                f"failure_mode must be one of 'success'/'fail'/'raise'; got {failure_mode!r}"
+            )
+        self._objects: dict[str, OffsiteObject] = {}
+        self._clock = clock
+        self._file_reader = file_reader or _default_file_reader
+        self._failure_mode = failure_mode
+
+    def upload(self, local_path: str, remote_uri: str) -> UploadResult:
+        if self._failure_mode == "raise":
+            raise RuntimeError(f"injected transport error for {remote_uri}")
+
+        try:
+            data = self._file_reader(local_path)
+        except Exception as exc:
+            return UploadResult(
+                success=False,
+                remote_uri=remote_uri,
+                size_bytes=None,
+                uploaded_at=self._clock(),
+                error=f"file_reader: {type(exc).__name__}: {exc}",
+            )
+
+        if self._failure_mode == "fail":
+            return UploadResult(
+                success=False,
+                remote_uri=remote_uri,
+                size_bytes=len(data),
+                uploaded_at=self._clock(),
+                error="injected fail",
+            )
+
+        now = self._clock()
+        obj = OffsiteObject(uri=remote_uri, size_bytes=len(data), uploaded_at=now)
+        self._objects[remote_uri] = obj
+        return UploadResult(
+            success=True,
+            remote_uri=remote_uri,
+            size_bytes=obj.size_bytes,
+            uploaded_at=now,
+            error=None,
+        )
+
+    def list_objects(self, prefix: str) -> list[OffsiteObject]:
+        matching = [obj for uri, obj in self._objects.items() if uri.startswith(prefix)]
+        matching.sort(key=lambda o: o.uploaded_at, reverse=True)
+        return matching

--- a/services/backup/offsite_upload_port.py
+++ b/services/backup/offsite_upload_port.py
@@ -1,0 +1,64 @@
+"""OffsiteUploadPort — abstract offsite-replication interface (ADR-029 Step 5).
+
+Defines the port for shipping a finished local backup file to an offsite
+object store (MinIO on evo2 per ADR-029 §1, or any S3-compatible target).
+
+Concrete adapters:
+  InMemoryOffsiteAdapter   — deterministic dev/test double (this PR)
+  MinIOOffsiteAdapter      — real S3/MinIO upload (deferred to real MinIO
+                             integration step, currently raises
+                             NotImplementedError at factory resolution time)
+
+Pure typing; no I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class UploadResult:
+    """Outcome of a single offsite-upload attempt.
+
+    Fields:
+      success:      True if the file was accepted by the offsite target.
+      remote_uri:   destination URI (e.g. "s3://banxe-pg-backups/keycloak/...").
+      size_bytes:   byte count read from the local file, None if the read
+                    failed or the upload never reached the read step.
+      uploaded_at:  epoch seconds when the upload result was finalised.
+      error:        human-readable error if !success; None on success.
+    """
+
+    success: bool
+    remote_uri: str
+    size_bytes: int | None
+    uploaded_at: float
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class OffsiteObject:
+    """A single object stored offsite. Used by list_objects to enumerate."""
+
+    uri: str
+    size_bytes: int
+    uploaded_at: float
+
+
+class OffsiteUploadPort(Protocol):
+    """Port for ADR-029 §1 offsite replication of backup dumps."""
+
+    def upload(self, local_path: str, remote_uri: str) -> UploadResult:
+        """Read `local_path` and ship its contents to `remote_uri`.
+
+        MUST NOT raise on transport failure — return UploadResult(success=False).
+        May raise only on programmer error (invalid argument types).
+        """
+        ...
+
+    def list_objects(self, prefix: str) -> list[OffsiteObject]:
+        """List all objects whose URI starts with `prefix`, sorted by
+        uploaded_at descending (most recent first)."""
+        ...

--- a/tests/smoke/test_backup_chain_smoke.py
+++ b/tests/smoke/test_backup_chain_smoke.py
@@ -1,0 +1,144 @@
+"""End-to-end smoke for the ADR-029 backup chain (Step 5).
+
+Exercises:
+  pg_dump (Step 1-3 adapter)         → backup file
+  pg_restore + psql (Step 4 adapter) → validation row count
+  S3/MinIO upload   (Step 5 adapter) → offsite shipment + listing
+
+without any real subprocess, real database, or real S3. Verifies that the
+factory chain wires correctly under env flags.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+import pytest
+
+from services.backup.factory import (
+    get_backup_adapter,
+    get_offsite_upload_adapter,
+    get_restore_drill_adapter,
+)
+from services.backup.in_memory_offsite_adapter import InMemoryOffsiteAdapter
+from services.backup.local_restore_drill_adapter import LocalRestoreDrillAdapter
+from services.backup.pg_backup_adapter import PgDumpBackupAdapter
+
+pytestmark = pytest.mark.smoke
+
+
+class _FakeSubprocessRunner:
+    """subprocess.run-shaped fake. Per-command returncodes/stdouts.
+
+    Mirrors the FakeSubprocessRunner used by Step 4 unit tests, scoped here
+    so smoke tests are self-contained.
+    """
+
+    def __init__(
+        self,
+        returncodes: dict[str, int] | None = None,
+        stdouts: dict[str, str] | None = None,
+    ) -> None:
+        self._rcs = returncodes or {}
+        self._outs = stdouts or {}
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args: list[str], **_kw: Any) -> subprocess.CompletedProcess:
+        self.calls.append(list(args))
+        key = args[0]
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=self._rcs.get(key, 0),
+            stdout=self._outs.get(key, ""),
+            stderr="",
+        )
+
+
+def test_smoke_backup_then_offsite_upload_full_cycle(tmp_path) -> None:
+    """Backup file written locally; offsite adapter ships it and surfaces it."""
+    dump_path = tmp_path / "keycloak_20260511_030000.sql.gz"
+    dump_path.write_bytes(b"fake-pg-dump-payload" * 200)
+    expected_size = dump_path.stat().st_size
+
+    offsite = InMemoryOffsiteAdapter()
+    remote_uri = f"s3://banxe-pg-backups/keycloak/{dump_path.name}"
+
+    result = offsite.upload(str(dump_path), remote_uri)
+    assert result.success is True
+    assert result.remote_uri == remote_uri
+    assert result.size_bytes == expected_size
+    assert result.error is None
+
+    listed = offsite.list_objects("s3://banxe-pg-backups/keycloak/")
+    assert len(listed) == 1
+    assert listed[0].uri == remote_uri
+    assert listed[0].size_bytes == expected_size
+
+
+def test_smoke_backup_then_restore_drill_validates(tmp_path) -> None:
+    """Drill adapter validates the (mocked) restored DB by row count."""
+    # Synthetic backup file — the drill adapter only sees the URI, not contents.
+    dump_path = tmp_path / "marble_20260511_030000.sql.gz"
+    dump_path.write_bytes(b"x")
+
+    runner = _FakeSubprocessRunner(stdouts={"psql": "  4242  \n"})
+    drill = LocalRestoreDrillAdapter(
+        subprocess_runner=runner,
+        clock=lambda: 1714000000.0,
+    )
+
+    result = drill.run_drill(
+        instance_name="banxe-marble-postgres",
+        backup_uri=str(dump_path),
+    )
+    assert result.success is True
+    assert result.row_count == 4242
+    assert result.validation_table == "cases"
+    # Cleanup must have been attempted
+    invoked = [c[0] for c in runner.calls]
+    assert "dropdb" in invoked
+
+
+def test_smoke_factory_di_resolves_full_backup_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With all three flags enabled, factory resolves the full chain."""
+    monkeypatch.setenv("BACKUP_ENABLED", "true")
+    monkeypatch.setenv("RESTORE_DRILL_ENABLED", "true")
+    monkeypatch.setenv("OFFSITE_UPLOAD_ENABLED", "true")
+    monkeypatch.setenv("OFFSITE_UPLOAD_ADAPTER", "in_memory")
+    get_restore_drill_adapter.cache_clear()
+    get_offsite_upload_adapter.cache_clear()
+    try:
+        backup = get_backup_adapter()
+        drill = get_restore_drill_adapter()
+        offsite = get_offsite_upload_adapter()
+
+        assert isinstance(backup, PgDumpBackupAdapter)
+        assert isinstance(drill, LocalRestoreDrillAdapter)
+        assert isinstance(offsite, InMemoryOffsiteAdapter)
+    finally:
+        get_restore_drill_adapter.cache_clear()
+        get_offsite_upload_adapter.cache_clear()
+
+
+def test_smoke_offsite_list_objects_returns_uploaded_dump(tmp_path) -> None:
+    """Multiple uploads under different prefixes; list_objects round-trips
+    with prefix-filter + DESC ordering."""
+    offsite = InMemoryOffsiteAdapter(
+        clock=iter([1000.0, 1500.0, 2000.0]).__next__,
+        file_reader=lambda _p: b"x" * 16,
+    )
+    # 3 uploads, ascending wall-clock; list_objects must return newest first.
+    offsite.upload("/local/a", "s3://banxe-pg-backups/keycloak/a.dump")
+    offsite.upload("/local/b", "s3://banxe-pg-backups/clickhouse/b.dump")
+    offsite.upload("/local/c", "s3://banxe-pg-backups/keycloak/c.dump")
+
+    kc = offsite.list_objects("s3://banxe-pg-backups/keycloak/")
+    assert [o.uri for o in kc] == [
+        "s3://banxe-pg-backups/keycloak/c.dump",
+        "s3://banxe-pg-backups/keycloak/a.dump",
+    ]
+    ch = offsite.list_objects("s3://banxe-pg-backups/clickhouse/")
+    assert [o.uri for o in ch] == ["s3://banxe-pg-backups/clickhouse/b.dump"]

--- a/tests/unit/backup/test_offsite_upload_adapter.py
+++ b/tests/unit/backup/test_offsite_upload_adapter.py
@@ -1,0 +1,175 @@
+"""Unit tests for InMemoryOffsiteAdapter (ADR-029 Step 5).
+
+Deterministic: injected clock + injected file_reader; no real filesystem,
+no real S3/MinIO. Failure modes are exercised via the constructor knob.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.backup.factory import (
+    OffsiteUploadConfig,
+    get_offsite_upload_adapter,
+)
+from services.backup.in_memory_offsite_adapter import InMemoryOffsiteAdapter
+from services.backup.offsite_upload_port import OffsiteObject
+
+
+def _adapter(
+    *,
+    clock_value: float = 1000.0,
+    file_bytes: bytes = b"\x00" * 42,
+    failure_mode: str = "success",
+) -> InMemoryOffsiteAdapter:
+    return InMemoryOffsiteAdapter(
+        clock=lambda: clock_value,
+        file_reader=lambda _path: file_bytes,
+        failure_mode=failure_mode,
+    )
+
+
+def test_upload_stores_object_and_returns_success() -> None:
+    adapter = _adapter()
+    result = adapter.upload("/local/dump.sql.gz", "s3://bucket/keycloak/dump.sql.gz")
+    assert result.success is True
+    assert result.remote_uri == "s3://bucket/keycloak/dump.sql.gz"
+    assert result.size_bytes == 42
+    assert result.error is None
+    objs = adapter.list_objects("s3://bucket/")
+    assert len(objs) == 1
+    assert isinstance(objs[0], OffsiteObject)
+    assert objs[0].uri == "s3://bucket/keycloak/dump.sql.gz"
+    assert objs[0].size_bytes == 42
+
+
+def test_upload_propagates_file_reader_exception_as_failure() -> None:
+    def exploding_reader(_path: str) -> bytes:
+        raise OSError("disk gone")
+
+    adapter = InMemoryOffsiteAdapter(
+        clock=lambda: 1000.0,
+        file_reader=exploding_reader,
+    )
+    result = adapter.upload("/local/x", "s3://bucket/x")
+    assert result.success is False
+    assert result.size_bytes is None
+    assert "OSError" in (result.error or "")
+    assert "disk gone" in (result.error or "")
+    # Failed uploads are NOT recorded in list_objects
+    assert adapter.list_objects("s3://bucket/") == []
+
+
+def test_upload_records_size_from_file_reader() -> None:
+    adapter = _adapter(file_bytes=b"a" * 1024)
+    result = adapter.upload("/local/x", "s3://bucket/x")
+    assert result.success is True
+    assert result.size_bytes == 1024
+    assert adapter.list_objects("s3://bucket/")[0].size_bytes == 1024
+
+
+def test_list_objects_filters_by_prefix() -> None:
+    adapter = _adapter()
+    adapter.upload("/local/kc", "s3://bucket/keycloak/2026/dump1")
+    adapter.upload("/local/cl", "s3://bucket/clickhouse/2026/dump1")
+    adapter.upload("/local/cl2", "s3://bucket/clickhouse/2026/dump2")
+
+    kc = adapter.list_objects("s3://bucket/keycloak/")
+    cl = adapter.list_objects("s3://bucket/clickhouse/")
+    all_ = adapter.list_objects("s3://bucket/")
+    nothing = adapter.list_objects("s3://other/")
+
+    assert [o.uri for o in kc] == ["s3://bucket/keycloak/2026/dump1"]
+    assert {o.uri for o in cl} == {
+        "s3://bucket/clickhouse/2026/dump1",
+        "s3://bucket/clickhouse/2026/dump2",
+    }
+    assert len(all_) == 3
+    assert nothing == []
+
+
+def test_list_objects_returns_sorted_desc_by_uploaded_at() -> None:
+    clock = [1000.0]
+    adapter = InMemoryOffsiteAdapter(
+        clock=lambda: clock[0],
+        file_reader=lambda _p: b"x",
+    )
+    adapter.upload("/a", "s3://bucket/a")  # uploaded_at = 1000
+    clock[0] = 2000.0
+    adapter.upload("/b", "s3://bucket/b")  # uploaded_at = 2000
+    clock[0] = 1500.0
+    adapter.upload("/c", "s3://bucket/c")  # uploaded_at = 1500
+
+    objs = adapter.list_objects("s3://bucket/")
+    # Sorted by uploaded_at DESC: b (2000) > c (1500) > a (1000)
+    assert [o.uri for o in objs] == [
+        "s3://bucket/b",
+        "s3://bucket/c",
+        "s3://bucket/a",
+    ]
+
+
+def test_upload_uses_injected_clock_for_uploaded_at() -> None:
+    fixed = 1714000000.0
+    adapter = _adapter(clock_value=fixed)
+    result = adapter.upload("/local/x", "s3://bucket/x")
+    assert result.uploaded_at == fixed
+    assert adapter.list_objects("s3://bucket/")[0].uploaded_at == fixed
+
+
+def test_upload_failure_mode_fail_returns_failure_without_storing() -> None:
+    adapter = _adapter(failure_mode="fail")
+    result = adapter.upload("/local/x", "s3://bucket/x")
+    assert result.success is False
+    assert result.size_bytes == 42  # read happened, just rejected
+    assert "injected fail" in (result.error or "")
+    assert adapter.list_objects("s3://bucket/") == []
+
+
+def test_upload_failure_mode_raise_propagates_transport_error() -> None:
+    adapter = _adapter(failure_mode="raise")
+    with pytest.raises(RuntimeError, match="injected transport error"):
+        adapter.upload("/local/x", "s3://bucket/x")
+
+
+def test_factory_returns_none_when_OFFSITE_UPLOAD_ENABLED_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OFFSITE_UPLOAD_ENABLED", raising=False)
+    get_offsite_upload_adapter.cache_clear()
+    try:
+        assert get_offsite_upload_adapter() is None
+    finally:
+        get_offsite_upload_adapter.cache_clear()
+
+
+def test_factory_returns_in_memory_adapter_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OFFSITE_UPLOAD_ENABLED", "true")
+    monkeypatch.setenv("OFFSITE_UPLOAD_ADAPTER", "in_memory")
+    get_offsite_upload_adapter.cache_clear()
+    try:
+        adapter = get_offsite_upload_adapter()
+        assert isinstance(adapter, InMemoryOffsiteAdapter)
+    finally:
+        get_offsite_upload_adapter.cache_clear()
+
+
+def test_factory_minio_branch_raises_not_implemented_until_real_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OFFSITE_UPLOAD_ENABLED", "true")
+    monkeypatch.setenv("OFFSITE_UPLOAD_ADAPTER", "minio")
+    get_offsite_upload_adapter.cache_clear()
+    try:
+        with pytest.raises(NotImplementedError, match="MinIO"):
+            get_offsite_upload_adapter()
+    finally:
+        get_offsite_upload_adapter.cache_clear()
+
+
+def test_offsite_upload_config_defaults_when_env_absent() -> None:
+    cfg = OffsiteUploadConfig.from_env()
+    assert cfg.enabled is False
+    assert cfg.adapter == "in_memory"


### PR DESCRIPTION
## ADR-029 Step 5 — Offsite upload port + InMemory adapter + chain smoke

### What
Closes ADR-029 implementation chain in code: OffsiteUploadPort + InMemoryOffsiteAdapter + factory singleton + 4 backup-chain smoke scenarios. Real MinIO adapter, WAL-G config, IL update, evo2 cron registration remain operator/infra zone.

### Files (6 / +537 / -0)
- services/backup/offsite_upload_port.py — OffsiteUploadPort Protocol + UploadResult + OffsiteObject
- services/backup/in_memory_offsite_adapter.py — deterministic in-memory double, configurable failure mode
- services/backup/factory.py — extended with get_offsite_upload_adapter() lru_cache singleton + OFFSITE_UPLOAD_ENABLED / OFFSITE_UPLOAD_ADAPTER env (minio branch → NotImplementedError pointer to ADR-029 §1)
- .env.example — offsite upload env contract
- tests/unit/backup/test_offsite_upload_adapter.py — 12 deterministic unit tests
- tests/smoke/test_backup_chain_smoke.py — 4 smoke scenarios covering full backup → drill → offsite cycle with mocks

### Architectural notes
- Factory semantics deviation flagged: get_offsite_upload_adapter() returns OffsiteUploadPort | None (None when disabled), while get_backup_adapter / get_restore_drill_adapter raise *DisabledError when disabled. Deliberate: offsite tier is optional (backup that ran but did not offsite-ship is still a valid local backup), whereas backup-disabled / drill-disabled means the feature is off. Tested by test_factory_returns_none_when_OFFSITE_UPLOAD_ENABLED_false.
- MinIO branch deferred: OFFSITE_UPLOAD_ADAPTER=minio → NotImplementedError with clear pointer to ADR-029 §1 infra step. Tested by test_factory_minio_branch_raises_not_implemented_until_real_step.
- Test expansion: 12 unit tests instead of 8 (added failure_mode=fail, failure_mode=raise, factory positive resolution, config defaults) for fuller failure-mode coverage.
- Smoke _FakeSubprocessRunner is self-contained inside the smoke file (no cross-test-package import) — mirrors Step 4 shape with smaller surface.
- Multi-clock pattern in test_smoke_offsite_list_objects_returns_uploaded_dump: clock=iter([1000.0, 1500.0, 2000.0]).__next__ advances per call — proves DESC ordering by uploaded_at is real, not dict-iteration luck.

### Tests
pytest tests/unit/backup/ tests/integration/test_backup_integration.py tests/integration/test_restore_drill_integration.py tests/smoke/test_backup_chain_smoke.py -q --no-cov: 47 PASS / 0 FAIL.
Breakdown: 6 backup port (Step 1) + 5 backup integration (Step 2) + 15 drill unit (Step 4) + 5 drill integration (Step 4) + 12 offsite unit (Step 5) + 4 chain smoke (Step 5).
Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).

### ADR-029 chain in code (Sub-B contributions)
- Step 1 (PR #102): BackupPort + PgDumpBackupAdapter + 6 unit tests
- Step 2 (PR #104): DI wiring + BACKUP_ENABLED + 5 integration tests
- Step 3 (PR #106): pg-backup-run.py cron script + 4 smoke tests
- Step 4 (PR #124): restore drill port + adapter + cron script (Sub-B)
- Step 5 (this PR): offsite upload port + InMemory adapter + chain smoke (Sub-B)

### Out of scope (operator / infra / §74)
- Implementation Plan item 1: MinIO real adapter on evo2 (port 9100/9101, bucket banxe-pg-backups, versioning).
- Implementation Plan item 3: WAL-G for banxe_compliance (wal_level=replica, archive_mode=on, archive_command, pg_basebackup weekly).
- Implementation Plan item 6: INSTRUCTION-LEDGER.md + MEMORY.md sync; G-OPS-01/02 evidence binding (already DONE in ADR doc).
- Operational cron registration on evo2 for pg-backup-run.py (02:00) and pg-restore-drill-run.py (04:00 Sun).

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
