### PR TITLE
feat(adr-028): Step 4 KYC reverification audit emitter + Port method + wrapper

### DIFF
--- a/services/kyc/factory.py
+++ b/services/kyc/factory.py
@@ -1,0 +1,25 @@
+"""KYC factory — DI singletons for KYC audit emitter (ADR-028 Step 4).
+
+get_kyc_retrigger_audit_emitter() resolves a shared KycRetriggerAuditEmitter
+bound to the singleton BufferedAuditPort from api.deps so re-verification
+audit events flow into the same SQLite ring buffer the drain cron consumes.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from services.kyc.kyc_retrigger_audit_emitter import KycRetriggerAuditEmitter
+
+
+@lru_cache(maxsize=1)
+def get_kyc_retrigger_audit_emitter() -> KycRetriggerAuditEmitter:
+    """Singleton KycRetriggerAuditEmitter wired to the shared ADR-027
+    BufferedAuditPort singleton (api.deps.get_buffered_audit_port).
+
+    Lazy-imports api.deps so callers that never need the emitter don't pay
+    the api.deps top-level import cost.
+    """
+    from api.deps import get_buffered_audit_port
+
+    return KycRetriggerAuditEmitter(audit_port=get_buffered_audit_port())

--- a/services/kyc/kyc_port.py
+++ b/services/kyc/kyc_port.py
@@ -109,6 +109,16 @@ class KYCWorkflowResult:
         return self.status in (KYCStatus.EDD_REQUIRED, KYCStatus.MLRO_REVIEW)
 
 
+# ADR-028 §matrix canonical trigger types for KYC reverification.
+KYC_RETRIGGER_TYPES: tuple[str, ...] = (
+    "role_changed",
+    "beneficial_owner_changed",
+    "sanctions_match",
+    "jurisdiction_changed",
+    "periodic_review_due",
+)
+
+
 class KYCWorkflowPort(Protocol):
     """Hexagonal port for KYC/KYB workflow orchestration."""
 
@@ -118,3 +128,16 @@ class KYCWorkflowPort(Protocol):
     def approve_edd(self, workflow_id: str, mlro_user_id: str) -> KYCWorkflowResult: ...
     def reject_workflow(self, workflow_id: str, reason: RejectionReason) -> KYCWorkflowResult: ...
     def health(self) -> bool: ...
+
+    # ADR-028 Step 4: trigger KYC re-verification for an existing customer.
+    # `trigger_type` MUST be one of KYC_RETRIGGER_TYPES (5 canonical values).
+    # `trigger_payload` carries trigger-specific context (e.g. previous/new
+    # value for role/jurisdiction changes; sanctions hit details).
+    # `requested_by` identifies the upstream actor (LifecycleFSM, MLRO, ...).
+    def trigger_reverification(
+        self,
+        customer_id: str,
+        trigger_type: str,
+        trigger_payload: dict,
+        requested_by: str | None = None,
+    ) -> None: ...

--- a/services/kyc/kyc_retrigger_audit_emitter.py
+++ b/services/kyc/kyc_retrigger_audit_emitter.py
@@ -1,0 +1,144 @@
+"""
+kyc_retrigger_audit_emitter.py — KYC_REVERIFICATION_TRIGGERED audit emitter
+(ADR-028 Step 4).
+
+Bridges the KYC re-trigger path to the ADR-027 BufferedAuditPort ring buffer
+and provides a thin wrapper (publish_kyc_retrigger_with_audit) that combines
+event publication with audit emission under a contextlib.suppress guard so
+audit-sink failure cannot break event delivery.
+
+Event shape (per ADR-028 §Implementation-Plan item 3 + audit_trail.AuditEvent):
+  event_type:  "KYC_REVERIFICATION_TRIGGERED"
+  entity_id:   customer_id (plain — operational reference for ClickHouse
+               partition + cross-event correlation)
+  actor:       requested_by (or "LifecycleFSM" when None)
+  severity:    AuditEvent vocabulary INFO | WARNING | MAJOR | CRITICAL,
+               mapped from trigger_type via TRIGGER_SEVERITY
+  payload:     {customer_id (sha256[:16] hashed for exfiltration safety),
+                trigger_type, trigger_payload, requested_by}
+  occurred_at: datetime.fromtimestamp(injected_clock(), tz=UTC)
+
+ADR-028 §matrix vs repo BanxeEventType deviation note:
+The Step 4 prompt requires 5 canonical trigger types (role_changed,
+beneficial_owner_changed, sanctions_match, jurisdiction_changed,
+periodic_review_due). The repo's BanxeEventType (services/events/event_bus.py)
+currently has only 3 (ROLE_CHANGED, BENEFICIAL_OWNER_CHANGED,
+JURISDICTION_CHANGED). The Port + emitter accept all 5 as strings; the
+wrapper publish_kyc_retrigger_with_audit consumes KycReTriggerEvent
+(BanxeEventType-shaped) and maps only the 3 representable values. Sanctions
+and periodic-review trigger paths arrive via different upstream channels
+not yet wired (deferred to subsequent steps / out of Step 4 scope).
+
+Pure delegator inside the emitter (no try/except); defence-in-depth only in
+the wrapper.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import contextlib
+from datetime import UTC, datetime
+import hashlib
+import time
+from typing import TYPE_CHECKING, Any
+
+from src.safeguarding.audit_trail import AuditEvent
+
+if TYPE_CHECKING:
+    from src.safeguarding.buffered_audit_port import BufferedAuditPort
+
+
+EVENT_KYC_REVERIFICATION_TRIGGERED = "KYC_REVERIFICATION_TRIGGERED"
+_DEFAULT_ACTOR = "LifecycleFSM"
+
+# Per Step 4 prompt — explicit severity per trigger type, in AuditEvent
+# vocabulary (INFO / WARNING / MAJOR / CRITICAL).
+TRIGGER_SEVERITY: dict[str, str] = {
+    "sanctions_match": "CRITICAL",
+    "role_changed": "CRITICAL",
+    "beneficial_owner_changed": "MAJOR",
+    "jurisdiction_changed": "MAJOR",
+    "periodic_review_due": "WARNING",
+}
+
+# BanxeEventType.value → Port trigger_type string (used by the wrapper).
+# Only the 3 currently-defined ADR-028 BanxeEventType values are mapped.
+_BANXE_EVENT_TO_TRIGGER_TYPE: dict[str, str] = {
+    "kyc.role_changed": "role_changed",
+    "kyc.beneficial_owner_changed": "beneficial_owner_changed",
+    "kyc.jurisdiction_changed": "jurisdiction_changed",
+}
+
+
+class KycRetriggerAuditEmitter:
+    """Build and forward KYC_REVERIFICATION_TRIGGERED events to BufferedAuditPort."""
+
+    def __init__(
+        self,
+        audit_port: BufferedAuditPort,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._audit = audit_port
+        self._clock = clock
+
+    def emit(
+        self,
+        customer_id: str,
+        trigger_type: str,
+        trigger_payload: dict,
+        requested_by: str | None = None,
+    ) -> None:
+        if trigger_type not in TRIGGER_SEVERITY:
+            raise ValueError(
+                f"unknown trigger_type {trigger_type!r}; supported: {sorted(TRIGGER_SEVERITY)!r}"
+            )
+        severity = TRIGGER_SEVERITY[trigger_type]
+        actor = requested_by or _DEFAULT_ACTOR
+        event = AuditEvent(
+            event_type=EVENT_KYC_REVERIFICATION_TRIGGERED,
+            entity_id=customer_id,
+            actor=actor,
+            payload={
+                "customer_id": hashlib.sha256(customer_id.encode("utf-8")).hexdigest()[:16],
+                "trigger_type": trigger_type,
+                "trigger_payload": dict(trigger_payload),
+                "requested_by": requested_by,
+            },
+            severity=severity,
+            occurred_at=datetime.fromtimestamp(self._clock(), tz=UTC),
+        )
+        self._audit.record(event)
+
+
+def publish_kyc_retrigger_with_audit(
+    event_bus: Any,
+    audit_emitter: KycRetriggerAuditEmitter,
+    event: Any,
+) -> None:
+    """Publish a KycReTriggerEvent then best-effort emit a matching audit record.
+
+    Order: publish first, audit second. Event publication is the load-bearing
+    operation; audit emission is best-effort and wrapped in
+    contextlib.suppress(Exception) so a broken audit sink cannot break event
+    delivery (defence-in-depth complementing ADR-027's own swallow).
+
+    Events whose BanxeEventType has no entry in _BANXE_EVENT_TO_TRIGGER_TYPE
+    (i.e. not one of the 3 currently-defined ADR-028 KYC re-trigger events)
+    are published but no audit event is emitted from this wrapper.
+    """
+    event_bus.publish(event)
+    trigger_type = _BANXE_EVENT_TO_TRIGGER_TYPE.get(event.event_type.value)
+    if trigger_type is None:
+        return
+    with contextlib.suppress(Exception):
+        audit_emitter.emit(
+            customer_id=event.customer_id,
+            trigger_type=trigger_type,
+            trigger_payload={
+                "previous_value": event.previous_value,
+                "new_value": event.new_value,
+                "criticality": event.criticality,
+                "gap_ref": event.gap_ref,
+            },
+            requested_by=event.triggered_by,
+        )

--- a/services/kyc/mock_kyc_workflow.py
+++ b/services/kyc/mock_kyc_workflow.py
@@ -84,6 +84,10 @@ class MockKYCWorkflow:
 
     def __init__(self) -> None:
         self._workflows: dict[str, KYCWorkflowResult] = {}
+        # ADR-028 Step 4: in-memory log of trigger_reverification calls for
+        # test inspection. Each entry is a dict with customer_id, trigger_type,
+        # trigger_payload, requested_by.
+        self.trigger_reverification_calls: list[dict] = []
 
     def _now(self) -> datetime:
         return datetime.now(UTC)
@@ -220,6 +224,28 @@ class MockKYCWorkflow:
 
     def health(self) -> bool:
         return True
+
+    def trigger_reverification(
+        self,
+        customer_id: str,
+        trigger_type: str,
+        trigger_payload: dict,
+        requested_by: str | None = None,
+    ) -> None:
+        """ADR-028 Step 4: record the trigger_reverification request.
+
+        Mock implementation — production BallerineAdapter will dispatch to
+        the workflow engine. This Mock simply appends to
+        trigger_reverification_calls for test assertions.
+        """
+        self.trigger_reverification_calls.append(
+            {
+                "customer_id": customer_id,
+                "trigger_type": trigger_type,
+                "trigger_payload": dict(trigger_payload),
+                "requested_by": requested_by,
+            }
+        )
 
 
 _bl_logger = _logging.getLogger(__name__)

--- a/tests/integration/test_kyc_retrigger_audit_emission.py
+++ b/tests/integration/test_kyc_retrigger_audit_emission.py
@@ -1,0 +1,123 @@
+"""Integration tests for publish_kyc_retrigger_with_audit (ADR-028 Step 4).
+
+Verify the wrapper publishes events to the (in-memory) bus FIRST and then
+best-effort emits an audit record. Audit emitter failures must NOT block
+event delivery — contextlib.suppress guard in the wrapper.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from services.events.event_bus import (
+    BanxeEventType,
+    KycReTriggerEvent,
+    build_kyc_retrigger_event,
+)
+from services.kyc.kyc_retrigger_audit_emitter import (
+    EVENT_KYC_REVERIFICATION_TRIGGERED,
+    KycRetriggerAuditEmitter,
+    publish_kyc_retrigger_with_audit,
+)
+
+
+class _FakeAuditPort:
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+
+    def record(self, entry: Any) -> None:
+        self.records.append(entry)
+
+
+class _FakeBus:
+    """Minimal EventBusPort.publish(event) double — KycReTriggerEvent is
+    a plain dataclass without DomainEvent.event_id, so the real
+    InMemoryEventBus (which logs event.event_id) can't accept it directly.
+    This fake records every published event for assertion.
+    """
+
+    def __init__(self) -> None:
+        self.published: list[Any] = []
+
+    def publish(self, event: Any) -> None:
+        self.published.append(event)
+
+
+def _build_event(
+    event_type: BanxeEventType = BanxeEventType.ROLE_CHANGED,
+    customer_id: str = "cust-banxe-001",
+) -> KycReTriggerEvent:
+    return build_kyc_retrigger_event(
+        event_type=event_type,
+        customer_id=customer_id,
+        triggered_by="lifecycle-observer",
+        previous_value="BENEFICIARY",
+        new_value="DIRECTOR",
+    )
+
+
+def test_wrapper_publishes_event_then_emits_audit() -> None:
+    bus = _FakeBus()
+    audit_port = _FakeAuditPort()
+    emitter = KycRetriggerAuditEmitter(audit_port=audit_port, clock=lambda: 1714000000.0)
+
+    event = _build_event()
+    publish_kyc_retrigger_with_audit(bus, emitter, event)
+
+    # Event published exactly once
+    assert len(bus.published) == 1
+    assert bus.published[0] is event
+    # Audit record emitted exactly once with correct shape
+    assert len(audit_port.records) == 1
+    rec = audit_port.records[0]
+    assert rec.event_type == EVENT_KYC_REVERIFICATION_TRIGGERED
+    assert rec.entity_id == "cust-banxe-001"
+    assert rec.severity == "CRITICAL"  # role_changed → CRITICAL
+    assert rec.payload["trigger_type"] == "role_changed"
+    assert rec.payload["trigger_payload"]["previous_value"] == "BENEFICIARY"
+    assert rec.payload["trigger_payload"]["new_value"] == "DIRECTOR"
+    assert rec.payload["trigger_payload"]["criticality"] == "HIGH"
+    assert rec.payload["trigger_payload"]["gap_ref"] == "G-KYC-01"
+    assert rec.payload["requested_by"] == "lifecycle-observer"
+    assert rec.actor == "lifecycle-observer"
+
+
+def test_wrapper_audit_emission_failure_does_not_break_event_publish() -> None:
+    """A broken audit emitter MUST NOT block event delivery."""
+    bus = _FakeBus()
+
+    class _BrokenEmitter:
+        def emit(self, **_kw: Any) -> None:
+            raise RuntimeError("audit sink offline")
+
+    event = _build_event()
+    publish_kyc_retrigger_with_audit(bus, _BrokenEmitter(), event)
+
+    # Event STILL published despite emitter explosion
+    assert len(bus.published) == 1
+    assert bus.published[0] is event
+
+
+def test_wrapper_extracts_fields_from_kyc_retrigger_event_dataclass_correctly() -> None:
+    """All three repo-supported BanxeEventType values map to the right
+    Port trigger_type strings + severity."""
+    bus = _FakeBus()
+    audit_port = _FakeAuditPort()
+    emitter = KycRetriggerAuditEmitter(audit_port=audit_port, clock=lambda: 1714000000.0)
+
+    cases = [
+        (BanxeEventType.ROLE_CHANGED, "role_changed", "CRITICAL"),
+        (BanxeEventType.BENEFICIAL_OWNER_CHANGED, "beneficial_owner_changed", "MAJOR"),
+        (BanxeEventType.JURISDICTION_CHANGED, "jurisdiction_changed", "MAJOR"),
+    ]
+    for event_type, expected_trigger, expected_severity in cases:
+        event = _build_event(event_type=event_type, customer_id=f"cust-{event_type.name}")
+        publish_kyc_retrigger_with_audit(bus, emitter, event)
+
+    assert len(bus.published) == 3
+    assert len(audit_port.records) == 3
+    by_entity = {r.entity_id: r for r in audit_port.records}
+    for event_type, expected_trigger, expected_severity in cases:
+        rec = by_entity[f"cust-{event_type.name}"]
+        assert rec.payload["trigger_type"] == expected_trigger
+        assert rec.severity == expected_severity

--- a/tests/unit/kyc/test_kyc_retrigger_audit_emitter.py
+++ b/tests/unit/kyc/test_kyc_retrigger_audit_emitter.py
@@ -1,0 +1,162 @@
+"""Unit tests for KycRetriggerAuditEmitter (ADR-028 Step 4).
+
+FakeBufferedAuditPort captures every entry passed to record(). No real
+SQLite, no real ClickHouse, no network. Injected clock for reproducible
+occurred_at assertions.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import hashlib
+from typing import Any
+
+import pytest
+
+from services.kyc.factory import get_kyc_retrigger_audit_emitter
+from services.kyc.kyc_retrigger_audit_emitter import (
+    EVENT_KYC_REVERIFICATION_TRIGGERED,
+    TRIGGER_SEVERITY,
+    KycRetriggerAuditEmitter,
+)
+
+
+class FakeBufferedAuditPort:
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+
+    def record(self, entry: Any) -> None:
+        self.records.append(entry)
+
+
+def _emitter(start_time: float = 1714000000.0):
+    clock = [start_time]
+    fake = FakeBufferedAuditPort()
+    return (
+        KycRetriggerAuditEmitter(audit_port=fake, clock=lambda: clock[0]),
+        fake,
+        clock,
+    )
+
+
+def test_emit_builds_canonical_event_with_KYC_REVERIFICATION_TRIGGERED_type() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit(
+        customer_id="cust-001",
+        trigger_type="role_changed",
+        trigger_payload={"old_role": "BENEFICIARY", "new_role": "DIRECTOR"},
+        requested_by="lifecycle-observer",
+    )
+    assert len(fake.records) == 1
+    ev = fake.records[0]
+    assert ev.event_type == EVENT_KYC_REVERIFICATION_TRIGGERED
+    assert ev.actor == "lifecycle-observer"
+    assert ev.payload["trigger_type"] == "role_changed"
+    assert ev.payload["trigger_payload"] == {
+        "old_role": "BENEFICIARY",
+        "new_role": "DIRECTOR",
+    }
+
+
+def test_emit_uses_customer_id_as_entity_id_plain() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit(
+        customer_id="cust-banxe-12345",
+        trigger_type="role_changed",
+        trigger_payload={},
+    )
+    assert fake.records[0].entity_id == "cust-banxe-12345"
+
+
+def test_emit_hashes_customer_id_in_payload_for_pii() -> None:
+    emitter, fake, _clock = _emitter()
+    raw = "cust-banxe-12345"
+    emitter.emit(
+        customer_id=raw,
+        trigger_type="role_changed",
+        trigger_payload={},
+    )
+    expected = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    assert fake.records[0].payload["customer_id"] == expected
+    assert fake.records[0].payload["customer_id"] != raw
+    assert len(fake.records[0].payload["customer_id"]) == 16
+
+
+def test_emit_severity_critical_for_sanctions_match() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit("cust", "sanctions_match", {})
+    assert fake.records[0].severity == "CRITICAL"
+
+
+def test_emit_severity_critical_for_role_changed() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit("cust", "role_changed", {})
+    assert fake.records[0].severity == "CRITICAL"
+
+
+def test_emit_severity_major_for_beneficial_owner_changed() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit("cust", "beneficial_owner_changed", {})
+    assert fake.records[0].severity == "MAJOR"
+
+
+def test_emit_severity_major_for_jurisdiction_changed() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit("cust", "jurisdiction_changed", {})
+    assert fake.records[0].severity == "MAJOR"
+
+
+def test_emit_severity_warning_for_periodic_review_due() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit("cust", "periodic_review_due", {})
+    assert fake.records[0].severity == "WARNING"
+
+
+def test_emit_unknown_trigger_type_raises_value_error() -> None:
+    emitter, _fake, _clock = _emitter()
+    with pytest.raises(ValueError, match="unknown trigger_type"):
+        emitter.emit("cust", "totally_made_up_trigger", {})
+
+
+def test_emit_uses_injected_clock_for_occurred_at_not_realtime() -> None:
+    fixed = 1714000000.0
+    emitter, fake, _clock = _emitter(start_time=fixed)
+    emitter.emit("cust", "role_changed", {})
+    assert fake.records[0].occurred_at == datetime.fromtimestamp(fixed, tz=UTC)
+
+
+def test_emit_default_actor_is_lifecycle_fsm_when_requested_by_none() -> None:
+    emitter, fake, _clock = _emitter()
+    emitter.emit("cust", "role_changed", {})  # no requested_by
+    assert fake.records[0].actor == "LifecycleFSM"
+
+
+def test_trigger_severity_map_covers_all_5_canonical_trigger_types() -> None:
+    assert set(TRIGGER_SEVERITY) == {
+        "sanctions_match",
+        "role_changed",
+        "beneficial_owner_changed",
+        "jurisdiction_changed",
+        "periodic_review_due",
+    }
+    # Only severities from the AuditEvent vocabulary
+    assert set(TRIGGER_SEVERITY.values()) <= {"INFO", "WARNING", "MAJOR", "CRITICAL"}
+
+
+def test_factory_get_kyc_retrigger_audit_emitter_returns_singleton(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("AUDIT_BUFFER_PATH", str(tmp_path / "audit.db"))
+    from api.deps import get_buffered_audit_port
+
+    get_kyc_retrigger_audit_emitter.cache_clear()
+    get_buffered_audit_port.cache_clear()
+    try:
+        a = get_kyc_retrigger_audit_emitter()
+        b = get_kyc_retrigger_audit_emitter()
+        assert a is b
+        assert isinstance(a, KycRetriggerAuditEmitter)
+        assert a._audit is get_buffered_audit_port()  # type: ignore[attr-defined]
+    finally:
+        get_kyc_retrigger_audit_emitter.cache_clear()
+        get_buffered_audit_port.cache_clear()

--- a/tests/unit/kyc/test_kyc_workflow_port_trigger_reverification.py
+++ b/tests/unit/kyc/test_kyc_workflow_port_trigger_reverification.py
@@ -1,0 +1,68 @@
+"""Unit tests for KYCWorkflowPort.trigger_reverification() surface + Mock
+behavior (ADR-028 Step 4).
+"""
+
+from __future__ import annotations
+
+from services.kyc.kyc_port import KYC_RETRIGGER_TYPES, KYCWorkflowPort
+from services.kyc.mock_kyc_workflow import MockKYCWorkflow
+
+
+def test_port_protocol_includes_trigger_reverification_method() -> None:
+    # Protocol surface check via attribute lookup (Protocols are not
+    # runtime-checkable by default; method existence is the contract).
+    assert hasattr(KYCWorkflowPort, "trigger_reverification")
+    assert callable(KYCWorkflowPort.trigger_reverification)
+
+
+def test_mock_trigger_reverification_records_invocation() -> None:
+    mock = MockKYCWorkflow()
+    mock.trigger_reverification(
+        customer_id="cust-1",
+        trigger_type="role_changed",
+        trigger_payload={"old": "X", "new": "Y"},
+        requested_by="lifecycle-observer",
+    )
+    assert len(mock.trigger_reverification_calls) == 1
+    call = mock.trigger_reverification_calls[0]
+    assert call["customer_id"] == "cust-1"
+    assert call["trigger_type"] == "role_changed"
+    assert call["trigger_payload"] == {"old": "X", "new": "Y"}
+    assert call["requested_by"] == "lifecycle-observer"
+
+
+def test_kyc_retrigger_types_tuple_has_5_canonical_values() -> None:
+    assert isinstance(KYC_RETRIGGER_TYPES, tuple)
+    assert set(KYC_RETRIGGER_TYPES) == {
+        "role_changed",
+        "beneficial_owner_changed",
+        "sanctions_match",
+        "jurisdiction_changed",
+        "periodic_review_due",
+    }
+    assert len(KYC_RETRIGGER_TYPES) == 5
+
+
+def test_mock_trigger_reverification_accepts_all_5_canonical_trigger_types() -> None:
+    mock = MockKYCWorkflow()
+    for tt in KYC_RETRIGGER_TYPES:
+        mock.trigger_reverification(
+            customer_id=f"cust-for-{tt}",
+            trigger_type=tt,
+            trigger_payload={"tt": tt},
+        )
+    assert len(mock.trigger_reverification_calls) == len(KYC_RETRIGGER_TYPES) == 5
+    assert {c["trigger_type"] for c in mock.trigger_reverification_calls} == set(
+        KYC_RETRIGGER_TYPES
+    )
+
+
+def test_mock_trigger_reverification_does_not_raise_on_unknown_trigger_type() -> None:
+    """Port is permissive at the Mock layer — validation happens in the
+    audit emitter (which raises ValueError on unknown trigger_type). This
+    matches the Mock convention used by the rest of services/kyc/."""
+    mock = MockKYCWorkflow()
+    mock.trigger_reverification(
+        customer_id="cust", trigger_type="anything_goes_at_mock_layer", trigger_payload={}
+    )
+    assert len(mock.trigger_reverification_calls) == 1


### PR DESCRIPTION
## ADR-028 Step 4 — KYC reverification audit emitter

### What
Closes ADR-028 Implementation Plan item 3 + adds AUDIT trail for KYC_REVERIFICATION_TRIGGERED events through ADR-027 BufferedAuditPort. FSM call-site integration deferred to Step 5.

### Files (8 / +571 / -0)
- services/kyc/kyc_port.py — trigger_reverification() on KYCWorkflowPort + KYC_RETRIGGER_TYPES tuple (5 canonical triggers)
- services/kyc/mock_kyc_workflow.py — usable Mock recording invocations (permissive, no NotImplementedError)
- services/kyc/kyc_retrigger_audit_emitter.py — KycRetriggerAuditEmitter + TRIGGER_SEVERITY map + publish_kyc_retrigger_with_audit wrapper (contextlib.suppress around audit)
- services/kyc/factory.py — get_kyc_retrigger_audit_emitter() lru_cache singleton (lazy api.deps.get_buffered_audit_port import)
- tests/unit/kyc/test_kyc_retrigger_audit_emitter.py — 13 deterministic unit tests
- tests/unit/kyc/test_kyc_workflow_port_trigger_reverification.py — 5 Port + Mock tests
- tests/integration/test_kyc_retrigger_audit_emission.py — 3 wrapper integration tests

### TRIGGER_SEVERITY mapping (verified against repo AuditSeverity enum)
- sanctions_match → CRITICAL
- role_changed → CRITICAL
- beneficial_owner_changed → MAJOR
- jurisdiction_changed → MAJOR
- periodic_review_due → WARNING

### Architectural notes
- §matrix vs repo BanxeEventType deviation: ADR-028 §matrix lists 5 trigger types; repo BanxeEventType enum currently has only 3 (ROLE_CHANGED, BENEFICIAL_OWNER_CHANGED, JURISDICTION_CHANGED — no SANCTIONS_MATCH, no PERIODIC_REVIEW_DUE). Port + emitter accept all 5 as strings; wrapper maps only the 3 representable values via _BANXE_EVENT_TO_TRIGGER_TYPE. Sanctions / periodic-review paths arrive via other upstream channels not yet wired — deferred.
- _FakeBus in integration test (not real InMemoryEventBus): repo InMemoryEventBus.publish() logs event.event_id[:8], but KycReTriggerEvent is a plain dataclass with NO event_id field (does not inherit DomainEvent). Pre-existing repo inconsistency between build_kyc_retrigger_event() output and bus contract — direct test against InMemoryEventBus crashes with AttributeError. Reconciling dataclass with DomainEvent is out of Step 4 scope (touches services/events/event_bus.py). Wrapper integration test uses minimal _FakeBus(publish) double — verifies wrapper semantics independent of bus mismatch. **Flag for §74 / next step**: reconcile KycReTriggerEvent with DomainEvent OR adjust InMemoryEventBus to tolerate event_id-less payloads.
- PII split: entity_id = customer_id plain (operational reference for ClickHouse partitioning + cross-event correlation); payload.customer_id = sha256[:16] (PII-safe on exfiltratable payload). Mirrors production audit consumer patterns.
- Mock permissive, emitter strict: MockKYCWorkflow.trigger_reverification accepts any trigger_type string (Mock convention); emitter.emit() raises ValueError on unknown trigger_type (TRIGGER_SEVERITY map is semantic contract).
- Defence-in-depth in wrapper: publish_kyc_retrigger_with_audit calls event_bus.publish(event) FIRST (load-bearing), then audit_emitter.emit() wrapped in contextlib.suppress(Exception). Verified by test_wrapper_audit_emission_failure_does_not_break_event_publish (BrokenEmitter raises on emit, event still published).
- Test expansion beyond prompt minimum: 13 emitter unit (vs 10) + 5 Port/Mock (vs 4) — added injected_clock, default actor, TRIGGER_SEVERITY vocabulary guard, Mock permissiveness on unknown trigger_type.
- Ruff auto-format on first commit: 1 file reformatted. Re-staged, re-verified, clean commit on second.

### Tests
pytest tests/unit/events/ tests/unit/kyc/ tests/integration/test_kyc_retrigger_lifecycle.py tests/integration/test_kyc_retrigger_audit_emission.py -q --no-cov: 35 PASS / 0 FAIL.
Breakdown: 8 existing event unit (Step 1) + 6 existing lifecycle integration (Step 2) + 13 new emitter unit + 5 new Port/Mock unit + 3 new wrapper integration.
Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest).

### ADR-028 chain in code so far
- Step 1 (PR #69): BanxeEventType extension + KycReTriggerEvent + build_kyc_retrigger_event + 8 unit tests
- Step 2 (PR #70): FSM lifecycle wiring + notify_attribute_change + integration test
- Step 3 (PR #99): kyc-retrigger-check.py operational script + 4 smoke tests
- Step 4 (this PR, Sub-B): Port method + Mock + audit emitter + wrapper

### Out of scope (operator / §74 / Step 5)
- Step 5: FSM call-site integration with publish_kyc_retrigger_with_audit (touches services/customer_lifecycle/fsm.py).
- KycReTriggerEvent reconciliation with DomainEvent base class OR InMemoryEventBus tolerance for event_id-less payloads.
- Sanctions_match / periodic_review_due upstream wiring (not yet representable in BanxeEventType).
- Production BallerineAdapter binding for trigger_reverification.
- INSTRUCTION-LEDGER / MEMORY.md sync.

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin
