### PR TITLE
feat(s12.5): prep G-IAM-08 keycloak db-password hardening package

### DIFF
--- a/INSTRUCTION-LEDGER.md
+++ b/INSTRUCTION-LEDGER.md
@@ -244,3 +244,30 @@
 - Real proof SHA: ba3fccceaa376b6ec1273f416bd6fb916353fca6
 - Supersedes: prior anchor 7708d4c (ledger commit 693ecab)
 - Reason: 7708d4c does not modify the three IL-LINT-03 files; ba3fccc does.
+
+
+---
+
+### IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12
+- Date: 2026-05-12
+- Status: DONE (prep package only; no production deploy)
+- Scope: Sub-B autonomous prep for G-IAM-08 mitigation (Keycloak DB
+  password exposed in keycloak.service ExecStart on evo1). This entry
+  documents repo-only scaffolding; production mitigation on evo1 remains
+  gated by Central + operator approval per HITL gate in the migration plan.
+- Files created (under `infra/keycloak/`):
+  - `G-IAM-08-MIGRATION-PLAN.md`
+  - `keycloak.service.d/g-iam-08-fix.conf.template`
+  - `db.password.template`
+  - `install-db-password-file.sh` (executable)
+  - `validate-g-iam-08-mitigation.sh` (executable; 17/17 PASS local run)
+  - `OPERATOR-RUNBOOK-G-IAM-08.md`
+- Recommended mitigation: native KC 26.x `--db-password-file=/etc/keycloak/db.password`
+  (file root:keycloak 0640); systemd drop-in replaces `ExecStart`. Rejected
+  alternative: `EnvironmentFile=` (leaks via `/proc/<pid>/environ`).
+- Anchors: G-IAM-08, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12,
+  IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 (Sprint S12.5),
+  IL-CANON-TERMINAL-B-AUTONOMOUS-FIXATION-2026-05-12,
+  IL-CANON-EXPLICIT-TARGET-INSTRUCTION-2026-05-12.
+- Production mitigation remains gated by Central + operator approval; no
+  evo1 deploy, no `systemctl daemon-reload`, no ssh evo1 performed by this PR.

