### PR TITLE
feat(s16-5): G-CI-02 branch-protection enforcement prep package

### DIFF
--- a/.github/protection-update-v2.json
+++ b/.github/protection-update-v2.json
@@ -1,0 +1,22 @@
+{
+  "_comment_anchors": "S16.5 G-CI-02 prep — extends ADR-035 Step 3 baseline (.github/protection-update.json: 3 checks) to cover all current CI gates. The two `guardian-*` contexts are externally provided GitHub App checks (app_id 15368 in live state on 2026-05-12); they are preserved here so this PUT body does not weaken protection. All other contexts map to a job name in .github/workflows/*.yml. Verified by scripts/validate-g-ci-02-prep.sh.",
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      { "context": "guardian-factory" },
+      { "context": "guardian-project" },
+      { "context": "Smoke Gate (mock tier)" },
+      { "context": "Smoke Gate (real stack)" },
+      { "context": "Gitleaks - Secrets Scan" },
+      { "context": "Ruff lint + format" },
+      { "context": "Biome lint + format (Frontend)" },
+      { "context": "Pytest (coverage >= 80%)" },
+      { "context": "Semgrep (banxe-rules)" },
+      { "context": "Vitest (frontend)" },
+      { "context": "Alembic — schema drift check" }
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}

--- a/docs/runbooks/branch-protection-g-ci-02-deploy-2026-05-12.md
+++ b/docs/runbooks/branch-protection-g-ci-02-deploy-2026-05-12.md
@@ -1,0 +1,157 @@
+# Operator runbook — S16.5 G-CI-02 branch-protection activation
+
+Owner sprint: S16.5.
+Anchors: ADR-035 G-CI-02; ADR-035 Step 3 baseline (`.github/protection-update.json`);
+S16.5 PREP package files (`.github/protection-update-v2.json`,
+`scripts/validate-g-ci-02-prep.sh`, this runbook).
+Status: PREP (this PR delivers the package only; **no remote API mutation here**).
+
+---
+
+## Purpose
+
+Switch branch protection on `main` of `CarmiBanxe/banxe-emi-stack` to require
+all currently-mandatory CI gates as `required_status_checks`. Today's
+protection state requires only 3 of those gates (the baseline shipped by
+ADR-035 Step 3); the v2 manifest in this package adds 8 more discovered in
+`.github/workflows/*.yml`.
+
+## Non-goal
+
+**This PR does NOT mutate the live protection state.** All artefacts are
+inert until an operator with `admin` on the repository runs the activation
+command in §3 below, gated by §6 HITL. Sub-B is single-writer-restricted
+per §71 of project canon and cannot execute this change.
+
+## 1. Pre-flight (operator on a developer host)
+
+1. Confirm working directory at the repo root with the v2 manifest:
+   `ls .github/protection-update-v2.json`.
+2. Run the offline validator and confirm `Summary: N PASS / 0 FAIL`:
+   ```sh
+   bash scripts/validate-g-ci-02-prep.sh
+   ```
+3. Snapshot the current protection state for rollback:
+   ```sh
+   gh api repos/CarmiBanxe/banxe-emi-stack/branches/main/protection \
+       > /tmp/protection-snapshot-$(date -u +%Y%m%dT%H%M%SZ).json
+   ```
+4. Inspect the snapshot — verify the `required_status_checks.contexts`
+   array matches the documented baseline (3 entries on 2026-05-12).
+5. Confirm GitHub App `guardian-*` checks are present in the snapshot
+   (these are externally provided and preserved by the v2 manifest).
+6. Verify the operator's GitHub session has the `admin:repo` scope:
+   `gh auth status`.
+
+## 2. Required status checks in v2
+
+The 11 contexts in `.github/protection-update-v2.json` are:
+
+| Context                              | Source                                | Status        |
+|--------------------------------------|---------------------------------------|---------------|
+| `guardian-factory`                   | external GitHub App                   | preserved     |
+| `guardian-project`                   | external GitHub App                   | preserved     |
+| `Smoke Gate (mock tier)`             | `.github/workflows/smoke-gate-mock.yml` | preserved   |
+| `Smoke Gate (real stack)`            | `.github/workflows/smoke-gate-full.yml` | new (S16.5) |
+| `Gitleaks - Secrets Scan`            | `.github/workflows/quality-gate.yml`  | new (S16.5)   |
+| `Ruff lint + format`                 | `.github/workflows/quality-gate.yml`  | new (S16.5)   |
+| `Biome lint + format (Frontend)`     | `.github/workflows/quality-gate.yml`  | new (S16.5)   |
+| `Pytest (coverage >= 80%)`           | `.github/workflows/quality-gate.yml`  | new (S16.5)   |
+| `Semgrep (banxe-rules)`              | `.github/workflows/quality-gate.yml`  | new (S16.5)   |
+| `Vitest (frontend)`                  | `.github/workflows/quality-gate.yml`  | new (S16.5)   |
+| `Alembic — schema drift check`       | `.github/workflows/alembic-check.yml` | new (S16.5)   |
+
+All other protection toggles preserve the current live state: `strict=true`,
+`enforce_admins=false`, `required_pull_request_reviews=null`,
+`restrictions=null`.
+
+## 3. Activation (operator-only, gated by §6 HITL)
+
+Run from the repo root after §1 pre-flight passes:
+
+```sh
+gh api -X PUT repos/CarmiBanxe/banxe-emi-stack/branches/main/protection \
+    --input .github/protection-update-v2.json
+```
+
+`gh api` will refuse if the operator lacks `admin:repo`. On success, GitHub
+returns the new protection state. Capture the response for the audit trail:
+
+```sh
+gh api -X PUT repos/CarmiBanxe/banxe-emi-stack/branches/main/protection \
+    --input .github/protection-update-v2.json \
+    > /tmp/protection-after-$(date -u +%Y%m%dT%H%M%SZ).json
+```
+
+## 4. Post-flight verification
+
+1. Re-read protection and confirm the 11-context list:
+   ```sh
+   gh api repos/CarmiBanxe/banxe-emi-stack/branches/main/protection \
+       | jq -r '.required_status_checks.checks[].context'
+   ```
+2. Open a dry-run PR from a branch that intentionally fails one of the new
+   gates (e.g. a deliberate lint violation). Verify the PR is `blocked`
+   in the GitHub UI and that the failing check appears under
+   `Required` in the status panel.
+3. Close the dry-run PR without merging.
+4. Record the dry-run PR number + outcome in the operator-side ledger
+   against this runbook.
+
+## 5. Rollback
+
+If §4 reveals an unintended consequence (e.g. a previously-optional check
+is now blocking legitimate work, or a gate name was misspelled), roll back
+in this exact order:
+
+1. Re-apply the snapshot captured in §1 step 3:
+   ```sh
+   gh api -X PUT repos/CarmiBanxe/banxe-emi-stack/branches/main/protection \
+       --input /tmp/protection-snapshot-<TIMESTAMP>.json
+   ```
+2. Verify the rollback took effect:
+   ```sh
+   gh api repos/CarmiBanxe/banxe-emi-stack/branches/main/protection \
+       | jq -r '.required_status_checks.checks[].context'
+   ```
+3. Confirm the dry-run PR is no longer `blocked` for the previously-new
+   reasons (close it once verified).
+4. File a follow-up task: name the specific contexts that misbehaved, and
+   propose a v3 manifest that excludes them OR fixes the underlying CI
+   issue first.
+
+## 6. HITL gate
+
+This activation requires:
+
+- **Central approval** — confirms the v2 manifest matches the discovered
+  CI surface AND that none of the listed gates is flapping today.
+- **Operator approval** — confirms there is no in-flight merge train that
+  would be blocked unexpectedly by the new gates within the next 24 h.
+
+Both approvals are recorded against this runbook in the operator-side
+sign-off ledger before the §3 activation command is executed.
+
+## 7. Operator sign-off block
+
+```
+Activation date     : __________________________
+Executor            : __________________________
+Central             : __________________________ (approval)
+Operator            : __________________________ (approval)
+Snapshot file       : /tmp/protection-snapshot-_________________.json
+Activation response : /tmp/protection-after-______________________.json
+Dry-run PR          : #_____ (result: BLOCKED as expected / UNEXPECTED)
+Outcome             : [ ] PASS    [ ] FAIL    [ ] ROLLBACK
+Rollback notes      :
+
+
+```
+
+## 8. References
+
+- `.github/protection-update.json` — ADR-035 Step 3 baseline (3 contexts).
+- `.github/protection-update-v2.json` — S16.5 G-CI-02 v2 (11 contexts).
+- `scripts/validate-g-ci-02-prep.sh` — offline validator.
+- `tests/unit/ci/test_g_ci_02_prep.py` — unit tests of the prep contract.
+- `.github/ADR-035-STEP-3-OPERATOR.md` — earlier ADR-035 operator note.

