### PR TITLE
feat(adr-028): Step 5 FSM call-site integration + chain smoke

### DIFF
--- a/services/customer_lifecycle/fsm.py
+++ b/services/customer_lifecycle/fsm.py
@@ -43,6 +43,16 @@ from services.events.event_bus import (
 )
 from services.kyc.kyc_port import KYCStatus
 
+# ADR-028 Step 5: BanxeEventType.value → Port trigger_type string mapping
+# (mirrored from services.kyc.kyc_retrigger_audit_emitter; kept here as a
+# module-local constant to avoid pulling the audit-emitter module into
+# fsm.py's import chain when no audit is wired).
+_BANXE_EVENT_TO_TRIGGER_TYPE: dict[str, str] = {
+    "kyc.role_changed": "role_changed",
+    "kyc.beneficial_owner_changed": "beneficial_owner_changed",
+    "kyc.jurisdiction_changed": "jurisdiction_changed",
+}
+
 # ── Narrow ports for lifecycle guards ─────────────────────────────────────────
 
 
@@ -158,6 +168,7 @@ class KYCLifecycleEngine:
         hitl: HITLLifecyclePort | None = None,
         observer: LifecycleObserverPort | None = None,
         event_bus: EventBusPort | None = None,
+        audit_emitter: object | None = None,
     ) -> None:
         self._engine = engine or LifecycleEngine(InMemoryLifecycleStore())
         self._kyc: KYCGuardPort = kyc_guard or InMemoryKYCGuard()
@@ -165,6 +176,9 @@ class KYCLifecycleEngine:
         self._hitl: HITLLifecyclePort = hitl or InMemoryHITLLifecyclePort()
         self._observer: LifecycleObserverPort | None = observer
         self._event_bus: EventBusPort | None = event_bus
+        # ADR-028 Step 5: optional KYC re-trigger audit emitter. When None,
+        # falls back to the lazy factory singleton inside notify_attribute_change.
+        self._audit_emitter: object | None = audit_emitter
         self._pending_retriggers: dict[str, KycReTriggerEvent] = {}
 
     def transition(
@@ -320,6 +334,32 @@ class KYCLifecycleEngine:
                     customer_id=customer_id,
                 )
             )
+
+        # ADR-028 Step 5: emit KYC_REVERIFICATION_TRIGGERED audit event after
+        # the bus publish. Wrapped in contextlib.suppress so an audit-sink
+        # failure cannot break event delivery (defence-in-depth complementing
+        # the ADR-027 BufferedAuditPort's own swallow).
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            emitter = self._audit_emitter
+            if emitter is None:
+                from services.kyc.factory import get_kyc_retrigger_audit_emitter
+
+                emitter = get_kyc_retrigger_audit_emitter()
+            trigger_type = _BANXE_EVENT_TO_TRIGGER_TYPE.get(event_type.value)
+            if trigger_type is not None:
+                emitter.emit(
+                    customer_id=customer_id,
+                    trigger_type=trigger_type,
+                    trigger_payload={
+                        "previous_value": previous_value,
+                        "new_value": new_value,
+                        "criticality": retrigger.criticality,
+                        "gap_ref": retrigger.gap_ref,
+                    },
+                    requested_by=triggered_by,
+                )
 
         if retrigger.criticality == "CRITICAL":
             if self._engine.get_state(customer_id) == CustomerState.ACTIVE:

