### PR TITLE
feat(s12.6): prep G-IAM-09 keycloak backup policy package

### DIFF
--- a/INSTRUCTION-LEDGER.md
+++ b/INSTRUCTION-LEDGER.md
@@ -271,3 +271,39 @@
   IL-CANON-EXPLICIT-TARGET-INSTRUCTION-2026-05-12.
 - Production mitigation remains gated by Central + operator approval; no
   evo1 deploy, no `systemctl daemon-reload`, no ssh evo1 performed by this PR.
+
+
+---
+
+### IL-OPS-S12-6-G-IAM-09-PREP-2026-05-12
+- Date: 2026-05-12
+- Status: DONE (prep package only; no production deploy)
+- Scope: Sub-B autonomous prep for G-IAM-09 mitigation (no Keycloak
+  backups present on evo1 — zero RPO, violates ADR-029 + FCA SYSC 4.1.5).
+  This entry documents repo-only scaffolding; production deploy of the
+  backup policy + first restore drill remain gated by Central + operator
+  approval per HITL gate in `G-IAM-09-BACKUP-POLICY.md` §6.
+- Files created (under `infra/keycloak/`):
+  - `G-IAM-09-BACKUP-POLICY.md` (policy + ADR-029 alignment matrix + deploy + rollback + HITL)
+  - `OPERATOR-RUNBOOK-G-IAM-09-RESTORE-DRILL.md` (sandbox-only drill flow + sign-off)
+  - `scripts/kc-backup.sh.template` (pg_dump -Fc → gpg AES256 → sha256 → off-host)
+  - `scripts/validate-g-iam-09-backup-prep.sh` (offline lint; 29/29 PASS local run)
+  - `cron.d/kc-backup.cron.template` (daily 02:30; placeholders for wrapper + log path)
+  - `examples/backup.env.example` (env placeholders; no secrets)
+  - `examples/offhost-target.example` (off-host transport variants)
+- Credential flow: backup wrapper reuses the `/etc/keycloak/db.password`
+  file landed by IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12 (PR #133, merged
+  f37f866) — no plaintext password in CLI args, env, cron, or any template.
+- ADR-029 alignment: format + retention + drill cadence proposed defaults;
+  values not specified in canonical ADR-029 carry explicit TODO markers in
+  the alignment matrix. Bank-side `services/backup/` code (BackupPort,
+  PgDumpBackupAdapter, RestoreDrillPort, OffsiteUploadPort) referenced
+  as concrete implementation anchors.
+- Anchors: G-IAM-09, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12,
+  IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 (Sprint S12.6),
+  IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12 (credential-file sibling),
+  IL-CANON-TERMINAL-B-AUTONOMOUS-FIXATION-2026-05-12,
+  IL-CANON-EXPLICIT-TARGET-INSTRUCTION-2026-05-12.
+- Production deploy + first restore drill remain gated by Central +
+  operator approval; no evo1 deploy, no `pg_dump` execution against
+  production, no `systemctl daemon-reload`, no `ssh evo1` performed.

