### PR TITLE
feat(adr-030): Step 4 AUTH_RATE_LIMIT_EXCEEDED audit emitter + 429 integration

### DIFF
--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -10,6 +10,7 @@ Router only handles HTTP concerns: request parsing, exception mapping, response 
 
 from __future__ import annotations
 
+import contextlib
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -36,7 +37,11 @@ from services.auth.auth_application_service import (
     AuthApplicationService,
     get_auth_application_service,
 )
-from services.auth.rate_limiter_factory import get_rate_limiter
+from services.auth.rate_limit_audit_emitter import lookup_endpoint_meta
+from services.auth.rate_limiter_factory import (
+    get_rate_limit_audit_emitter,
+    get_rate_limiter,
+)
 from services.auth.sca_application_service import (
     ScaApplicationError,
     ScaApplicationService,
@@ -85,12 +90,59 @@ _ERROR_CODE_TO_HTTP: dict[str, int] = {
 _rate_limiter = get_rate_limiter()
 
 
-def _check_rate_limit(client_id: str, endpoint: str) -> None:
-    """Enforce rate limit. Raises HTTPException 429 if exceeded."""
+def _emit_rate_limit_audit(
+    endpoint: str,
+    client_id: str,
+    client_ip: str,
+    retry_after: int | None,
+) -> None:
+    """ADR-030 Step 4: emit AUTH_RATE_LIMIT_EXCEEDED before the 429 response.
+
+    Identity dimension + AuditEvent severity come from the ADR-030 §matrix
+    lookup. Endpoints not in the matrix get a generic INFO entry so the audit
+    trail still records the 429. Emitter failures are swallowed by the
+    underlying BufferedAuditPort (ADR-027) — they cannot break the 429 path.
+    """
+    meta = lookup_endpoint_meta(endpoint)
+    if meta is None:
+        identity_dimension, severity = ("unknown", "INFO")
+    else:
+        identity_dimension, severity = meta
+    # contextlib.suppress: a broken audit path MUST NOT block the 429
+    # response. BufferedAuditPort.record() already swallows internal errors
+    # per ADR-027, but any failure in factory resolution / matrix lookup
+    # would still propagate without this guard.
+    with contextlib.suppress(Exception):
+        emitter = get_rate_limit_audit_emitter()
+        emitter.emit_rate_limit_exceeded(
+            endpoint=endpoint,
+            identity_dimension=identity_dimension,
+            identity_value=client_id,
+            client_ip=client_ip,
+            limit=f"retry_after={retry_after or 60}s",
+            severity=severity,
+        )
+
+
+def _check_rate_limit(client_id: str, endpoint: str, client_ip: str | None = None) -> None:
+    """Enforce rate limit. Raises HTTPException 429 if exceeded.
+
+    On 429, emit an AUTH_RATE_LIMIT_EXCEEDED audit event via the ADR-027
+    BufferedAuditPort (per ADR-030 §Implementation-Plan item 4) before
+    raising. `client_ip` is recorded in the audit payload; defaults to
+    `client_id` when not separately known (e.g. login flows where client_id
+    already IS the IP).
+    """
     if _rate_limiter is None:
         return
     result = _rate_limiter.check_rate(client_id, endpoint)
     if not result.allowed:
+        _emit_rate_limit_audit(
+            endpoint=endpoint,
+            client_id=client_id,
+            client_ip=client_ip or client_id,
+            retry_after=result.retry_after,
+        )
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail=f"Rate limit exceeded. Retry after {result.retry_after}s.",

--- a/services/auth/rate_limit_audit_emitter.py
+++ b/services/auth/rate_limit_audit_emitter.py
@@ -1,0 +1,114 @@
+"""
+rate_limit_audit_emitter.py — AUTH_RATE_LIMIT_EXCEEDED audit emitter
+(ADR-030 §Implementation-Plan item 4).
+
+Bridges the rate-limit 429 path to the ADR-027 BufferedAuditPort ring buffer.
+Pure event-builder + delegator. The buffer port already swallows internal
+errors per ADR-027, so no try/except is layered here.
+
+Event shape (per ADR-030 §Endpoint × Limit Matrix):
+  event_type:  "AUTH_RATE_LIMIT_EXCEEDED"
+  entity_id:   endpoint path (e.g. "/auth/login")
+  actor:       "RateLimiter"
+  severity:    AuditEvent vocabulary INFO | WARNING | MAJOR | CRITICAL
+               (ADR-030 §matrix HIGH/MEDIUM/CRITICAL/LOW mapped to
+                MAJOR/WARNING/CRITICAL/INFO — see _SEVERITY_MAP below)
+  payload:     endpoint, identity_dimension, identity_value
+               (account_id / customer_id are hashed to sha256[:16] for PII
+                safety; IP / challenge_id / refresh_token_jti / client_id
+                are stored plain), client_ip, limit, severity_label
+  occurred_at: datetime.fromtimestamp(injected_clock(), tz=UTC)
+
+Severity-mapping deviation note: the original Step 4 prompt suggested
+"CRITICAL → ERROR, HIGH/MEDIUM/LOW → WARNING". The actual AuditEvent
+vocabulary in src/safeguarding/audit_trail.py is {INFO, WARNING, MAJOR,
+CRITICAL} — no ERROR. This module follows the repo vocabulary verbatim
+(prompt: "verify mapping from existing audit_trail.py before coding").
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+import hashlib
+import time
+from typing import TYPE_CHECKING
+
+from src.safeguarding.audit_trail import AuditEvent
+
+if TYPE_CHECKING:
+    from src.safeguarding.buffered_audit_port import BufferedAuditPort
+
+
+EVENT_AUTH_RATE_LIMIT_EXCEEDED = "AUTH_RATE_LIMIT_EXCEEDED"
+_ACTOR = "RateLimiter"
+
+# Identity dimensions whose value is treated as PII and must be hashed
+# before being persisted in the audit trail.
+_HASHED_DIMENSIONS: frozenset[str] = frozenset({"account_id", "customer_id"})
+
+# ADR-030 §Endpoint × Limit Matrix → (identity_dimension, AuditEvent.severity)
+# severity values translate ADR-030 HIGH→MAJOR, MEDIUM→WARNING,
+# CRITICAL→CRITICAL, LOW→INFO (per audit_trail.AuditEvent docstring).
+ENDPOINT_AUDIT_META: dict[str, tuple[str, str]] = {
+    "/auth/login": ("IP", "MAJOR"),
+    "/auth/token/refresh": ("refresh_token_jti", "WARNING"),
+    "/auth/sca/initiate": ("customer_id", "MAJOR"),
+    "/auth/sca/verify": ("challenge_id", "CRITICAL"),
+    "/auth/sca/resend": ("challenge_id", "WARNING"),
+    "/auth/sca/methods": ("IP", "INFO"),
+    "/auth/token": ("client_id", "INFO"),
+}
+
+
+def lookup_endpoint_meta(endpoint: str) -> tuple[str, str] | None:
+    """Return (identity_dimension, severity) for the given endpoint, or None
+    if the endpoint is not in the ADR-030 matrix."""
+    return ENDPOINT_AUDIT_META.get(endpoint)
+
+
+def hash_identity_if_pii(dimension: str, value: str) -> str:
+    """sha256[:16] hex for PII dimensions (account_id, customer_id);
+    pass-through for non-PII dimensions (IP, challenge_id, refresh_token_jti,
+    client_id)."""
+    if dimension in _HASHED_DIMENSIONS:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+    return value
+
+
+class RateLimitAuditEmitter:
+    """Build and forward AUTH_RATE_LIMIT_EXCEEDED events to BufferedAuditPort."""
+
+    def __init__(
+        self,
+        audit_port: BufferedAuditPort,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._audit = audit_port
+        self._clock = clock
+
+    def emit_rate_limit_exceeded(
+        self,
+        endpoint: str,
+        identity_dimension: str,
+        identity_value: str,
+        client_ip: str,
+        limit: str,
+        severity: str,
+    ) -> None:
+        event = AuditEvent(
+            event_type=EVENT_AUTH_RATE_LIMIT_EXCEEDED,
+            entity_id=endpoint,
+            actor=_ACTOR,
+            payload={
+                "endpoint": endpoint,
+                "identity_dimension": identity_dimension,
+                "identity_value": hash_identity_if_pii(identity_dimension, identity_value),
+                "client_ip": client_ip,
+                "limit": limit,
+                "severity_label": severity,
+            },
+            severity=severity,
+            occurred_at=datetime.fromtimestamp(self._clock(), tz=UTC),
+        )
+        self._audit.record(event)

--- a/services/auth/rate_limiter_factory.py
+++ b/services/auth/rate_limiter_factory.py
@@ -10,8 +10,10 @@ Usage:
 
 from __future__ import annotations
 
+from functools import lru_cache
 import os
 
+from services.auth.rate_limit_audit_emitter import RateLimitAuditEmitter
 from services.auth.redis_rate_limiter import RedisRateLimiterAdapter
 
 
@@ -26,3 +28,16 @@ def get_rate_limiter() -> RedisRateLimiterAdapter | None:
         window_seconds=int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "60")),
         lockout_seconds=int(os.environ.get("RATE_LIMIT_LOCKOUT_SECONDS", "300")),
     )
+
+
+@lru_cache(maxsize=1)
+def get_rate_limit_audit_emitter() -> RateLimitAuditEmitter:
+    """Singleton RateLimitAuditEmitter wired to the shared ADR-027
+    BufferedAuditPort singleton (api.deps.get_buffered_audit_port).
+
+    Lazy-imports api.deps to avoid pulling the full api.deps top-level chain
+    unless rate-limit audit emission is actually used.
+    """
+    from api.deps import get_buffered_audit_port
+
+    return RateLimitAuditEmitter(audit_port=get_buffered_audit_port())

--- a/tests/integration/test_rate_limit_audit_emission.py
+++ b/tests/integration/test_rate_limit_audit_emission.py
@@ -1,0 +1,148 @@
+"""Integration tests for ADR-030 Step 4 — 429 path emits AUTH_RATE_LIMIT_EXCEEDED.
+
+These exercise api/routers/auth._check_rate_limit directly with a stubbed
+rate limiter that forces the not-allowed branch, and a stubbed
+get_rate_limit_audit_emitter that captures the AuditEvent that would have
+been pushed to BufferedAuditPort. No real Redis, no real SQLite, no real
+HTTP server — pure function-level integration of the router 429 path with
+the audit emitter contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from fastapi import HTTPException
+import pytest
+
+from api.routers import auth as auth_router
+from services.auth.rate_limit_audit_emitter import (
+    EVENT_AUTH_RATE_LIMIT_EXCEEDED,
+    RateLimitAuditEmitter,
+)
+
+
+class _FakeRateLimiter:
+    """Forces not-allowed path on every check; tracks invocations."""
+
+    def __init__(self, retry_after: int = 60) -> None:
+        self._retry = retry_after
+        self.checks: list[tuple[str, str]] = []
+
+    def check_rate(self, client_id: str, endpoint: str):
+        self.checks.append((client_id, endpoint))
+
+        class _Result:
+            allowed = False
+            retry_after = self._retry  # noqa: B023
+
+        return _Result()
+
+    def record_attempt(self, *_a: Any, **_kw: Any) -> None:  # pragma: no cover
+        pass
+
+
+class _FakeAuditPort:
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+
+    def record(self, entry: Any) -> None:
+        self.records.append(entry)
+
+
+@pytest.fixture
+def _wire_429_capture(monkeypatch: pytest.MonkeyPatch):
+    """Wire a forced-block rate limiter + capturing audit port into the router."""
+    fake_audit = _FakeAuditPort()
+    emitter = RateLimitAuditEmitter(audit_port=fake_audit, clock=lambda: 1714000000.0)
+
+    monkeypatch.setattr(auth_router, "_rate_limiter", _FakeRateLimiter())
+    monkeypatch.setattr(auth_router, "get_rate_limit_audit_emitter", lambda: emitter)
+    return fake_audit
+
+
+def test_429_on_auth_login_emits_audit_event_with_ip_dimension(
+    _wire_429_capture: _FakeAuditPort,
+) -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        auth_router._check_rate_limit(
+            client_id="203.0.113.42",
+            endpoint="/auth/login",
+            client_ip="203.0.113.42",
+        )
+    assert excinfo.value.status_code == 429
+    assert len(_wire_429_capture.records) == 1
+    ev = _wire_429_capture.records[0]
+    assert ev.event_type == EVENT_AUTH_RATE_LIMIT_EXCEEDED
+    assert ev.entity_id == "/auth/login"
+    assert ev.severity == "MAJOR"  # ADR-030 §matrix HIGH → AuditEvent MAJOR
+    assert ev.payload["identity_dimension"] == "IP"
+    assert ev.payload["identity_value"] == "203.0.113.42"
+    assert ev.payload["client_ip"] == "203.0.113.42"
+
+
+def test_429_on_sca_verify_emits_audit_event_with_challenge_id_dimension_critical_severity(
+    _wire_429_capture: _FakeAuditPort,
+) -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        auth_router._check_rate_limit(
+            client_id="ch-abc-123",
+            endpoint="/auth/sca/verify",
+            client_ip="198.51.100.7",
+        )
+    assert excinfo.value.status_code == 429
+    assert len(_wire_429_capture.records) == 1
+    ev = _wire_429_capture.records[0]
+    assert ev.severity == "CRITICAL"  # ADR-030 §matrix CRITICAL → CRITICAL
+    assert ev.payload["identity_dimension"] == "challenge_id"
+    assert ev.payload["identity_value"] == "ch-abc-123"  # NOT hashed
+    assert ev.payload["client_ip"] == "198.51.100.7"
+
+
+def test_429_on_sca_initiate_emits_audit_event_with_customer_id_dimension_hashed(
+    _wire_429_capture: _FakeAuditPort,
+) -> None:
+    raw_customer = "cust-banxe-77777"
+    expected_hash = hashlib.sha256(raw_customer.encode("utf-8")).hexdigest()[:16]
+
+    with pytest.raises(HTTPException) as excinfo:
+        auth_router._check_rate_limit(
+            client_id=raw_customer,
+            endpoint="/auth/sca/initiate",
+            client_ip="198.51.100.42",
+        )
+    assert excinfo.value.status_code == 429
+    ev = _wire_429_capture.records[0]
+    assert ev.severity == "MAJOR"
+    assert ev.payload["identity_dimension"] == "customer_id"
+    # PII safety — raw customer_id MUST be sha256[:16]-hashed
+    assert ev.payload["identity_value"] == expected_hash
+    assert ev.payload["identity_value"] != raw_customer
+
+
+def test_audit_emitter_failure_does_not_break_429_response_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken emitter (raises on emit) must not block the 429 path."""
+
+    class _BrokenEmitter:
+        def emit_rate_limit_exceeded(self, **_kw: Any) -> None:
+            raise RuntimeError("audit-sink offline")
+
+    monkeypatch.setattr(auth_router, "_rate_limiter", _FakeRateLimiter())
+    monkeypatch.setattr(
+        auth_router,
+        "get_rate_limit_audit_emitter",
+        lambda: _BrokenEmitter(),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        auth_router._check_rate_limit(
+            client_id="1.2.3.4",
+            endpoint="/auth/login",
+            client_ip="1.2.3.4",
+        )
+    # 429 still raised even though emitter blew up — the suppress around
+    # the emitter call in _emit_rate_limit_audit keeps the 429 path safe.
+    assert excinfo.value.status_code == 429

--- a/tests/unit/auth/test_rate_limit_audit_emitter.py
+++ b/tests/unit/auth/test_rate_limit_audit_emitter.py
@@ -1,0 +1,236 @@
+"""Unit tests for RateLimitAuditEmitter (ADR-030 Step 4).
+
+Deterministic FakeBufferedAuditPort captures every entry passed to record().
+No real SQLite, no real ClickHouse, no network. Injected clock for
+reproducible occurred_at assertions.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import hashlib
+from typing import Any
+
+import pytest
+
+from services.auth.rate_limit_audit_emitter import (
+    ENDPOINT_AUDIT_META,
+    EVENT_AUTH_RATE_LIMIT_EXCEEDED,
+    RateLimitAuditEmitter,
+    hash_identity_if_pii,
+    lookup_endpoint_meta,
+)
+from services.auth.rate_limiter_factory import get_rate_limit_audit_emitter
+
+
+class FakeBufferedAuditPort:
+    """In-memory test double matching BufferedAuditPort.record(entry)."""
+
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+
+    def record(self, entry: Any) -> None:
+        self.records.append(entry)
+
+
+def _emitter(start_time: float = 1714000000.0):
+    clock = [start_time]
+    fake = FakeBufferedAuditPort()
+    return (
+        RateLimitAuditEmitter(audit_port=fake, clock=lambda: clock[0]),
+        fake,
+        clock,
+    )
+
+
+def test_emit_builds_canonical_event_with_AUTH_RATE_LIMIT_EXCEEDED_type() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit_rate_limit_exceeded(
+        endpoint="/auth/login",
+        identity_dimension="IP",
+        identity_value="203.0.113.42",
+        client_ip="203.0.113.42",
+        limit="retry_after=60s",
+        severity="MAJOR",
+    )
+    assert len(fake.records) == 1
+    ev = fake.records[0]
+    assert ev.event_type == EVENT_AUTH_RATE_LIMIT_EXCEEDED
+    assert ev.entity_id == "/auth/login"
+    assert ev.actor == "RateLimiter"
+    assert ev.severity == "MAJOR"
+    assert ev.payload["identity_dimension"] == "IP"
+    assert ev.payload["identity_value"] == "203.0.113.42"
+    assert ev.payload["client_ip"] == "203.0.113.42"
+    assert ev.payload["limit"] == "retry_after=60s"
+    assert ev.payload["severity_label"] == "MAJOR"
+
+
+def test_emit_records_to_audit_port_each_call_appends() -> None:
+    emitter, fake, _clock = _emitter()
+    for _ in range(3):
+        emitter.emit_rate_limit_exceeded(
+            endpoint="/auth/sca/verify",
+            identity_dimension="challenge_id",
+            identity_value="ch-1",
+            client_ip="203.0.113.10",
+            limit="x",
+            severity="CRITICAL",
+        )
+    assert len(fake.records) == 3
+    assert all(r.event_type == EVENT_AUTH_RATE_LIMIT_EXCEEDED for r in fake.records)
+
+
+def test_emit_uses_injected_clock_for_occurred_at_not_realtime() -> None:
+    fixed_ts = 1714000000.0
+    emitter, fake, _clock = _emitter(start_time=fixed_ts)
+    emitter.emit_rate_limit_exceeded(
+        endpoint="/auth/login",
+        identity_dimension="IP",
+        identity_value="1.2.3.4",
+        client_ip="1.2.3.4",
+        limit="x",
+        severity="MAJOR",
+    )
+    assert fake.records[0].occurred_at == datetime.fromtimestamp(fixed_ts, tz=UTC)
+
+
+def test_emit_hashes_account_id_identity_value() -> None:
+    emitter, fake, _clock = _emitter()
+    raw = "user-12345@banxe.io"
+    emitter.emit_rate_limit_exceeded(
+        endpoint="/auth/login",
+        identity_dimension="account_id",
+        identity_value=raw,
+        client_ip="1.2.3.4",
+        limit="x",
+        severity="MAJOR",
+    )
+    expected = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    assert fake.records[0].payload["identity_value"] == expected
+    assert fake.records[0].payload["identity_value"] != raw
+
+
+def test_emit_hashes_customer_id_identity_value() -> None:
+    emitter, fake, _clock = _emitter()
+    raw = "cust-banxe-77777"
+    emitter.emit_rate_limit_exceeded(
+        endpoint="/auth/sca/initiate",
+        identity_dimension="customer_id",
+        identity_value=raw,
+        client_ip="1.2.3.4",
+        limit="x",
+        severity="MAJOR",
+    )
+    expected = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    assert fake.records[0].payload["identity_value"] == expected
+
+
+def test_emit_does_not_hash_ip_identity_value() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit_rate_limit_exceeded(
+        endpoint="/auth/login",
+        identity_dimension="IP",
+        identity_value="198.51.100.7",
+        client_ip="198.51.100.7",
+        limit="x",
+        severity="MAJOR",
+    )
+    assert fake.records[0].payload["identity_value"] == "198.51.100.7"
+
+
+def test_emit_does_not_hash_challenge_id_identity_value() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit_rate_limit_exceeded(
+        endpoint="/auth/sca/verify",
+        identity_dimension="challenge_id",
+        identity_value="ch-abc-123",
+        client_ip="1.2.3.4",
+        limit="x",
+        severity="CRITICAL",
+    )
+    assert fake.records[0].payload["identity_value"] == "ch-abc-123"
+
+
+def test_emit_does_not_hash_refresh_token_jti_identity_value() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit_rate_limit_exceeded(
+        endpoint="/auth/token/refresh",
+        identity_dimension="refresh_token_jti",
+        identity_value="jti-xyz-789",
+        client_ip="1.2.3.4",
+        limit="x",
+        severity="WARNING",
+    )
+    assert fake.records[0].payload["identity_value"] == "jti-xyz-789"
+
+
+def test_emit_severity_propagates_to_event_severity_field() -> None:
+    # ADR-030 §matrix severity HIGH/MEDIUM/CRITICAL/LOW translates to
+    # AuditEvent vocabulary MAJOR/WARNING/CRITICAL/INFO at the caller's end.
+    emitter, fake, _clock = _emitter()
+    for sev in ("INFO", "WARNING", "MAJOR", "CRITICAL"):
+        emitter.emit_rate_limit_exceeded(
+            endpoint="/auth/login",
+            identity_dimension="IP",
+            identity_value="1.2.3.4",
+            client_ip="1.2.3.4",
+            limit="x",
+            severity=sev,
+        )
+    assert [r.severity for r in fake.records] == [
+        "INFO",
+        "WARNING",
+        "MAJOR",
+        "CRITICAL",
+    ]
+
+
+def test_lookup_endpoint_meta_returns_adr030_matrix_dimension_and_severity() -> None:
+    # Spot-check a few rows of ADR-030 §Endpoint × Limit Matrix
+    assert lookup_endpoint_meta("/auth/login") == ("IP", "MAJOR")
+    assert lookup_endpoint_meta("/auth/sca/verify") == ("challenge_id", "CRITICAL")
+    assert lookup_endpoint_meta("/auth/sca/resend") == ("challenge_id", "WARNING")
+    assert lookup_endpoint_meta("/auth/token/refresh") == (
+        "refresh_token_jti",
+        "WARNING",
+    )
+    assert lookup_endpoint_meta("/auth/sca/methods") == ("IP", "INFO")
+    assert lookup_endpoint_meta("/nonexistent") is None
+    # Matrix has exactly 7 entries (matches ADR-030 matrix line count)
+    assert len(ENDPOINT_AUDIT_META) == 7
+
+
+def test_hash_identity_if_pii_helper_directly() -> None:
+    assert hash_identity_if_pii("IP", "1.2.3.4") == "1.2.3.4"
+    raw = "cust-1"
+    assert (
+        hash_identity_if_pii("customer_id", raw) == (hashlib.sha256(raw.encode()).hexdigest()[:16])
+    )
+    assert (
+        hash_identity_if_pii("account_id", raw) == (hashlib.sha256(raw.encode()).hexdigest()[:16])
+    )
+    # 16 hex chars
+    assert len(hash_identity_if_pii("customer_id", raw)) == 16
+
+
+def test_factory_get_rate_limit_audit_emitter_returns_singleton(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """@lru_cache singleton; two calls return the same instance, isolated
+    to a tmp SQLite path so production /tmp/banxe-audit-buffer.db is untouched."""
+    monkeypatch.setenv("AUDIT_BUFFER_PATH", str(tmp_path / "audit.db"))
+    from api.deps import get_buffered_audit_port
+
+    get_rate_limit_audit_emitter.cache_clear()
+    get_buffered_audit_port.cache_clear()
+    try:
+        a = get_rate_limit_audit_emitter()
+        b = get_rate_limit_audit_emitter()
+        assert a is b
+        assert isinstance(a, RateLimitAuditEmitter)
+        # The emitter holds the SHARED audit port singleton
+        assert a._audit is get_buffered_audit_port()  # type: ignore[attr-defined]
+    finally:
+        get_rate_limit_audit_emitter.cache_clear()
+        get_buffered_audit_port.cache_clear()


### PR DESCRIPTION
## ADR-030 Step 4 — Rate-limit audit emitter

### What
Closes ADR-030 Implementation Plan item 4: emit AUTH_RATE_LIMIT_EXCEEDED events through ADR-027 BufferedAuditPort whenever the rate limiter returns 429. PSD2/ASVS/GDPR audit trail for rate-limit events now complete.

### Files (5 / +568 / -3)
- services/auth/rate_limit_audit_emitter.py — RateLimitAuditEmitter + EVENT_AUTH_RATE_LIMIT_EXCEEDED + ENDPOINT_AUDIT_META matrix + sha256 PII hashing helper
- services/auth/rate_limiter_factory.py — extended with get_rate_limit_audit_emitter() lru_cache singleton
- api/routers/auth.py — _check_rate_limit emits audit event via _emit_rate_limit_audit (contextlib.suppress wrapper for 429-path safety)
- tests/unit/auth/test_rate_limit_audit_emitter.py — 12 deterministic unit tests
- tests/integration/test_rate_limit_audit_emission.py — 4 integration tests

### Severity vocabulary deviation
ADR-030 §matrix uses {CRITICAL, HIGH, MEDIUM, LOW}. Repo AuditEvent severity is {INFO, WARNING, MAJOR, CRITICAL} — no ERROR. Followed repo vocabulary verbatim per the prompt's own instruction:
- ADR-030 CRITICAL → AuditEvent CRITICAL
- ADR-030 HIGH → AuditEvent MAJOR
- ADR-030 MEDIUM → AuditEvent WARNING
- ADR-030 LOW → AuditEvent INFO

### Architectural notes
- Single source of truth for the matrix: ENDPOINT_AUDIT_META in rate_limit_audit_emitter.py encodes ADR-030 §Endpoint × Limit Matrix as {endpoint: (dimension, severity)}. Test test_lookup_endpoint_meta_returns_adr030_matrix_dimension_and_severity has len(...) == 7 guard against accidental matrix shrinkage.
- PII safety: account_id and customer_id identity values are sha256-hashed (first 16 hex chars) before persisting. IP, challenge_id, refresh_token_jti, client_id pass through plain. Hashing covered by 6 distinct unit tests + integration test with customer_id.
- Integration hook at _check_rate_limit (NOT global app exception handler): keeps emission inside bounded context of api/routers/auth.py, captures endpoint + identity directly without re-parsing request.url.path, zero net code in api/main.py.
- Defence around emitter in router: _emit_rate_limit_audit wraps emitter in contextlib.suppress(Exception) so broken audit sink (factory resolution failure, broken matrix lookup) cannot break the 429 response path. Asserted by test_audit_emitter_failure_does_not_break_429_response_path (BrokenEmitter raises on emit, HTTPException 429 still bubbles up).
- Emitter is pure: no try/except inside emitter (per prompt) — exceptions propagate. Defence is one level up at the integration site. Lets unit tests catch real emitter bugs while keeping 429 path safe in production.
- Test count: 12 unit tests (prompt asked 8-9) — added does_not_hash_refresh_token_jti, severity_propagates_to_event_severity_field with all 4 levels, dedicated lookup_endpoint_meta matrix coverage, and direct hash_identity_if_pii helper test for fuller PII-boundary coverage.

### Tests
pytest tests/unit/auth/ tests/integration/test_rate_limiter_integration.py tests/integration/test_rate_limit_audit_emission.py -q --no-cov: 28 PASS / 0 FAIL.
Breakdown: 6 existing unit (Step 1) + 6 existing integration (Step 2) + 12 new emitter unit + 4 new integration.
Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).

### Out of scope (operator / infra / §74)
- ADR-030 canon status transition Proposed → Accepted (operator confirms Option (b) per Decision section).
- INSTRUCTION-LEDGER / MEMORY.md sync.
- Traefik / nginx edge layer (Option c, P1).

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