--- a/tests/integration/test_kyc_retrigger_fsm_audit_integration.py
+++ b/tests/integration/test_kyc_retrigger_fsm_audit_integration.py
@@ -1,0 +1,141 @@
+"""Integration tests for ADR-028 Step 5 — FSM call-site emits audit event.
+
+These exercise services.customer_lifecycle.fsm.KYCLifecycleEngine
+.notify_attribute_change against an in-memory event bus + a capturing
+audit emitter (injected via constructor) and verify that the KYC
+re-trigger path produces both:
+  1) the existing DomainEvent on the bus (unchanged from Step 2)
+  2) a new KYC_REVERIFICATION_TRIGGERED audit record (Step 5 hook)
+
+No real audit subsystem, no real EventBus persistence beyond the
+in-memory fake.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from services.customer_lifecycle.fsm import KYCLifecycleEngine
+from services.events.event_bus import BanxeEventType, InMemoryEventBus
+
+
+class _FakeAuditEmitter:
+    """Capturing audit emitter — mirrors KycRetriggerAuditEmitter.emit shape."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def emit(
+        self,
+        customer_id: str,
+        trigger_type: str,
+        trigger_payload: dict,
+        requested_by: str | None = None,
+    ) -> None:
+        self.calls.append(
+            {
+                "customer_id": customer_id,
+                "trigger_type": trigger_type,
+                "trigger_payload": dict(trigger_payload),
+                "requested_by": requested_by,
+            }
+        )
+
+
+def _engine_with_audit():
+    bus = InMemoryEventBus()
+    audit = _FakeAuditEmitter()
+    engine = KYCLifecycleEngine(event_bus=bus, audit_emitter=audit)
+    return engine, bus, audit
+
+
+def test_fsm_role_change_publishes_event_and_emits_audit() -> None:
+    engine, bus, audit = _engine_with_audit()
+    engine.notify_attribute_change(
+        customer_id="cust-role-1",
+        event_type=BanxeEventType.ROLE_CHANGED,
+        triggered_by="admin",
+        previous_value="DIRECTOR",
+        new_value="SHAREHOLDER",
+    )
+    # Existing behavior: DomainEvent on bus, ROLE_CHANGED-typed
+    role_events = bus.events_of_type(BanxeEventType.ROLE_CHANGED)
+    assert len(role_events) == 1
+    # New behavior: audit emitter saw exactly one call
+    assert len(audit.calls) == 1
+    call = audit.calls[0]
+    assert call["customer_id"] == "cust-role-1"
+    assert call["trigger_type"] == "role_changed"
+    assert call["requested_by"] == "admin"
+    assert call["trigger_payload"]["previous_value"] == "DIRECTOR"
+    assert call["trigger_payload"]["new_value"] == "SHAREHOLDER"
+    # criticality + gap_ref come from build_kyc_retrigger_event
+    assert call["trigger_payload"]["criticality"] == "HIGH"
+    assert call["trigger_payload"]["gap_ref"] == "G-KYC-01"
+
+
+def test_fsm_beneficial_owner_change_publishes_event_and_emits_audit() -> None:
+    engine, bus, audit = _engine_with_audit()
+    engine.notify_attribute_change(
+        customer_id="cust-bo-1",
+        event_type=BanxeEventType.BENEFICIAL_OWNER_CHANGED,
+        triggered_by="compliance",
+        previous_value="OWNER_A",
+        new_value="OWNER_B",
+    )
+    assert len(bus.events_of_type(BanxeEventType.BENEFICIAL_OWNER_CHANGED)) == 1
+    assert len(audit.calls) == 1
+    assert audit.calls[0]["trigger_type"] == "beneficial_owner_changed"
+
+
+def test_fsm_jurisdiction_change_publishes_event_and_emits_audit() -> None:
+    engine, bus, audit = _engine_with_audit()
+    engine.notify_attribute_change(
+        customer_id="cust-jur-1",
+        event_type=BanxeEventType.JURISDICTION_CHANGED,
+        triggered_by="onboarding",
+        previous_value="GB",
+        new_value="DE",
+    )
+    assert len(bus.events_of_type(BanxeEventType.JURISDICTION_CHANGED)) == 1
+    assert len(audit.calls) == 1
+    assert audit.calls[0]["trigger_type"] == "jurisdiction_changed"
+
+
+def test_fsm_audit_emitter_failure_does_not_block_event_publish() -> None:
+    """A broken audit emitter MUST NOT prevent the DomainEvent from being
+    published. Step 5 FSM hook wraps audit emission in
+    contextlib.suppress(Exception)."""
+
+    class _BrokenEmitter:
+        def emit(self, **_kw: Any) -> None:
+            raise RuntimeError("audit sink offline")
+
+    bus = InMemoryEventBus()
+    engine = KYCLifecycleEngine(event_bus=bus, audit_emitter=_BrokenEmitter())
+    engine.notify_attribute_change(
+        customer_id="cust-broken-audit",
+        event_type=BanxeEventType.ROLE_CHANGED,
+        triggered_by="admin",
+        previous_value="X",
+        new_value="Y",
+    )
+    # Event still on bus despite broken audit emitter
+    assert len(bus.events_of_type(BanxeEventType.ROLE_CHANGED)) == 1
+
+
+def test_fsm_audit_emission_does_not_break_existing_step2_contract() -> None:
+    """Regression guard: KYCLifecycleEngine still records pending retrigger
+    and the audit hook is purely additive."""
+    engine, _bus, _audit = _engine_with_audit()
+    retrigger = engine.notify_attribute_change(
+        customer_id="cust-regression",
+        event_type=BanxeEventType.ROLE_CHANGED,
+        triggered_by="admin",
+        previous_value="X",
+        new_value="Y",
+    )
+    # Step 2 contract preserved
+    assert retrigger.event_type == BanxeEventType.ROLE_CHANGED
+    assert retrigger.customer_id == "cust-regression"
+    assert engine.get_pending_retrigger("cust-regression") is retrigger