--- a/scripts/validate-g-ci-02-prep.sh
+++ b/scripts/validate-g-ci-02-prep.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# validate-g-ci-02-prep.sh — offline validator for the S16.5 G-CI-02 prep
+# package. NO network mutation. NO call to GitHub. Pure-local lint of:
+#   - .github/protection-update-v2.json (well-formed + schema invariants)
+#   - cross-reference: every context exists in .github/workflows/*.yml OR
+#     is on the known-external allowlist (guardian-* GitHub App checks)
+#
+# Anchors:
+#   S16.5; ADR-035 G-CI-02 prep; ADR-035 Step 3 baseline.
+#
+# Exit codes:
+#   0  all checks PASS
+#   1  at least one check FAIL
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PROTECTION_JSON="${ROOT_DIR}/.github/protection-update-v2.json"
+WORKFLOWS_DIR="${ROOT_DIR}/.github/workflows"
+RUNBOOK="${ROOT_DIR}/docs/runbooks/branch-protection-g-ci-02-deploy-2026-05-12.md"
+
+# Externally-provided checks (GitHub App, not in our YAML).
+KNOWN_EXTERNAL=(
+  "guardian-factory"
+  "guardian-project"
+)
+
+pass=0
+fail=0
+
+ok()    { echo "  [PASS] $*"; pass=$((pass + 1)); }
+bad()   { echo "  [FAIL] $*"; fail=$((fail + 1)); }
+check() { local label=$1; shift; if "$@"; then ok "$label"; else bad "$label"; fi }
+
+exists() { [[ -f "$1" ]]; }
+json_valid() { jq empty "$1" >/dev/null 2>&1; }
+json_eq() { local file=$1 path=$2 want=$3; [[ "$(jq -r "$path" "$file")" == "$want" ]]; }
+json_jq_truthy() { local file=$1 expr=$2; [[ "$(jq -r "$expr" "$file")" == "true" ]]; }
+json_jq_count_ge() { local file=$1 expr=$2 min=$3; [[ "$(jq -r "$expr" "$file")" -ge "$min" ]]; }
+contains_check_context() {
+    local file=$1 want=$2
+    jq -e --arg w "$want" '.required_status_checks.checks[].context | select(. == $w)' "$file" >/dev/null 2>&1
+}
+is_in_external_allowlist() {
+    local want=$1
+    for e in "${KNOWN_EXTERNAL[@]}"; do
+        [[ "$e" == "$want" ]] && return 0
+    done
+    return 1
+}
+context_in_some_workflow() {
+    local want=$1
+    grep -RF "name: $want" "${WORKFLOWS_DIR}" >/dev/null 2>&1
+}
+
+echo "S16.5 G-CI-02 prep offline validation"
+echo "----------------------------------------"
+
+echo "[1] File presence"
+check "protection-update-v2.json present"  exists "$PROTECTION_JSON"
+check "runbook present"                    exists "$RUNBOOK"
+
+echo "[2] JSON well-formedness"
+check "protection-update-v2.json parses as JSON"  json_valid "$PROTECTION_JSON"
+
+echo "[3] Schema invariants"
+check "strict == true" \
+    json_eq "$PROTECTION_JSON" '.required_status_checks.strict' "true"
+check "enforce_admins == false" \
+    json_eq "$PROTECTION_JSON" '.enforce_admins' "false"
+check "required_pull_request_reviews preserved as null" \
+    json_eq "$PROTECTION_JSON" '.required_pull_request_reviews' "null"
+check "restrictions preserved as null" \
+    json_eq "$PROTECTION_JSON" '.restrictions' "null"
+check "checks array length >= 9 (3 baseline + at least 6 new gates)" \
+    json_jq_count_ge "$PROTECTION_JSON" '.required_status_checks.checks | length' 9
+
+echo "[4] Baseline preservation (ADR-035 Step 3)"
+check "Smoke Gate (mock tier) preserved" \
+    contains_check_context "$PROTECTION_JSON" "Smoke Gate (mock tier)"
+check "guardian-factory preserved (external)" \
+    contains_check_context "$PROTECTION_JSON" "guardian-factory"
+check "guardian-project preserved (external)" \
+    contains_check_context "$PROTECTION_JSON" "guardian-project"
+
+echo "[5] G-CI-02 newly-required gates present"
+check "Smoke Gate (real stack) listed" \
+    contains_check_context "$PROTECTION_JSON" "Smoke Gate (real stack)"
+check "Pytest (coverage >= 80%) listed" \
+    contains_check_context "$PROTECTION_JSON" "Pytest (coverage >= 80%)"
+check "Ruff lint + format listed" \
+    contains_check_context "$PROTECTION_JSON" "Ruff lint + format"
+check "Semgrep (banxe-rules) listed" \
+    contains_check_context "$PROTECTION_JSON" "Semgrep (banxe-rules)"
+check "Gitleaks - Secrets Scan listed" \
+    contains_check_context "$PROTECTION_JSON" "Gitleaks - Secrets Scan"
+check "Biome lint + format (Frontend) listed" \
+    contains_check_context "$PROTECTION_JSON" "Biome lint + format (Frontend)"
+check "Vitest (frontend) listed" \
+    contains_check_context "$PROTECTION_JSON" "Vitest (frontend)"
+check "Alembic — schema drift check listed" \
+    contains_check_context "$PROTECTION_JSON" "Alembic — schema drift check"
+
+echo "[6] Cross-reference: each context exists in workflows or external allowlist"
+fail_xref=0
+while IFS= read -r ctx; do
+    if context_in_some_workflow "$ctx"; then
+        ok "context resolved in workflows: ${ctx}"
+    elif is_in_external_allowlist "$ctx"; then
+        ok "context on known-external allowlist: ${ctx}"
+    else
+        bad "context not found in workflows or external allowlist: ${ctx}"
+        fail_xref=$((fail_xref + 1))
+    fi
+done < <(jq -r '.required_status_checks.checks[].context' "$PROTECTION_JSON")
+
+echo "[7] Schema-guard: no unexpected top-level keys"
+unexpected="$(jq -r '
+    [keys[]
+     | select(. != "_comment_anchors"
+              and . != "required_status_checks"
+              and . != "enforce_admins"
+              and . != "required_pull_request_reviews"
+              and . != "restrictions")]
+    | join(",")
+' "$PROTECTION_JSON")"
+check "no unexpected top-level keys (got: '${unexpected:-none}')" \
+    test -z "$unexpected"
+
+echo "----------------------------------------"
+echo "Summary: ${pass} PASS / ${fail} FAIL"
+
+if [[ "$fail" -gt 0 ]]; then
+    exit 1
+fi