--- a/infra/keycloak/G-IAM-08-MIGRATION-PLAN.md
+++ b/infra/keycloak/G-IAM-08-MIGRATION-PLAN.md
@@ -1,0 +1,184 @@
+# G-IAM-08 — Keycloak DB password hardening (migration plan)
+
+Owner sprint: S12.5 (per IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11).
+Anchors: G-IAM-08, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12,
+FCA SYSC 4.1, GDPR Art. 32.
+Status: PREP (this PR delivers the package only; no production deploy here).
+
+---
+
+## 1. Problem statement
+
+Verified evidence (2026-05-12 07:37:50Z, Central diagnostic on evo1):
+the Keycloak systemd unit's `ExecStart` contains the live database password
+as a command-line argument:
+
+```
+... --db-password=teral> ...
+```
+
+This makes the password visible to any user who can run `ps -ef`, including
+unprivileged accounts on the same host. The disclosure path is:
+`/proc/<pid>/cmdline` → process listing → log scrapers, oncall tooling,
+backup snapshots.
+
+Affected stack at the time of evidence:
+- KC version: 26.2.5
+- JDK: 21
+- Profile: `prod`
+- DB: PostgreSQL at `jdbc:postgresql://127.0.0.1:15433/keycloak`
+
+Regulatory mapping:
+- **FCA SYSC 4.1** — adequate management systems and controls.
+- **GDPR Art. 32** — appropriate technical measures (credential confidentiality
+  is a baseline technical measure).
+
+Operational impact today:
+- Blocks Sprint S12.4 realm provisioning (no realm authoring should land
+  while an authoring credential is exposed in the process table).
+- Increases blast radius of any compromise that gains shell access on evo1.
+
+## 2. Candidate solutions
+
+### (a) `--db-password-file=/etc/keycloak/db.password` (Keycloak 26.x native)
+
+Keycloak 26.x supports `--db-password-file=<path>` as a first-class alternative
+to `--db-password=<literal>`. Keycloak reads the file at startup; the file
+contents never enter the process command line.
+
+**Pros**
+- Native KC flag; no shell-side wrapping required.
+- File permissions are the only protection knob — easy to audit
+  (`ls -l /etc/keycloak/db.password`).
+- Matches the standard pattern used by other Quarkus services.
+
+**Cons**
+- File on disk → must be permissioned correctly (root:keycloak 0640).
+- Operator must place + maintain the file out-of-band of systemd.
+
+### (b) systemd `EnvironmentFile=` with `KC_DB_PASSWORD`
+
+Switch the unit to load `KC_DB_PASSWORD` from a systemd `EnvironmentFile=`,
+and drop the `--db-password=` argument; Keycloak picks the value up from the
+environment variable.
+
+**Pros**
+- No on-disk file requires Keycloak-aware code; only systemd touches it.
+- Existing operator familiarity with `EnvironmentFile=` pattern.
+
+**Cons**
+- The password ends up in `/proc/<pid>/environ`, readable by the same uid
+  that runs Keycloak (and by root). On a multi-tenant host this can be a
+  larger surface than a single file with 0640 perms.
+- Environment variables are easier to leak via crash dumps, error
+  reporters, debug pages.
+
+## 3. Recommended solution: (a) `--db-password-file`
+
+Adopt `--db-password-file=/etc/keycloak/db.password` with the file owned
+`root:keycloak` and mode `0640`. This matches the principle of least
+exposure: the password is readable by exactly the keycloak service user
+(for read) and root (for management), and is never present on the process
+command line or in the process environment.
+
+The templates and runbook in this prep package implement option (a).
+
+## 4. Migration steps (operator-runnable on evo1; NOT in this PR)
+
+The steps below are written for Central or the operator to execute later on
+evo1, gated by HITL approval (see §6). They are NOT executed by this commit.
+
+1. **Pre-flight diagnostic**
+   - `systemctl status keycloak` — confirm currently running, capture
+     baseline ExecStart line.
+   - `ps -ef | grep '[k]eycloak.*--db-password='` — confirm the exposure
+     (this is the condition that triggered G-IAM-08).
+   - `systemctl cat keycloak` — capture full effective unit for rollback
+     reference.
+   - Capture KC version + JDK + profile via `journalctl -u keycloak -n 100
+     --no-pager | head -20`.
+   - Test DB connectivity via the existing KC health endpoint or
+     `psql -h 127.0.0.1 -p 15433 -U <user> -d keycloak -c '\conninfo'`.
+
+2. **Create the password file (operator manual)**
+   - Read the current value from the active `--db-password=` argument or
+     from the operator's source-of-truth vault. Do NOT echo to shell history.
+   - Write to a temp file (e.g. `/root/.kc-db.password.tmp`) with `umask 077`.
+   - Move to `/etc/keycloak/db.password` (create directory if missing).
+
+3. **Set permissions**
+   - `chown root:keycloak /etc/keycloak/db.password`
+   - `chmod 0640 /etc/keycloak/db.password`
+   - `ls -l /etc/keycloak/db.password` → must show
+     `-rw-r----- 1 root keycloak ...`.
+
+4. **Install the systemd drop-in**
+   - `install -d /etc/systemd/system/keycloak.service.d`
+   - Render the template `infra/keycloak/keycloak.service.d/g-iam-08-fix.conf.template`
+     by substituting `{{KC_HOME}}` with the live path (e.g.
+     `/home/banxe/keycloak-26.2.5`).
+   - Place at `/etc/systemd/system/keycloak.service.d/g-iam-08-fix.conf`.
+
+5. **Reload + restart**
+   - `systemctl daemon-reload`
+   - `systemctl restart keycloak`
+
+6. **Post-restart verification**
+   - `systemctl status keycloak` — must be `active (running)`.
+   - `journalctl -u keycloak -n 50 --no-pager` — no DB-auth errors.
+   - `ss -ltnp | grep 8080` (or the configured KC port) — listening.
+   - KC realm-login smoke (if a non-prod realm is available).
+   - DB connectivity confirmed via KC health endpoint or `psql`.
+
+7. **Confirm exposure closed**
+   - `ps -ef | grep '[k]eycloak.*--db-password='` → must return NO matches.
+   - `cat /proc/$(pgrep -f keycloak)/cmdline | tr '\0' ' '` → must not
+     contain `--db-password=`.
+
+## 5. Rollback procedure
+
+If post-migration verification fails, rollback in this exact order:
+
+1. `rm -f /etc/systemd/system/keycloak.service.d/g-iam-08-fix.conf`
+   (drop the override; the original unit's ExecStart returns to effect).
+2. `systemctl daemon-reload`
+3. `systemctl restart keycloak`
+4. Validate that `systemctl cat keycloak` matches the pre-migration baseline
+   captured in §4 step 1.
+5. Re-run `systemctl status keycloak` and the post-restart verification
+   commands from §4 step 6.
+6. Leave `/etc/keycloak/db.password` in place (no harm; not yet referenced)
+   unless explicitly directed to remove. Removing it is a follow-up clean-up,
+   not a rollback prerequisite.
+
+## 6. HITL gate
+
+This migration is destructive on production Keycloak (restart, brief auth
+outage during restart). It requires **explicit Central + operator approval
+before deploy**, recorded against IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12 in
+the operator-side ledger. The HITL artifact is the operator sign-off block
+in `OPERATOR-RUNBOOK-G-IAM-08.md`.
+
+## 7. Post-migration follow-up
+
+- Schedule the DB password rotation per Sprint S12.5 90-day cadence
+  (per IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 — "client
+  secrets rotation 90d"). Future rotations only update
+  `/etc/keycloak/db.password` and restart KC; no systemd-level changes.
+- Add the file `/etc/keycloak/db.password` to the next backup-coverage
+  review (the password file is now a secret-of-record).
+- Record this hardening as evidence on the FCA SYSC 4.1 control map at
+  the next compliance review.
+
+## 8. Cross-references
+
+- IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12 (gap origin).
+- IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 (S12.5 owner).
+- IL-CANON-TERMINAL-B-AUTONOMOUS-FIXATION-2026-05-12 (this PR's authority).
+- IL-CANON-EXPLICIT-TARGET-INSTRUCTION-2026-05-12 (target = repo prep only).
+- Sibling files in this directory:
+  - `keycloak.service.d/g-iam-08-fix.conf.template` — systemd drop-in.
+  - `db.password.template` — password-file placeholder.
+  - `install-db-password-file.sh` — installer script.
+  - `validate-g-iam-08-mitigation.sh` — offline validator.
+  - `OPERATOR-RUNBOOK-G-IAM-08.md` — operator runbook.

--- a/infra/keycloak/OPERATOR-RUNBOOK-G-IAM-08.md
+++ b/infra/keycloak/OPERATOR-RUNBOOK-G-IAM-08.md
@@ -1,0 +1,113 @@
+# Operator runbook — G-IAM-08 Keycloak DB password hardening
+
+Owner sprint: S12.5.
+Anchors: G-IAM-08, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12,
+IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12.
+
+---
+
+## Purpose
+
+Deploy the G-IAM-08 mitigation on production evo1: replace the
+`--db-password=<literal>` argument on the Keycloak systemd unit with
+`--db-password-file=/etc/keycloak/db.password`.
+
+## Non-goal
+
+**This runbook does NOT deploy from inside this repo PR.** The PR delivers
+only the prep package (templates + plan + installer + validator). Deployment
+is operator-driven on evo1 and gated by Central + operator approval per the
+HITL gate in `G-IAM-08-MIGRATION-PLAN.md` §6.
+
+## Pre-checks (run before any change)
+
+1. `systemctl status keycloak` — capture baseline; confirm `active (running)`.
+2. `systemctl cat keycloak > /root/keycloak.unit.pre-g-iam-08.txt` — full
+   effective unit snapshot for rollback reference.
+3. `ps -ef | grep '[k]eycloak.*--db-password='` — confirm the exposure that
+   triggered G-IAM-08 is still present (do not log the result to anywhere
+   shared).
+4. `journalctl -u keycloak -n 100 --no-pager | head -20` — capture KC
+   version + JDK + profile lines.
+5. `ss -ltnp | grep 8080` (or configured port) — confirm listener.
+
+## Deploy steps
+
+The reference files in this PR live at `infra/keycloak/` in the
+banxe-emi-stack repo. Operator workflow on evo1:
+
+1. **Stage password file.**
+   - Read the current DB password from the operator's source-of-truth vault
+     (NOT from `ps -ef` after deploy starts).
+   - `umask 077; printf '%s' "<PASSWORD>" > /root/.kc-db.password.tmp`
+   - Run the installer:
+     `./install-db-password-file.sh /root/.kc-db.password.tmp /etc/keycloak`
+   - `ls -l /etc/keycloak/db.password` — verify
+     `-rw-r----- 1 root keycloak ...`.
+   - `shred -u /root/.kc-db.password.tmp`.
+
+2. **Render + install the systemd drop-in.**
+   - Substitute `{{KC_HOME}}` in
+     `keycloak.service.d/g-iam-08-fix.conf.template`
+     (e.g. `/home/banxe/keycloak-26.2.5`).
+   - `install -d -m 0755 /etc/systemd/system/keycloak.service.d`
+   - Place the rendered file at
+     `/etc/systemd/system/keycloak.service.d/g-iam-08-fix.conf`.
+   - `chmod 0644 /etc/systemd/system/keycloak.service.d/g-iam-08-fix.conf`.
+
+3. **Reload + restart.**
+   - `systemctl daemon-reload`
+   - `systemctl restart keycloak`
+
+## Validation steps (smoke checklist)
+
+After restart, run all of the following. ALL must pass before sign-off.
+
+- [ ] `systemctl status keycloak` — `active (running)`.
+- [ ] `journalctl -u keycloak -n 50 --no-pager` — no DB-auth errors; no
+      `password-file` errors.
+- [ ] `ss -ltnp | grep 8080` (or configured port) — listening.
+- [ ] KC health endpoint responds (or realm login sanity check if the
+      operational profile permits).
+- [ ] `ps -ef | grep '[k]eycloak.*--db-password='` — returns NO matches
+      (exposure closed).
+- [ ] `cat /proc/$(pgrep -f keycloak)/cmdline | tr '\0' ' '` does NOT
+      contain `--db-password=`.
+- [ ] `ls -l /etc/keycloak/db.password` — owner `root:keycloak`, mode `0640`.
+
+## Rollback (if any validation step fails)
+
+Follow `G-IAM-08-MIGRATION-PLAN.md` §5 verbatim:
+
+1. `rm -f /etc/systemd/system/keycloak.service.d/g-iam-08-fix.conf`
+2. `systemctl daemon-reload`
+3. `systemctl restart keycloak`
+4. Compare `systemctl cat keycloak` against the pre-migration baseline
+   captured in pre-check #2.
+5. Confirm `systemctl status keycloak` returns to `active (running)`.
+
+## Operator sign-off block
+
+Fill in upon completion (success or rollback). Append to the operator
+sign-off ledger.
+
+```
+Date           : __________________________
+Executor       : __________________________
+Reviewer       : __________________________
+Result         : [ ] PASS    [ ] FAIL    [ ] ROLLBACK
+Rollback needed: [ ] No      [ ] Yes (details below)
+Notes          :
+
+
+```
+
+## References
+
+- `G-IAM-08-MIGRATION-PLAN.md` (this directory) — full plan + rationale.
+- `keycloak.service.d/g-iam-08-fix.conf.template` — systemd drop-in.
+- `db.password.template` — password-file placeholder.
+- `install-db-password-file.sh` — installer.
+- `validate-g-iam-08-mitigation.sh` — offline validator (run from CI / dev).
+- IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12 — gap origin.
+- IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12 — this prep package's IL pairing.

--- a/infra/keycloak/db.password.template
+++ b/infra/keycloak/db.password.template
@@ -1,0 +1,1 @@
+# Operator: replace contents with current KC DB password; install as /etc/keycloak/db.password with owner root:keycloak and mode 0640.

--- a/infra/keycloak/install-db-password-file.sh
+++ b/infra/keycloak/install-db-password-file.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install-db-password-file.sh — install Keycloak DB password file in place.
+#
+# Idempotent installer for the G-IAM-08 mitigation.
+# Usage:
+#   ./install-db-password-file.sh <source-file> <target-dir>
+#
+# - <source-file> : path to the operator-prepared password file (a single
+#                   line, no trailing newline beyond the password value).
+# - <target-dir>  : destination directory (default usage: /etc/keycloak).
+#                   The script writes the password to <target-dir>/db.password.
+#
+# After install:
+#   * mode  0640
+#   * owner root:keycloak  (skipped with warning if not run as root)
+#   * directory created if missing
+#
+# Anchors:
+#   G-IAM-08, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12
+#
+# No secret values are echoed to stdout.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <source-file> <target-dir>" >&2
+    exit 2
+}
+
+[[ $# -eq 2 ]] || usage
+
+SRC=$1
+TARGET_DIR=$2
+TARGET_FILE="${TARGET_DIR}/db.password"
+
+if [[ ! -f "$SRC" ]]; then
+    echo "ERROR: source file not found: $SRC" >&2
+    exit 1
+fi
+
+if [[ ! -s "$SRC" ]]; then
+    echo "ERROR: source file is empty: $SRC" >&2
+    exit 1
+fi
+
+# Create target dir if missing (mode 0755 for the dir is conventional).
+if [[ ! -d "$TARGET_DIR" ]]; then
+    install -d -m 0755 "$TARGET_DIR"
+fi
+
+# Install via umask-safe `install` to apply mode atomically.
+install -m 0640 "$SRC" "$TARGET_FILE"
+
+# Set ownership to root:keycloak when running as root; otherwise warn.
+if [[ "$(id -u)" -eq 0 ]]; then
+    chown root:keycloak "$TARGET_FILE"
+else
+    echo "WARNING: not running as root; skipping chown root:keycloak on ${TARGET_FILE}." >&2
+    echo "         Re-run as root or run: sudo chown root:keycloak ${TARGET_FILE}" >&2
+fi
+
+# Resulting metadata only (no contents).
+ls -l "$TARGET_FILE"

--- a/infra/keycloak/keycloak.service.d/g-iam-08-fix.conf.template
+++ b/infra/keycloak/keycloak.service.d/g-iam-08-fix.conf.template
@@ -1,0 +1,31 @@
+# Keycloak systemd drop-in — G-IAM-08 mitigation template
+# ---------------------------------------------------------------------------
+# Purpose:
+#   Replace the inline `--db-password=<literal>` argument on Keycloak's
+#   ExecStart with `--db-password-file=/etc/keycloak/db.password` so that
+#   the DB password is never visible in `ps -ef` / `/proc/<pid>/cmdline`.
+#
+# Anchors:
+#   G-IAM-08
+#   IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12
+#   IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 (Sprint S12.5)
+#
+# Operator substitution required at deploy time:
+#   {{KC_HOME}} → live Keycloak install root, e.g. /home/banxe/keycloak-26.2.5
+#
+# Install path: /etc/systemd/system/keycloak.service.d/g-iam-08-fix.conf
+# Requires:     /etc/keycloak/db.password exists, mode 0640, owner root:keycloak.
+# ---------------------------------------------------------------------------
+
+[Service]
+# Reset the inherited ExecStart so this drop-in fully replaces it.
+ExecStart=
+ExecStart={{KC_HOME}}/bin/kc.sh start \
+  --optimized \
+  --db=postgres \
+  --db-url=jdbc:postgresql://127.0.0.1:15433/keycloak \
+  --db-username=keycloak \
+  --db-password-file=/etc/keycloak/db.password \
+  --http-enabled=true \
+  --hostname-strict=false \
+  --proxy-headers=xforwarded

--- a/infra/keycloak/validate-g-iam-08-mitigation.sh
+++ b/infra/keycloak/validate-g-iam-08-mitigation.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# validate-g-iam-08-mitigation.sh — offline validator for the G-IAM-08 prep
+# package. No remote access. No production touch.
+#
+# Anchors:
+#   G-IAM-08, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12
+#
+# Exit codes:
+#   0 — all checks PASS
+#   1 — at least one check FAIL
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLAN="${ROOT_DIR}/G-IAM-08-MIGRATION-PLAN.md"
+DROPIN="${ROOT_DIR}/keycloak.service.d/g-iam-08-fix.conf.template"
+PASSWORD_TEMPLATE="${ROOT_DIR}/db.password.template"
+RUNBOOK="${ROOT_DIR}/OPERATOR-RUNBOOK-G-IAM-08.md"
+INSTALLER="${ROOT_DIR}/install-db-password-file.sh"
+
+pass_count=0
+fail_count=0
+
+check() {
+    local label=$1
+    shift
+    if "$@"; then
+        echo "  [PASS] ${label}"
+        pass_count=$((pass_count + 1))
+    else
+        echo "  [FAIL] ${label}"
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+exists() { [[ -f "$1" ]]; }
+contains() { grep -q -- "$2" "$1"; }
+not_contains() { ! grep -q -- "$2" "$1"; }
+# not_contains_noncomment: like not_contains, but ignores commented lines
+# (lines whose first non-blank character is '#'). Used to assert that the
+# active config in a template doesn't contain a forbidden token even when
+# a header comment quotes it for explanatory purposes.
+not_contains_noncomment() {
+    ! grep -v '^[[:space:]]*#' "$1" | grep -q -- "$2"
+}
+
+echo "G-IAM-08 prep-package offline validation"
+echo "----------------------------------------"
+
+echo "[1] File presence"
+check "migration plan present"   exists "$PLAN"
+check "systemd drop-in template present" exists "$DROPIN"
+check "password file template present"   exists "$PASSWORD_TEMPLATE"
+check "operator runbook present"         exists "$RUNBOOK"
+check "installer script present"         exists "$INSTALLER"
+
+echo "[2] systemd drop-in template content"
+check "template uses --db-password-file=/etc/keycloak/db.password" \
+    contains "$DROPIN" "--db-password-file=/etc/keycloak/db.password"
+check "template active config does NOT contain --db-password=<literal> flag" \
+    not_contains_noncomment "$DROPIN" "--db-password=[^f]"
+check "template references G-IAM-08 in header" \
+    contains "$DROPIN" "G-IAM-08"
+
+echo "[3] Migration plan content"
+check "plan references G-IAM-08" \
+    contains "$PLAN" "G-IAM-08"
+check "plan records the 2026-05-12 verified evidence timestamp" \
+    contains "$PLAN" "2026-05-12 07:37:50Z"
+check "plan includes a Rollback section" \
+    contains "$PLAN" "Rollback"
+check "plan includes HITL gate language" \
+    contains "$PLAN" "HITL"
+
+echo "[4] Runbook content"
+check "runbook references G-IAM-08" \
+    contains "$RUNBOOK" "G-IAM-08"
+check "runbook contains explicit non-deploy statement" \
+    contains "$RUNBOOK" "does NOT deploy"
+check "runbook includes operator sign-off block" \
+    contains "$RUNBOOK" "sign-off"
+
+echo "[5] Installer script sanity"
+check "installer has set -euo pipefail" \
+    contains "$INSTALLER" "set -euo pipefail"
+check "installer does NOT echo secrets via cat target" \
+    not_contains "$INSTALLER" "cat \"\${TARGET_FILE}\""
+
+echo "----------------------------------------"
+echo "Summary: ${pass_count} PASS / ${fail_count} FAIL"
+
+if [[ "$fail_count" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Sprint S12.5 PREP — G-IAM-08 Keycloak DB password hardening (prep only)

### What
Repo-only scaffolding so Central can later deploy the G-IAM-08 mitigation on evo1 with confidence. No production deploy in this PR.

### Problem (verified 2026-05-12 07:37:50Z by Central diagnostic on evo1)
keycloak.service ExecStart on evo1 contains `--db-password=<literal>` — visible to any user via `ps -ef` / `/proc/<pid>/cmdline`. KC 26.2.5, JDK 21, profile=prod, Postgres backend at `jdbc:postgresql://127.0.0.1:15433/keycloak`. Triggers G-IAM-08 (P1). Blocks S12.4 realm provisioning. Regulatory: FCA SYSC 4.1, GDPR Art. 32.

### Recommended mitigation
Adopt native KC 26.x flag `--db-password-file=/etc/keycloak/db.password` (file `root:keycloak 0640`) via a systemd drop-in. Rejected alternative `EnvironmentFile=` (leaks via `/proc/<pid>/environ`).

### Files (7 / +513 / -0)
- `infra/keycloak/G-IAM-08-MIGRATION-PLAN.md` — full migration plan: problem statement (with evidence timestamp + source), two candidate solutions, recommendation, 7-step migration sequence, rollback procedure, HITL gate, post-migration follow-up.
- `infra/keycloak/keycloak.service.d/g-iam-08-fix.conf.template` — systemd drop-in template. Uses `{{KC_HOME}}` placeholder for operator substitution at deploy. ExecStart= reset + new ExecStart with `--db-password-file=/etc/keycloak/db.password`.
- `infra/keycloak/db.password.template` — password-file placeholder with a single comment line instructing the operator.
- `infra/keycloak/install-db-password-file.sh` — idempotent installer (`set -euo pipefail`); usage `./install-db-password-file.sh <source-file> <target-dir>`; chmod 0640; chown root:keycloak (skips with warning if non-root); never echoes secrets to stdout.
- `infra/keycloak/validate-g-iam-08-mitigation.sh` — offline validator. Asserts file presence, template uses the file-form flag, template's active config does NOT contain `--db-password=<literal>` (comment lines skipped via `not_contains_noncomment`), plan references G-IAM-08 + 2026-05-12 evidence + Rollback + HITL, runbook contains non-deploy statement + sign-off block, installer hygiene. Local run: 17/17 PASS.
- `infra/keycloak/OPERATOR-RUNBOOK-G-IAM-08.md` — operator runbook: purpose, explicit non-goal (this PR does NOT deploy), pre-checks, deploy steps, smoke checklist, rollback steps, sign-off block (date / executor / reviewer / result / rollback needed).
- `INSTRUCTION-LEDGER.md` — appended IL entry `IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12` (DONE; prep package only; production mitigation gated by Central + operator approval).

### Anchors
- G-IAM-08
- IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12 (gap origin)
- IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 (Sprint S12.5)
- IL-CANON-TERMINAL-B-AUTONOMOUS-FIXATION-2026-05-12 (this PR's authority)
- IL-CANON-EXPLICIT-TARGET-INSTRUCTION-2026-05-12

### Out of scope
- No production deploy. No `ssh evo1`. No `systemctl daemon-reload`. No service code under `services/**`. No docs under `docs/canon/**` or `docs/factory/**`. No `HITL-MATRIX.yaml`. No `MEMORY.md`.
- ROADMAP.md left untouched (no Sprint S12.5 checklist pattern present in this repo's ROADMAP).

### HITL gate
Production mitigation on evo1 requires explicit Central + operator approval before deploy, recorded against IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12. The HITL artifact is the operator sign-off block in `OPERATOR-RUNBOOK-G-IAM-08.md`.

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added migration plan and operator runbook with deployment steps, rollback procedures, and compliance references
  * Recorded infrastructure ledger entry documenting credential hardening scaffolding

* **New Features**
  * Introduced installer script for secure database password file management
  * Added validation script to verify hardening implementation compliance
  * Created systemd configuration template for password file integration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CarmiBanxe/banxe-emi-stack/pull/133)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->