--- a/tests/smoke/test_kyc_retrigger_chain_smoke.py
+++ b/tests/smoke/test_kyc_retrigger_chain_smoke.py
@@ -1,0 +1,145 @@
+"""End-to-end chain smoke for ADR-028 (Step 5).
+
+Exercises the full FSM → DomainEvent bus → KYC_REVERIFICATION_TRIGGERED
+audit chain for the 3 currently-supported BanxeEventType KYC re-trigger
+events. No real audit subsystem; uses a capturing _FakeAuditEmitter that
+mirrors KycRetriggerAuditEmitter.emit's shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from services.customer_lifecycle.fsm import KYCLifecycleEngine
+from services.events.event_bus import BanxeEventType, InMemoryEventBus
+from services.kyc.kyc_retrigger_audit_emitter import (
+    TRIGGER_SEVERITY,
+)
+
+pytestmark = pytest.mark.smoke
+
+
+class _FakeAuditEmitter:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def emit(
+        self,
+        customer_id: str,
+        trigger_type: str,
+        trigger_payload: dict,
+        requested_by: str | None = None,
+    ) -> None:
+        self.calls.append(
+            {
+                "customer_id": customer_id,
+                "trigger_type": trigger_type,
+                "trigger_payload": dict(trigger_payload),
+                "requested_by": requested_by,
+            }
+        )
+
+
+def _engine_with_audit():
+    bus = InMemoryEventBus()
+    audit = _FakeAuditEmitter()
+    engine = KYCLifecycleEngine(event_bus=bus, audit_emitter=audit)
+    return engine, bus, audit
+
+
+def test_smoke_full_role_changed_chain_event_to_audit() -> None:
+    engine, bus, audit = _engine_with_audit()
+    engine.notify_attribute_change(
+        customer_id="cust-role-smoke",
+        event_type=BanxeEventType.ROLE_CHANGED,
+        triggered_by="admin",
+        previous_value="DIRECTOR",
+        new_value="SHAREHOLDER",
+    )
+    # Both legs of the chain fired
+    assert len(bus.events_of_type(BanxeEventType.ROLE_CHANGED)) == 1
+    assert len(audit.calls) == 1
+    assert audit.calls[0]["trigger_type"] == "role_changed"
+
+
+def test_smoke_full_beneficial_owner_changed_chain() -> None:
+    engine, bus, audit = _engine_with_audit()
+    engine.notify_attribute_change(
+        customer_id="cust-bo-smoke",
+        event_type=BanxeEventType.BENEFICIAL_OWNER_CHANGED,
+        triggered_by="compliance",
+        previous_value="OWNER_A",
+        new_value="OWNER_B",
+    )
+    assert len(bus.events_of_type(BanxeEventType.BENEFICIAL_OWNER_CHANGED)) == 1
+    assert len(audit.calls) == 1
+    assert audit.calls[0]["trigger_type"] == "beneficial_owner_changed"
+
+
+def test_smoke_full_jurisdiction_changed_chain() -> None:
+    engine, bus, audit = _engine_with_audit()
+    engine.notify_attribute_change(
+        customer_id="cust-jur-smoke",
+        event_type=BanxeEventType.JURISDICTION_CHANGED,
+        triggered_by="onboarding",
+        previous_value="GB",
+        new_value="DE",
+    )
+    assert len(bus.events_of_type(BanxeEventType.JURISDICTION_CHANGED)) == 1
+    assert len(audit.calls) == 1
+    assert audit.calls[0]["trigger_type"] == "jurisdiction_changed"
+
+
+def test_smoke_audit_severity_mapping_via_trigger_severity_table() -> None:
+    """TRIGGER_SEVERITY (Step 4 module constant) correctly classifies the
+    3 FSM-supported trigger types per ADR-028 §matrix."""
+    assert TRIGGER_SEVERITY["role_changed"] == "CRITICAL"
+    assert TRIGGER_SEVERITY["beneficial_owner_changed"] == "MAJOR"
+    assert TRIGGER_SEVERITY["jurisdiction_changed"] == "MAJOR"
+
+
+def test_smoke_audit_call_carries_criticality_and_gap_ref_from_event_payload() -> None:
+    """The FSM-emitted audit call must surface criticality + gap_ref derived
+    from build_kyc_retrigger_event so downstream consumers can dedupe /
+    route by either field."""
+    engine, _bus, audit = _engine_with_audit()
+    engine.notify_attribute_change(
+        customer_id="cust-payload-check",
+        event_type=BanxeEventType.JURISDICTION_CHANGED,
+        triggered_by="onboarding",
+        previous_value="GB",
+        new_value="DE",
+    )
+    payload = audit.calls[0]["trigger_payload"]
+    # JURISDICTION_CHANGED → criticality=CRITICAL, gap_ref=G-KYC-02 per
+    # _KYC_RETRIGGER_CRITICALITY / _KYC_RETRIGGER_GAP_REF in event_bus.
+    assert payload["criticality"] == "CRITICAL"
+    assert payload["gap_ref"] == "G-KYC-02"
+    assert payload["previous_value"] == "GB"
+    assert payload["new_value"] == "DE"
+
+
+def test_smoke_broken_audit_emitter_does_not_break_fsm() -> None:
+    """If the audit sink crashes, the FSM publish + retrigger record must
+    still complete. Verified by the contextlib.suppress(Exception) guard
+    around the audit call in fsm.notify_attribute_change."""
+
+    class _Boom:
+        def emit(self, **_kw: Any) -> None:
+            raise RuntimeError("kaput")
+
+    bus = InMemoryEventBus()
+    engine = KYCLifecycleEngine(event_bus=bus, audit_emitter=_Boom())
+    retrigger = engine.notify_attribute_change(
+        customer_id="cust-suppress",
+        event_type=BanxeEventType.ROLE_CHANGED,
+        triggered_by="admin",
+        previous_value="X",
+        new_value="Y",
+    )
+    # FSM still produced the retrigger record AND published the event
+    assert retrigger is not None
+    assert retrigger.customer_id == "cust-suppress"
+    assert len(bus.events_of_type(BanxeEventType.ROLE_CHANGED)) == 1


### PR DESCRIPTION
## ADR-028 Step 5 — FSM call-site integration + chain smoke

### What
Closes ADR-028 implementation chain in code by wiring FSM call-site integration and adding additive smoke/integration coverage on top of Steps 1-4.

### Reported by Sub-terminal B
- Commit: cc67d63
- Files: 3 files / +326 / -0
- Targeted pytest: 43 PASS / 0 FAIL
- Full hook chain: PASS
- Scope: additive Step 5 only; ADR-028 canon status already Accepted, this PR closes code-side chain.

### Important bounded-context note
The prompt suggested replacing direct publish with the Step 4 wrapper, but the current FSM path publishes DomainEvent payloads while the Step 4 wrapper expects KycReTriggerEvent. To avoid breaking Step 2 bus contract/tests, Step 5 keeps DomainEvent publish intact and adds inline audit emission with the same suppress(Exception) defence-in-depth. Follow-up reconciliation between KycReTriggerEvent and DomainEvent remains outside this bounded context.

### Cleanup / follow-up
- ADR-028 code chain complete after merge.
- Separate follow-up may be needed for KycReTriggerEvent / DomainEvent reconciliation.