--- a/tests/unit/ci/test_g_ci_02_prep.py
+++ b/tests/unit/ci/test_g_ci_02_prep.py
@@ -1,0 +1,136 @@
+"""Unit tests for the S16.5 G-CI-02 prep package.
+
+Validates the protection-update-v2.json manifest's schema invariants and
+cross-references each required context against the workflows that actually
+declare it. No network calls; no GitHub API access.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROTECTION_JSON = REPO_ROOT / ".github" / "protection-update-v2.json"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+# Externally-provided checks (GitHub App, not in workflow YAML).
+KNOWN_EXTERNAL: set[str] = {"guardian-factory", "guardian-project"}
+
+EXPECTED_TOP_LEVEL_KEYS: set[str] = {
+    "_comment_anchors",
+    "required_status_checks",
+    "enforce_admins",
+    "required_pull_request_reviews",
+    "restrictions",
+}
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return json.loads(PROTECTION_JSON.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def workflow_contents() -> str:
+    chunks: list[str] = []
+    for yml in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        chunks.append(yml.read_text(encoding="utf-8"))
+    return "\n".join(chunks)
+
+
+def test_protection_update_v2_json_is_valid_json() -> None:
+    json.loads(PROTECTION_JSON.read_text(encoding="utf-8"))
+
+
+def test_protection_update_v2_strict_true(manifest: dict) -> None:
+    assert manifest["required_status_checks"]["strict"] is True
+
+
+def test_protection_update_v2_enforce_admins_false(manifest: dict) -> None:
+    assert manifest["enforce_admins"] is False
+
+
+def test_protection_update_v2_pull_request_reviews_preserved_null(
+    manifest: dict,
+) -> None:
+    """ADR-035 Step 3 baseline left this null; preserve to avoid widening
+    the attack surface."""
+    assert manifest["required_pull_request_reviews"] is None
+    assert manifest["restrictions"] is None
+
+
+def test_protection_update_v2_required_checks_minimum_count(manifest: dict) -> None:
+    checks = manifest["required_status_checks"]["checks"]
+    assert len(checks) >= 8, f"expected >= 8 required checks, got {len(checks)}"
+
+
+def test_protection_update_v2_no_unexpected_keys(manifest: dict) -> None:
+    """Schema guard — every top-level key is one of the expected protection
+    fields (or the documented `_comment_anchors`)."""
+    unexpected = set(manifest.keys()) - EXPECTED_TOP_LEVEL_KEYS
+    assert unexpected == set(), f"unexpected top-level keys: {unexpected}"
+
+
+def test_protection_update_v2_required_checks_all_exist_in_workflows(
+    manifest: dict, workflow_contents: str
+) -> None:
+    """Every check context must either appear as a `name: <ctx>` line in
+    some workflow YAML or be on the known-external allowlist."""
+    missing: list[str] = []
+    for check in manifest["required_status_checks"]["checks"]:
+        ctx = check["context"]
+        if ctx in KNOWN_EXTERNAL:
+            continue
+        marker = f"name: {ctx}"
+        if marker not in workflow_contents:
+            missing.append(ctx)
+    assert missing == [], f"contexts not found in any workflow YAML: {missing}"
+
+
+def test_protection_update_v2_baseline_preserved(manifest: dict) -> None:
+    """ADR-035 Step 3 baseline contexts must remain — removing any would
+    weaken protection."""
+    listed = {c["context"] for c in manifest["required_status_checks"]["checks"]}
+    for baseline in (
+        "guardian-factory",
+        "guardian-project",
+        "Smoke Gate (mock tier)",
+    ):
+        assert baseline in listed, f"baseline context dropped: {baseline}"
+
+
+def test_protection_update_v2_g_ci_02_new_gates_present(manifest: dict) -> None:
+    """S16.5 G-CI-02 newly-required gates."""
+    listed = {c["context"] for c in manifest["required_status_checks"]["checks"]}
+    for new_gate in (
+        "Smoke Gate (real stack)",
+        "Pytest (coverage >= 80%)",
+        "Ruff lint + format",
+        "Semgrep (banxe-rules)",
+        "Gitleaks - Secrets Scan",
+        "Biome lint + format (Frontend)",
+        "Vitest (frontend)",
+        "Alembic — schema drift check",
+    ):
+        assert new_gate in listed, f"G-CI-02 gate missing: {new_gate}"
+
+
+def test_protection_update_v2_check_entries_well_shaped(manifest: dict) -> None:
+    """Every check entry is an object with a single `context` key."""
+    for entry in manifest["required_status_checks"]["checks"]:
+        assert isinstance(entry, dict), f"non-object check entry: {entry!r}"
+        assert "context" in entry, f"missing 'context' in check entry: {entry!r}"
+        assert isinstance(entry["context"], str), f"non-string context: {entry!r}"
+        assert entry["context"], "empty context string"
+
+
+def test_protection_update_v2_check_contexts_unique(manifest: dict) -> None:
+    """Duplicate contexts in the PUT body are silently deduplicated by
+    GitHub but indicate a manifest bug."""
+    contexts = [c["context"] for c in manifest["required_status_checks"]["checks"]]
+    assert len(contexts) == len(set(contexts)), (
+        f"duplicate contexts: {sorted(c for c in contexts if contexts.count(c) > 1)}"
+    )


### PR DESCRIPTION
## S16.5 G-CI-02 — Branch-protection enforcement prep

### What
HITL-gated prep package extending ADR-035 Step 3 baseline. Adds 8 newly-required CI gates to required_status_checks on main, preserving the 3 existing baseline contexts. **NO PRODUCTION DEPLOY**: Sub-B is single-writer-restricted per §71; activation is operator HITL action.

### Files (5 / +450 / -0)
- `.github/protection-update-v2.json` — PUT body extending required_status_checks to 11 contexts
- `scripts/validate-g-ci-02-prep.sh` — offline validator (no network mutation)
- `docs/runbooks/branch-protection-g-ci-02-deploy-2026-05-12.md` — HITL operator runbook
- `tests/unit/ci/__init__.py` — new test sub-package marker
- `tests/unit/ci/test_g_ci_02_prep.py` — schema + cross-reference guards (11 tests)

### Live protection state (read-only diagnostic)
Currently 3 required contexts on main: `guardian-factory`, `guardian-project` (external GitHub App, app_id=15368), `Smoke Gate (mock tier)`. strict=true, enforce_admins=false, required_pull_request_reviews=null, restrictions=null. v2 preserves all four toggles and extends contexts array to 11.

### v2 contexts (11 total)
Baseline preserved (3):
- guardian-factory (external GitHub App)
- guardian-project (external GitHub App)
- Smoke Gate (mock tier)

Newly required (8, discovered in .github/workflows/*.yml):
- Smoke Gate (real stack)
- Pytest (coverage >= 80%)
- Ruff lint + format
- Semgrep (banxe-rules)
- Gitleaks - Secrets Scan
- Biome lint + format (Frontend)
- Vitest (frontend)
- Alembic — schema drift check

No invented contexts. Each new entry verified by `grep -F "name: tx>"` against workflow YAMLs by the validator.

### External allowlist
Two guardian-* contexts documented as "GitHub App, not in workflow YAML" in both validator (KNOWN_EXTERNAL array) and runbook (table); preserved to avoid weakening protection.

### Known caveat (not blocking v2)
Naming-collision: `Ruff lint + format`, `Biome`, `Vitest` jobs appear in BOTH quality-gate.yml AND dedicated lint-python.yml / lint-frontend.yml workflows with overlapping/identical name: values. v2 lists quality-gate.yml canonical names; dedicated-workflow jobs run anyway (same check-run name in GitHub UI). If Central wants distinct names per workflow, that is a CI-design follow-up, not a v2 blocker.

### Validator quirk fixed
Initial `jq -e empty "$1"` flagged valid JSON as invalid (empty filter produces no output, -e treats no-output as failure). Corrected to `jq empty "$1"` (no -e). 31/31 PASS.

### Tests
- bash scripts/validate-g-ci-02-prep.sh: 31/31 PASS
- pytest tests/unit/ci/ -q --no-cov: 11 PASS / 0 FAIL
- Full pre-commit hook chain: PASS (Auditor, ruff lint+format, bandit, IAM guard, semgrep, full pytest)

### Activation (HITL — operator zone, NOT Sub-B)
Per `docs/runbooks/branch-protection-g-ci-02-deploy-2026-05-12.md`:
1. Pre-flight: `gh api GET .../branches/main/protection > pre-state-snapshot.json`
2. Activate: `gh api PUT --input .github/protection-update-v2.json .../branches/main/protection`
3. Post-flight: re-read protection; dry-run draft PR with failing check; confirm merge blocked
4. Rollback: `gh api PUT --input pre-state-snapshot.json`

### Out of scope (Central / §74)
- INSTRUCTION-LEDGER / MEMORY.md sync (IL-CANON-DOCUMENTATION-OWNED-BY-CENTRAL-2026-05-12)
- Actual branch-protection mutation (operator HITL)
- CI-design follow-up on naming-collision

### Operator merge
gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated main branch protection configuration to enforce additional required CI status checks, including smoke tests, security scanning, linting, code formatting, and database schema validation.
  * Added validation tooling and comprehensive unit tests to ensure branch protection configuration correctness and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CarmiBanxe/banxe-emi-stack/pull/136)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->