--- a/infra/keycloak/G-IAM-09-BACKUP-POLICY.md
+++ b/infra/keycloak/G-IAM-09-BACKUP-POLICY.md
@@ -1,0 +1,186 @@
+# G-IAM-09 — Keycloak backup policy (forward + rollback)
+
+Owner sprint: S12.6 (per IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11).
+Anchors: G-IAM-09, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12,
+ADR-029 (Postgres backup strategy — canonical lives in banxe-architecture),
+FCA SYSC 4.1.5 (operational resilience).
+Status: PREP (this PR delivers the policy + scaffolding only; no deploy here).
+
+---
+
+## 1. Problem statement
+
+Verified evidence (2026-05-12 07:37:50Z, Central diagnostic on evo1):
+
+- No Keycloak backup artifacts located on evo1: no files under
+  `/var/backups`, `/opt/backups`, or any `*keycloak*backup*` path.
+- KC 26.2.5 in production with the Postgres backend at
+  `jdbc:postgresql://127.0.0.1:15433/keycloak` (port 15433 suggests
+  containerized PG; verify at deploy time).
+- Backup state RPO is effectively unbounded — any DB-loss event today
+  results in total loss of realm, clients, users, sessions, audit rows.
+
+Regulatory mapping:
+- **FCA SYSC 4.1.5** — operational resilience and recoverability.
+- **ADR-029 (Postgres backup strategy)** — canonical contract; this policy
+  is the Keycloak-specific specialisation. Where ADR-029 specifies a value,
+  this document reuses it. Where ADR-029 is silent or KC-specific, this
+  document records a TODO + proposed default + rationale.
+
+Operational impact today:
+- Blocks S12.4 realm provisioning (no realm authoring should land while the
+  authoring substrate has zero RPO).
+- Cannot exercise rollback for the G-IAM-08 hardening (PR #133) — if KC fails
+  post-migration, there is no restorable baseline.
+
+## 2. Scope
+
+In scope:
+- The Keycloak Postgres backend database (port 15433, db `keycloak`).
+- Realm metadata, clients, users, federated-identity links, audit table
+  (`event_entity` etc.), session-state tables.
+- Encryption-at-rest of the resulting artifact.
+- Off-host copy of the artifact.
+- Monthly restore-drill cadence with operator sign-off.
+
+Out of scope:
+- The Keycloak install tree itself (`/home/banxe/keycloak-26.2.5/`) —
+  immutable / re-installable from packaging.
+- Application-side databases other than the KC backend.
+- Long-term archival beyond 12 months (separate retention conversation).
+
+## 3. ADR-029 alignment matrix
+
+Each row maps an ADR-029 requirement to a KC-specific tuning. The
+canonical ADR-029 lives in `banxe-architecture/decisions/`; values listed
+as TODO are proposed defaults pending Central confirmation against the
+authoritative ADR text.
+
+| ADR-029 requirement              | KC-specific value (this policy)                              | Source / status |
+|----------------------------------|--------------------------------------------------------------|-----------------|
+| Backup frequency                  | Daily, 02:30 local time (off-peak; avoids n8n at 02:00)      | TODO — confirm ADR-029 baseline; proposed |
+| Dump format                       | `pg_dump -Fc` (custom format — selective restore + compact)  | Aligned with `services/backup/pg_backup_adapter.py:PgDumpBackupAdapter` (which already uses `--format=custom`) |
+| Encryption at rest                | GPG symmetric (AES256) with passphrase file root:keycloak 0640 | TODO — confirm ADR-029 (alternative: age) |
+| Off-host target                   | TODO — proposed: `s3://banxe-pg-backups/keycloak/<host>/<date>.gpg` if ADR-029 §1 MinIO bucket is in scope; fallback rsync to evo2:/data/banxe/backups/keycloak/ | TODO |
+| Retention                         | 7 daily + 4 weekly + 12 monthly (rolling)                    | TODO — confirm ADR-029; proposed default mirrors `services/backup/factory.py:BACKUP_RETENTION_COUNT=7` baseline |
+| Restore-drill cadence             | Monthly, first business day of month, sandbox-only           | TODO — confirm ADR-029 §4 schedule (current bank-side adapter `services/backup/restore_drill_port.py` exists but is not gated by ADR cadence text) |
+| Drill validation                  | `pg_restore --list` + sandbox KC startup + realm/user count parity | This policy |
+| Operator sign-off                 | Required for first backup + every restore drill              | This policy + HITL gate (§6) |
+
+Bank-side code anchors usable as concrete reference points:
+- `services/backup/backup_port.py` — `BackupPort` abstract contract.
+- `services/backup/pg_backup_adapter.py` — `PgDumpBackupAdapter` with
+  `--format=custom`, `BACKUP_PG_*` env contract, retention rotation.
+- `services/backup/restore_drill_port.py` — `RestoreDrillPort` abstract.
+- `services/backup/local_restore_drill_adapter.py` — `LocalRestoreDrillAdapter`
+  (drill orchestration in code; sandbox-only).
+- `services/backup/offsite_upload_port.py` — `OffsiteUploadPort` abstract;
+  `InMemoryOffsiteAdapter` for dev; MinIO adapter pending real integration.
+
+Where the policy mandates a value that ADR-029 does not yet specify for KC,
+the operator deploy step (§4) carries the value selection into the rendered
+cron + wrapper at install time.
+
+## 4. Backup contract
+
+| Property               | Value                                                        |
+|------------------------|--------------------------------------------------------------|
+| Source DB              | jdbc:postgresql://127.0.0.1:15433/keycloak                   |
+| Source DB user         | `keycloak` (read-only role preferred; TODO — confirm) |
+| Auth method            | Password file `/etc/keycloak/db.password` (root:keycloak 0640) — reuses the G-IAM-08 file (PR #133) |
+| Dump command           | `pg_dump -Fc -h <host> -p <port> -U <user> -d keycloak`      |
+| Artifact filename      | `keycloak-<YYYYMMDD-HHMMSS>.dump.gpg`                        |
+| Encryption             | `gpg --symmetric --cipher-algo AES256 --batch --passphrase-file <PASSPHRASE_FILE>` |
+| Local staging dir      | `/var/backups/keycloak/` (root:keycloak 0750)                |
+| Integrity              | `sha256sum` of encrypted artifact written next to it (`.sha256` sidecar) |
+| Off-host copy          | Operator-chosen MinIO bucket OR rsync target (TODO)         |
+| Local retention        | 7 daily files; oldest pruned by wrapper script               |
+| Off-host retention     | 7 daily + 4 weekly + 12 monthly (operator-managed)           |
+| Cron schedule          | `30 2 * * *` (02:30 daily)                                   |
+| Logging                | `/var/log/keycloak/backup.log` (root:keycloak 0640)          |
+
+## 5. Operator deploy procedure (NOT executed in this PR)
+
+The steps below are operator-runnable on evo1, gated by §6 HITL.
+
+1. **Pre-flight on evo1**
+   - Confirm PG reachable: `psql -h 127.0.0.1 -p 15433 -U keycloak -d keycloak -c '\conninfo'` (use password file).
+   - Confirm disk space: `df -h /var/backups` — minimum 10 GB free.
+   - Confirm `gpg` installed: `gpg --version`.
+   - Confirm encryption passphrase file exists at the operator-chosen path,
+     mode 0600, owner root. (NOT committed to git.)
+   - Confirm off-host target reachable.
+
+2. **Install the wrapper**
+   - Render `infra/keycloak/scripts/kc-backup.sh.template` by substituting
+     `{{KC_DB_HOST}}`, `{{KC_DB_PORT}}`, `{{KC_DB_NAME}}`, `{{KC_DB_USER}}`,
+     `{{KC_DB_PASSWORD_FILE}}`, `{{BACKUP_DIR}}`, `{{ENCRYPTION_RECIPIENT}}`,
+     `{{OFFHOST_TARGET}}`.
+   - Place at `/usr/local/bin/kc-backup.sh` mode 0750 root:keycloak.
+
+3. **Install cron entry**
+   - Render `infra/keycloak/cron.d/kc-backup.cron.template` and install at
+     `/etc/cron.d/kc-backup` mode 0644 root:root.
+
+4. **First manual backup**
+   - Run `sudo -u keycloak /usr/local/bin/kc-backup.sh` once interactively.
+   - Verify artifact + sha256 sidecar present in `/var/backups/keycloak/`.
+   - Verify off-host artifact present at the chosen target.
+
+5. **Schedule first restore drill within 7 days**
+   - See §7 for the drill procedure.
+   - First drill must be operator-witnessed; result logged against
+     `IL-OPS-S12-6-G-IAM-09-PREP-2026-05-12` (see `INSTRUCTION-LEDGER.md`).
+
+## 6. HITL gate
+
+- Initial deploy requires Central + operator approval per
+  IL-CANON-TERMINAL-B-AUTONOMOUS-FIXATION-2026-05-12.
+- Every restore drill requires operator witness + sign-off (see runbook).
+- The first successful backup AND the first successful drill must be logged
+  against `IL-OPS-S12-6-G-IAM-09-PREP-2026-05-12`.
+
+## 7. Restore drill procedure (NOT executed in this PR)
+
+See `OPERATOR-RUNBOOK-G-IAM-09-RESTORE-DRILL.md` for the operator-facing
+runbook. Summary:
+
+1. Provision a sandbox Postgres instance (container or temp DB, NOT prod).
+2. Copy latest encrypted dump from off-host to sandbox host.
+3. Verify `sha256sum -c` against sidecar.
+4. `gpg --decrypt` → temp `.dump` file.
+5. `pg_restore --list <dump>` succeeds (catalog readable).
+6. `pg_restore -h <sandbox> -p <sandbox-port> -U <sandbox-user> -d keycloak_drill <dump>`.
+7. Start a secondary KC instance pointing at the sandbox DB.
+8. Verify `select count(*) from realm`, `select count(*) from user_entity`,
+   `select count(*) from client` match the production baseline (recorded the day
+   the backup was taken).
+9. Tear down sandbox cleanly; never write back to production.
+
+## 8. Rollback
+
+Backup policy is additive — rollback removes the policy without affecting
+prod KC operation:
+
+1. `rm /etc/cron.d/kc-backup`
+2. `rm /usr/local/bin/kc-backup.sh`
+3. Optionally `rm -rf /var/backups/keycloak/` (keeps last artifact by default;
+   document the choice).
+4. No KC restart required.
+
+Existing artifacts remain restorable via the runbook procedure regardless of
+whether the cron is active.
+
+## 9. Cross-references
+
+- `OPERATOR-RUNBOOK-G-IAM-09-RESTORE-DRILL.md` — operator-facing drill runbook.
+- `scripts/kc-backup.sh.template` — wrapper template.
+- `cron.d/kc-backup.cron.template` — cron template.
+- `scripts/validate-g-iam-09-backup-prep.sh` — offline lint validator.
+- `examples/backup.env.example` — env placeholder.
+- `examples/offhost-target.example` — off-host target placeholder.
+- `G-IAM-08-MIGRATION-PLAN.md` — sibling sprint S12.5 (PR #133), shares the
+  `/etc/keycloak/db.password` credential file.
+- ADR-029 canonical (banxe-architecture) — Postgres backup strategy.
+- IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 — S12.6 owner.
+- IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12 — gap origin.

--- a/infra/keycloak/OPERATOR-RUNBOOK-G-IAM-09-RESTORE-DRILL.md
+++ b/infra/keycloak/OPERATOR-RUNBOOK-G-IAM-09-RESTORE-DRILL.md
@@ -1,0 +1,146 @@
+# Operator runbook — G-IAM-09 Keycloak restore drill
+
+Owner sprint: S12.6.
+Anchors: G-IAM-09, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12,
+IL-OPS-S12-6-G-IAM-09-PREP-2026-05-12, ADR-029 (Postgres backup strategy
+— canonical in banxe-architecture).
+
+---
+
+## Purpose
+
+Verify that a Keycloak Postgres backup artifact produced by the wrapper
+defined in `G-IAM-09-BACKUP-POLICY.md` can be:
+
+1. Located on the off-host target.
+2. Verified against its `sha256` sidecar.
+3. Decrypted with the operator-held passphrase.
+4. Inspected via `pg_restore --list`.
+5. Restored into a sandbox PG instance.
+6. Read by a sandbox Keycloak instance with realm/user/client counts that
+   match the production baseline recorded the day the backup was taken.
+
+## Non-goal
+
+**This runbook does NOT perform a production restore.** Every step below
+operates on a sandbox PG + sandbox KC. Touching the production KC backend
+or production realm is explicitly out of scope of this runbook.
+
+Likewise, this prep PR does **not** execute any restore drill. The runbook
+is operator-executable on evo1/sandbox after deploy of the G-IAM-09 backup
+policy and after Central + operator HITL approval.
+
+## Prerequisites
+
+- G-IAM-09 backup wrapper installed and running daily (per `G-IAM-09-BACKUP-POLICY.md` §5).
+- At least one full backup artifact present on the off-host target.
+- Operator holds the encryption passphrase (out-of-band).
+- A sandbox PG instance available (container, ephemeral VM, or non-prod DB
+  with a `keycloak_drill` database created for this purpose).
+- A sandbox Keycloak install available (matching KC version 26.2.5).
+- Production baseline counts recorded the day of the source backup
+  (realm count, user count, client count) — for parity assertion.
+
+## Pre-checks
+
+1. `ls -l <offhost-target>/keycloak-<YYYYMMDD-HHMMSS>.dump.gpg{,.sha256}` — both files present.
+2. Free disk on sandbox host: at least 2× the encrypted artifact size.
+3. `gpg --version`, `pg_restore --version`, `sha256sum --version` available
+   on sandbox host.
+
+## Drill steps
+
+1. **Stage artifact.**
+   - Copy artifact + sidecar from off-host target into a sandbox workdir
+     (e.g. `/tmp/kc-drill-<YYYYMMDD>/`).
+2. **Verify integrity.**
+   - `cd <workdir> && sha256sum -c keycloak-<stamp>.dump.gpg.sha256`
+   - Must report `OK`. Any mismatch ABORTS the drill.
+3. **Decrypt.**
+   - `gpg --batch --passphrase-file <passphrase-file>
+        --decrypt -o keycloak-<stamp>.dump
+        keycloak-<stamp>.dump.gpg`
+   - Result: a `.dump` file (pg_dump custom format).
+4. **Inspect catalog.**
+   - `pg_restore --list keycloak-<stamp>.dump | head -50`
+   - Must list expected schemas (`public`, `keycloak`-style tables).
+5. **Provision sandbox DB.**
+   - Create database `keycloak_drill` in the sandbox PG.
+   - Create role with `CREATEDB`+`CREATEROLE` for the drill — NOT shared
+     with any prod credential.
+6. **Restore.**
+   - `pg_restore --no-owner --no-privileges
+        --host=<sandbox-host> --port=<sandbox-port> --username=<sandbox-user>
+        --dbname=keycloak_drill keycloak-<stamp>.dump`
+   - Capture stdout/stderr to `/tmp/kc-drill-<YYYYMMDD>/restore.log`.
+   - Acceptable warnings: missing role grants (sandbox doesn't replicate
+     prod roles). ABORT on real errors (FATAL, ERROR).
+7. **Start sandbox Keycloak.**
+   - Configure the sandbox KC's `--db-url` to the sandbox PG and
+     `--db-name=keycloak_drill`.
+   - Start KC; wait for `Listening on:` log line.
+8. **Validate counts.**
+   - Connect to sandbox KC admin OR run SQL directly:
+     - `select count(*) from realm;`
+     - `select count(*) from user_entity;`
+     - `select count(*) from client;`
+   - Compare against production baseline captured the day of the source
+     backup. Variance within ±1 (in-flight changes during the dump window)
+     is acceptable; larger variance ABORTS and triggers investigation.
+9. **Capture evidence.**
+   - `journalctl -u keycloak-sandbox -n 200 --no-pager > evidence-kc.log`
+   - `cat /tmp/kc-drill-<YYYYMMDD>/restore.log >> evidence-restore.log`
+   - Archive the directory under operator drill-evidence retention.
+10. **Tear down.**
+    - Stop sandbox KC.
+    - `dropdb keycloak_drill` on sandbox PG.
+    - `rm -rf /tmp/kc-drill-<YYYYMMDD>/` (decrypted dump must not linger).
+
+## Validation checklist
+
+- [ ] Artifact present on off-host target.
+- [ ] `sha256sum -c` PASS.
+- [ ] `gpg --decrypt` PASS.
+- [ ] `pg_restore --list` PASS.
+- [ ] Restore into sandbox PG PASS (no FATAL/ERROR).
+- [ ] Sandbox KC starts cleanly against restored DB.
+- [ ] realm count parity within tolerance.
+- [ ] user_entity count parity within tolerance.
+- [ ] client count parity within tolerance.
+- [ ] Evidence archived.
+- [ ] Sandbox torn down; decrypted dump removed.
+
+## Rollback / cleanup
+
+A drill is non-destructive on production. "Rollback" here is sandbox cleanup:
+
+1. Stop sandbox KC (e.g. `systemctl stop keycloak-sandbox` or container down).
+2. `dropdb keycloak_drill` on sandbox PG.
+3. `shred -u` (or equivalent) the decrypted dump; `rm -rf` the workdir.
+4. Retain evidence archive per operator policy (suggest 90 days).
+
+## Operator sign-off block
+
+```
+Drill date     : __________________________
+Source backup  : keycloak-_________________.dump.gpg
+Off-host source: __________________________
+Executor       : __________________________
+Reviewer       : __________________________
+Restore log    : __________________________ (path / artifact ID)
+KC sandbox log : __________________________ (path / artifact ID)
+Result         : [ ] PASS    [ ] FAIL    [ ] ABORTED
+Notes / variance:
+
+
+```
+
+## References
+
+- `G-IAM-09-BACKUP-POLICY.md` — full backup policy + ADR-029 alignment matrix.
+- `scripts/kc-backup.sh.template` — wrapper template.
+- `cron.d/kc-backup.cron.template` — cron template.
+- `scripts/validate-g-iam-09-backup-prep.sh` — offline validator (run from CI / dev).
+- `examples/backup.env.example` — env placeholder.
+- `examples/offhost-target.example` — off-host target placeholder.
+- IL-OPS-S12-6-G-IAM-09-PREP-2026-05-12 — this prep package's IL pairing.

--- a/infra/keycloak/cron.d/kc-backup.cron.template
+++ b/infra/keycloak/cron.d/kc-backup.cron.template
@@ -1,0 +1,22 @@
+# /etc/cron.d/kc-backup — Keycloak backup cron (G-IAM-09 prep template)
+#
+# Anchors: G-IAM-09, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12,
+#          IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 (Sprint S12.6).
+#
+# Deploy only after Central + operator approval per HITL gate in
+# G-IAM-09-BACKUP-POLICY.md §6.
+#
+# Schedule rationale: 02:30 daily is off-peak and avoids the n8n window at
+# 02:00. If ADR-029 specifies a different baseline, override at install time.
+#
+# Substitute placeholders at install time:
+#   {{WRAPPER_PATH}} — usually /usr/local/bin/kc-backup.sh
+#   {{LOG_PATH}}     — usually /var/log/keycloak/backup.log
+#
+# Format: m h dom mon dow user command
+
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Daily Keycloak Postgres backup → encrypted artifact → off-host copy.
+30 2 * * * root {{WRAPPER_PATH}} >> {{LOG_PATH}} 2>&1

--- a/infra/keycloak/examples/backup.env.example
+++ b/infra/keycloak/examples/backup.env.example
@@ -1,0 +1,26 @@
+# backup.env.example — placeholders for the G-IAM-09 KC backup wrapper.
+# Operator: copy this file to a non-committed location at deploy time,
+# substitute concrete values, and source it from the wrapper rendering
+# step. NEVER commit a filled-in version of this file to git.
+
+# Keycloak Postgres backend (verified prod target on evo1).
+KC_DB_HOST=127.0.0.1
+KC_DB_PORT=15433
+KC_DB_NAME=keycloak
+KC_DB_USER=keycloak
+
+# Credential file — already present from G-IAM-08 (PR #133).
+# Owner root:keycloak, mode 0640. The wrapper reads PGPASSWORD from this file.
+KC_DB_PASSWORD_FILE=/etc/keycloak/db.password
+
+# Encryption passphrase file. NOT committed to git. Owner root, mode 0600.
+ENCRYPTION_PASSPHRASE_FILE=/etc/keycloak/backup.gpg.passphrase
+
+# Local staging directory for encrypted artifacts + sha256 sidecars.
+BACKUP_DIR=/var/backups/keycloak
+
+# Cron logging.
+LOG_PATH=/var/log/keycloak/backup.log
+
+# Local retention (days). Off-host retention is operator-managed.
+RETENTION_DAYS=7

--- a/infra/keycloak/examples/offhost-target.example
+++ b/infra/keycloak/examples/offhost-target.example
@@ -1,0 +1,12 @@
+# offhost-target.example — choose ONE off-host target at deploy time.
+# Operator: substitute into the wrapper template's {{OFFHOST_TARGET}}.
+# NEVER commit credentials or live host names to git.
+
+# Variant A: S3-compatible (MinIO bucket per ADR-029 §1 if in scope).
+# OFFHOST_TARGET=s3://banxe-pg-backups/keycloak/<host>/
+
+# Variant B: rsync to evo2 (or other off-host fileserver).
+# OFFHOST_TARGET=banxe@evo2:/data/banxe/backups/keycloak/
+
+# Variant C: SSH+scp via dedicated backup user (operator preference).
+# OFFHOST_TARGET=banxe-backup@evo2:/data/banxe/backups/keycloak/

--- a/infra/keycloak/scripts/kc-backup.sh.template
+++ b/infra/keycloak/scripts/kc-backup.sh.template
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# kc-backup.sh — Keycloak Postgres backup wrapper (G-IAM-09 prep template).
+#
+# Anchors:
+#   G-IAM-09
+#   IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12
+#   IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 (Sprint S12.6)
+#   ADR-029 (Postgres backup strategy — canonical lives in banxe-architecture)
+#
+# Operator substitution required at deploy time. Every `{{...}}` placeholder
+# below must be replaced with a concrete value before installing this script
+# at /usr/local/bin/kc-backup.sh:
+#
+#   {{KC_DB_HOST}}            — e.g. 127.0.0.1
+#   {{KC_DB_PORT}}            — e.g. 15433
+#   {{KC_DB_NAME}}            — e.g. keycloak
+#   {{KC_DB_USER}}            — e.g. keycloak (read-only role preferred)
+#   {{KC_DB_PASSWORD_FILE}}   — e.g. /etc/keycloak/db.password (G-IAM-08 file)
+#   {{BACKUP_DIR}}            — e.g. /var/backups/keycloak
+#   {{ENCRYPTION_PASSPHRASE_FILE}} — e.g. /etc/keycloak/backup.gpg.passphrase (root 0600)
+#   {{OFFHOST_TARGET}}        — e.g. s3://banxe-pg-backups/keycloak/<host>/
+#                                    OR rsync://evo2/banxe-backups/keycloak/
+#
+# Exit codes:
+#   0  success — artifact present, encrypted, checksummed, off-host copied
+#   1  generic failure (any step)
+#   2  pre-flight failure (missing tool or unreadable file)
+#   3  pg_dump failed
+#   4  encryption failed
+#   5  off-host copy failed
+#
+# This template MUST NOT execute a real backup in the prep PR; it is rendered
+# and installed by the operator at deploy time.
+
+set -euo pipefail
+
+# ── Configuration (operator-substituted) ─────────────────────────────────
+KC_DB_HOST="{{KC_DB_HOST}}"
+KC_DB_PORT="{{KC_DB_PORT}}"
+KC_DB_NAME="{{KC_DB_NAME}}"
+KC_DB_USER="{{KC_DB_USER}}"
+KC_DB_PASSWORD_FILE="{{KC_DB_PASSWORD_FILE}}"
+BACKUP_DIR="{{BACKUP_DIR}}"
+ENCRYPTION_PASSPHRASE_FILE="{{ENCRYPTION_PASSPHRASE_FILE}}"
+OFFHOST_TARGET="{{OFFHOST_TARGET}}"
+RETENTION_DAYS=7
+
+# ── Derived values ───────────────────────────────────────────────────────
+STAMP="$(date -u +%Y%m%d-%H%M%S)"
+DUMP_PATH="${BACKUP_DIR}/keycloak-${STAMP}.dump"
+ENC_PATH="${DUMP_PATH}.gpg"
+SHA_PATH="${ENC_PATH}.sha256"
+LOG_PREFIX="kc-backup[${STAMP}]"
+
+log() { printf '%s %s\n' "${LOG_PREFIX}" "$*"; }
+die() { log "ERROR: $*"; exit "${2:-1}"; }
+
+# ── Pre-flight ───────────────────────────────────────────────────────────
+log "pre-flight"
+command -v pg_dump   >/dev/null 2>&1 || die "pg_dump not installed" 2
+command -v gpg       >/dev/null 2>&1 || die "gpg not installed" 2
+command -v sha256sum >/dev/null 2>&1 || die "sha256sum not installed" 2
+
+[[ -r "${KC_DB_PASSWORD_FILE}" ]]      || die "password file unreadable: ${KC_DB_PASSWORD_FILE}" 2
+[[ -r "${ENCRYPTION_PASSPHRASE_FILE}" ]] || die "passphrase file unreadable: ${ENCRYPTION_PASSPHRASE_FILE}" 2
+
+install -d -m 0750 "${BACKUP_DIR}"
+
+# ── pg_dump (custom format) ──────────────────────────────────────────────
+log "pg_dump -Fc → ${DUMP_PATH}"
+PGPASSWORD="$(cat "${KC_DB_PASSWORD_FILE}")" \
+  pg_dump -Fc \
+    --host="${KC_DB_HOST}" \
+    --port="${KC_DB_PORT}" \
+    --username="${KC_DB_USER}" \
+    --file="${DUMP_PATH}" \
+    "${KC_DB_NAME}" \
+  || die "pg_dump failed" 3
+
+# ── Encrypt at rest ──────────────────────────────────────────────────────
+log "encrypt → ${ENC_PATH}"
+gpg --batch --yes \
+    --passphrase-file "${ENCRYPTION_PASSPHRASE_FILE}" \
+    --symmetric --cipher-algo AES256 \
+    --output "${ENC_PATH}" \
+    "${DUMP_PATH}" \
+  || die "gpg encrypt failed" 4
+
+shred -u "${DUMP_PATH}" 2>/dev/null || rm -f "${DUMP_PATH}"
+
+# ── Checksum sidecar ─────────────────────────────────────────────────────
+log "sha256 → ${SHA_PATH}"
+( cd "$(dirname "${ENC_PATH}")" && sha256sum "$(basename "${ENC_PATH}")" > "$(basename "${SHA_PATH}")" )
+
+# ── Off-host copy ────────────────────────────────────────────────────────
+log "off-host copy → ${OFFHOST_TARGET}"
+# Operator-chosen transport. Common variants below; remove the unused ones
+# at install time. Each variant must verify the uploaded object before exit 0.
+case "${OFFHOST_TARGET}" in
+  s3://*)
+    aws s3 cp "${ENC_PATH}" "${OFFHOST_TARGET%/}/" --only-show-errors \
+      || die "s3 cp failed" 5
+    aws s3 cp "${SHA_PATH}" "${OFFHOST_TARGET%/}/" --only-show-errors \
+      || die "s3 cp sha failed" 5
+    ;;
+  rsync://* | *@*:*)
+    rsync -av --no-perms "${ENC_PATH}" "${SHA_PATH}" "${OFFHOST_TARGET}" \
+      || die "rsync failed" 5
+    ;;
+  *)
+    die "unsupported OFFHOST_TARGET scheme: ${OFFHOST_TARGET}" 5
+    ;;
+esac
+
+# ── Local retention rotation ─────────────────────────────────────────────
+log "rotate local artifacts (keep ${RETENTION_DAYS} days)"
+find "${BACKUP_DIR}" -maxdepth 1 -type f \
+  \( -name 'keycloak-*.dump.gpg' -o -name 'keycloak-*.dump.gpg.sha256' \) \
+  -mtime "+${RETENTION_DAYS}" -delete
+
+log "OK"
+exit 0

--- a/infra/keycloak/scripts/validate-g-iam-09-backup-prep.sh
+++ b/infra/keycloak/scripts/validate-g-iam-09-backup-prep.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# validate-g-iam-09-backup-prep.sh — offline lint for the G-IAM-09 prep
+# package. No remote access. No execution of the wrapper. No production
+# touch.
+#
+# Anchors:
+#   G-IAM-09, IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12
+#
+# Exit codes:
+#   0  all checks PASS
+#   1  at least one check FAIL
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+POLICY="${ROOT_DIR}/G-IAM-09-BACKUP-POLICY.md"
+RUNBOOK="${ROOT_DIR}/OPERATOR-RUNBOOK-G-IAM-09-RESTORE-DRILL.md"
+WRAPPER="${ROOT_DIR}/scripts/kc-backup.sh.template"
+CRON="${ROOT_DIR}/cron.d/kc-backup.cron.template"
+ENV_EXAMPLE="${ROOT_DIR}/examples/backup.env.example"
+OFFHOST_EXAMPLE="${ROOT_DIR}/examples/offhost-target.example"
+
+pass_count=0
+fail_count=0
+
+check() {
+    local label=$1
+    shift
+    if "$@"; then
+        echo "  [PASS] ${label}"
+        pass_count=$((pass_count + 1))
+    else
+        echo "  [FAIL] ${label}"
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+exists() { [[ -f "$1" ]]; }
+contains() { grep -q -- "$2" "$1"; }
+not_contains() { ! grep -q -- "$2" "$1"; }
+# not_contains_noncomment: ignore commented lines.
+not_contains_noncomment() {
+    ! grep -v '^[[:space:]]*#' "$1" | grep -q -- "$2"
+}
+
+echo "G-IAM-09 prep-package offline validation"
+echo "----------------------------------------"
+
+echo "[1] File presence"
+check "backup policy present"            exists "$POLICY"
+check "restore-drill runbook present"    exists "$RUNBOOK"
+check "wrapper template present"         exists "$WRAPPER"
+check "cron template present"            exists "$CRON"
+check "env example present"              exists "$ENV_EXAMPLE"
+check "off-host target example present"  exists "$OFFHOST_EXAMPLE"
+
+echo "[2] Wrapper template content"
+check "wrapper uses pg_dump -Fc"                 contains "$WRAPPER" "pg_dump -Fc"
+check "wrapper uses password file (KC_DB_PASSWORD_FILE)" \
+    contains "$WRAPPER" "KC_DB_PASSWORD_FILE"
+check "wrapper does NOT carry plaintext --db-password=<literal>" \
+    not_contains_noncomment "$WRAPPER" "--db-password=[^f]"
+check "wrapper does NOT carry plaintext PGPASSWORD assignment in shell" \
+    not_contains_noncomment "$WRAPPER" "PGPASSWORD=[^\"$]"
+check "wrapper performs sha256 step"             contains "$WRAPPER" "sha256sum"
+check "wrapper has off-host copy step"           contains "$WRAPPER" "OFFHOST_TARGET"
+check "wrapper has retention rotation step"      contains "$WRAPPER" "RETENTION_DAYS"
+check "wrapper has set -euo pipefail"            contains "$WRAPPER" "set -euo pipefail"
+check "wrapper has gpg symmetric encrypt step"   contains "$WRAPPER" "gpg --batch"
+
+echo "[3] Cron template content"
+check "cron references wrapper path placeholder" contains "$CRON" "{{WRAPPER_PATH}}"
+check "cron references log path placeholder"     contains "$CRON" "{{LOG_PATH}}"
+check "cron has explicit deploy-after-approval comment" \
+    contains "$CRON" "after Central + operator approval"
+
+echo "[4] Policy doc content"
+check "policy references G-IAM-09"               contains "$POLICY" "G-IAM-09"
+check "policy references ADR-029"                contains "$POLICY" "ADR-029"
+check "policy records evidence timestamp"        contains "$POLICY" "2026-05-12 07:37:50Z"
+check "policy contains HITL gate section"        contains "$POLICY" "HITL gate"
+check "policy contains rollback section"         contains "$POLICY" "Rollback"
+check "policy contains alignment matrix"         contains "$POLICY" "alignment matrix"
+
+echo "[5] Runbook content"
+check "runbook references G-IAM-09"              contains "$RUNBOOK" "G-IAM-09"
+check "runbook contains explicit non-deploy statement" \
+    contains "$RUNBOOK" "does NOT perform a production restore"
+check "runbook contains restore drill section"   contains "$RUNBOOK" "Drill steps"
+check "runbook contains operator sign-off block" contains "$RUNBOOK" "sign-off"
+check "runbook contains validation checklist"    contains "$RUNBOOK" "Validation checklist"
+
+echo "----------------------------------------"
+echo "Summary: ${pass_count} PASS / ${fail_count} FAIL"
+
+if [[ "$fail_count" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Sprint S12.6 PREP — G-IAM-09 Keycloak backup policy (prep only)

### What
Forward-looking backup-policy scaffolding for Keycloak on evo1: policy doc + pg_dump wrapper template + cron template + restore-drill runbook + offline validator + IL pairing. No production deploy in this PR.

### Problem (verified 2026-05-12 07:37:50Z by Central diagnostic on evo1)
No Keycloak backup artifacts present (`/var/backups`, `/opt/backups`, any `*keycloak*backup*` path = empty). RPO is effectively unbounded. KC 26.2.5, Postgres backend at `jdbc:postgresql://127.0.0.1:15433/keycloak`. Triggers G-IAM-09 (P1). Blocks S12.4 realm provisioning and renders the G-IAM-08 mitigation (PR #133) unrollback-able. Regulatory: FCA SYSC 4.1.5; ADR-029 violation.

### Backup contract (proposed; ADR-029 alignment matrix in the policy doc)
- `pg_dump -Fc` → gpg AES256 symmetric → sha256 sidecar → off-host copy → local rotation 7 days.
- Daily 02:30 cron (off-peak; off the n8n window).
- Credential reuse: wrapper reads PGPASSWORD from `/etc/keycloak/db.password` (the file landed by IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12 / PR #133). Zero plaintext passwords in CLI args, env, cron, or any template.
- Off-host target: variant-driven (S3-compatible / rsync) — operator chooses at deploy time per ADR-029 §1 once finalised.
- Restore drill: monthly, sandbox-only, operator-witnessed sign-off.

### Files (8 / +648 / -0)
- `infra/keycloak/G-IAM-09-BACKUP-POLICY.md` — policy + ADR-029 alignment matrix (TODO markers for canon-pending values) + deploy procedure + restore-drill summary + rollback + HITL gate.
- `infra/keycloak/scripts/kc-backup.sh.template` — wrapper template with `{{KC_DB_*}}`, `{{BACKUP_DIR}}`, `{{ENCRYPTION_PASSPHRASE_FILE}}`, `{{OFFHOST_TARGET}}` placeholders. `set -euo pipefail`; documented exit codes; idempotent; off-host transport variants (S3 / rsync).
- `infra/keycloak/cron.d/kc-backup.cron.template` — daily 02:30 cron with `{{WRAPPER_PATH}}` + `{{LOG_PATH}}` placeholders; deploy-after-approval header.
- `infra/keycloak/OPERATOR-RUNBOOK-G-IAM-09-RESTORE-DRILL.md` — sandbox-only drill runbook (10 numbered steps) + validation checklist + operator sign-off block + explicit "does NOT perform a production restore" statement.
- `infra/keycloak/scripts/validate-g-iam-09-backup-prep.sh` — offline lint. Asserts file presence; wrapper uses `pg_dump -Fc` + password-file + sha256 + off-host + retention rotation + gpg AES256; wrapper carries NO plaintext `--db-password=<literal>` or shell-quoted `PGPASSWORD=`; cron uses both placeholders + deploy-after-approval header; policy carries G-IAM-09, ADR-029, evidence timestamp, HITL gate, Rollback, alignment matrix; runbook carries non-deploy statement + drill section + sign-off + validation checklist. Local run: **29/29 PASS**.
- `infra/keycloak/examples/backup.env.example` — env placeholders; no secrets.
- `infra/keycloak/examples/offhost-target.example` — off-host transport variants; no secrets.
- `INSTRUCTION-LEDGER.md` — appended `IL-OPS-S12-6-G-IAM-09-PREP-2026-05-12` (DONE; prep package only).

### Anchors
- G-IAM-09
- IL-OPS-S12-1-DONE-EVIDENCE-AND-NEW-GAPS-2026-05-12 (gap origin)
- IL-OPS-ROADMAP-SPRINTS-S12-S25-APPROVED-2026-05-11 (Sprint S12.6)
- IL-OPS-S12-5-G-IAM-08-PREP-2026-05-12 (credential-file sibling — PR #133, merged f37f866)
- ADR-029 (Postgres backup strategy — canonical lives in banxe-architecture)
- IL-CANON-TERMINAL-B-AUTONOMOUS-FIXATION-2026-05-12
- IL-CANON-EXPLICIT-TARGET-INSTRUCTION-2026-05-12

### ADR-029 alignment + TODOs
Values that aligned with canonical ADR-029 or with bank-side `services/backup/` code are concrete. Values not specified in ADR-029 are explicitly TODO with proposed defaults + rationale in the alignment matrix (frequency, retention, encryption scheme, off-host target). Operator substitutes at deploy time.

### Out of scope
- No production deploy. No `ssh evo1`. No `pg_dump` execution against the production DB. No `systemctl daemon-reload`. No service code under `services/**`. No docs under `docs/canon/**` or `docs/factory/**`. No `HITL-MATRIX.yaml`. No `MEMORY.md`. No `banxe-architecture` edits.
- ROADMAP.md left untouched: line 1945 mentions G-IAM-09 in a different sub-context (KC_DB Postgres migration target, not backup policy), and there is no Sprint S12.6 line in ROADMAP per prompt's "do not invent new roadmap structure" rule.

### HITL gate
Production deploy of the backup policy AND the first restore drill require explicit Central + operator approval, recorded against IL-OPS-S12-6-G-IAM-09-PREP-2026-05-12. The HITL artefacts are the operator sign-off blocks in the policy + restore-drill runbook.

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Keycloak database backup and restore drill functionality
  * Enabled daily automated backups with configurable retention and off-host storage support (S3, rsync, SSH/SCP)

* **Documentation**
  * Added backup policy and operator runbook for restore procedures
  * Included example configurations for backup wrapper and off-host targets

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CarmiBanxe/banxe-emi-stack/pull/134)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->