### PR TITLE
feat(s16-7): real GitHub-API protection reader adapter (read-only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,3 +139,17 @@ SECRET_ROTATION_INTERVAL_DAYS=90
 # Comma-separated list of env var names to manage
 SECRET_ROTATION_MANAGED_KEYS=KC_BOOT_ADMIN_PASSWORD,KC_DB_PASSWORD,AUTH_SECRET_KEY
 SECRET_ROTATION_ENV_FILE=.env
+
+# === CI governance drift sentry (S16.6 + S16.7) ===
+# Read-only branch-protection monitor for main. Real-API adapter calls
+# GET /repos/{owner}/{repo}/branches/{branch}/protection — no mutation.
+#
+# Token resolution order: CI_GOVERNANCE_GH_TOKEN → GH_TOKEN → GITHUB_TOKEN.
+# Recommended PAT scope: repo:status (or public_repo for public repos).
+CI_GOVERNANCE_GH_TOKEN=
+CI_GOVERNANCE_REPO_OWNER=CarmiBanxe
+CI_GOVERNANCE_REPO_NAME=banxe-emi-stack
+CI_GOVERNANCE_BRANCH=main
+# Reader selector: "in_memory" (S16.6 default) | "gh_api" (force real) |
+# "auto" (real if any token env present, else in_memory).
+CI_GOVERNANCE_READER_MODE=auto

--- a/scripts/ci-protection-drift-check.py
+++ b/scripts/ci-protection-drift-check.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-ci-protection-drift-check.py — S16.6 CI governance drift sentry CLI.
+ci-protection-drift-check.py — CI governance drift sentry CLI
+(S16.6 baseline + S16.7 real-API reader).
 
 Compares the live branch-protection state on `main` against the S16.5
 baseline (`.github/protection-update-v2.json` by default) and reports any
@@ -11,9 +12,10 @@ Modes
 - `--dry-run-payload <path>` : load the payload from a JSON file (operator
   captured it earlier via `gh api .../branches/main/protection`). Pure
   offline — no network access.
-- (default)                  : real GitHub-API reader. **NOT WIRED YET** in
-  S16.6. CLI prints the diagnostic and exits 2 (cron-safe). Wiring requires
-  GH_TOKEN / PAT plumbing and lands in a follow-up step.
+- (default)                  : real GitHub-API reader if any of
+  CI_GOVERNANCE_GH_TOKEN / GH_TOKEN / GITHUB_TOKEN env vars is set.
+  Otherwise exits 2 (cron-safe). Real adapter is read-only —
+  GET /repos/{owner}/{repo}/branches/{branch}/protection — no mutation.
 
 Flags
 -----
@@ -22,6 +24,11 @@ Flags
 - `--emit-alert`             : when drift is detected, route an alert via
                                 the ADR-033 AlertRoutingPort. Off by
                                 default (cron-safe dry runs).
+- `--force-real-api`         : force the real GitHub-API reader even when
+                                --dry-run-payload is supplied. Useful for
+                                operator-driven validation runs that must
+                                hit the live state, ignoring any local
+                                payload snapshot.
 
 Exit codes
 ----------
@@ -65,36 +72,65 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--dry-run-payload",
         default=None,
         help="path to a JSON file containing a captured GitHub-API payload "
-        "(offline mode; bypasses the real-API reader)",
+        "(offline mode; bypasses the real-API reader unless --force-real-api)",
     )
     p.add_argument(
         "--emit-alert",
         action="store_true",
         help="route a drift alert via the ADR-033 AlertRoutingPort on drift",
     )
+    p.add_argument(
+        "--force-real-api",
+        action="store_true",
+        help="force the real GitHub-API reader (overrides --dry-run-payload)",
+    )
     return p
+
+
+def _load_payload_reader(path: str):
+    """Build an InMemoryProtectionReader from a captured JSON payload file."""
+    from services.ci_governance.in_memory_protection_reader import (
+        InMemoryProtectionReader,
+    )
+
+    payload_text = Path(path).read_text(encoding="utf-8")
+    payload = json.loads(payload_text)
+    return InMemoryProtectionReader(payload)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_arg_parser().parse_args(argv)
 
-    # Resolve the reader.
-    if args.dry_run_payload:
-        from services.ci_governance.in_memory_protection_reader import (
-            InMemoryProtectionReader,
-        )
+    from services.ci_governance.factory import (
+        get_real_gh_protection_reader,
+        resolve_gh_token,
+    )
 
-        payload_text = Path(args.dry_run_payload).read_text(encoding="utf-8")
+    # Reader-selection precedence:
+    #   1. --force-real-api  → real-API reader, ignore --dry-run-payload
+    #   2. --dry-run-payload → in-memory reader from the captured JSON
+    #   3. any token env present → real-API reader (auto)
+    #   4. otherwise → exit 2 (cron-safe)
+    if args.force_real_api:
+        if resolve_gh_token() is None:
+            logger.error(
+                "--force-real-api set but no token env (CI_GOVERNANCE_GH_TOKEN / "
+                "GH_TOKEN / GITHUB_TOKEN) is present"
+            )
+            return 2
+        reader = get_real_gh_protection_reader()
+    elif args.dry_run_payload:
         try:
-            payload = json.loads(payload_text)
+            reader = _load_payload_reader(args.dry_run_payload)
         except json.JSONDecodeError as exc:
             logger.error("dry-run-payload not valid JSON: %s", exc)
             return 2
-        reader = InMemoryProtectionReader(payload)
+    elif resolve_gh_token() is not None:
+        reader = get_real_gh_protection_reader()
     else:
         logger.error(
-            "real-API reader not wired yet (S16.6 deferred to follow-up); "
-            "re-invoke with --dry-run-payload <captured-gh-api.json>"
+            "no reader wired: supply --dry-run-payload <captured-gh-api.json> "
+            "OR set CI_GOVERNANCE_GH_TOKEN / GH_TOKEN / GITHUB_TOKEN in env"
         )
         return 2
 

--- a/services/ci_governance/factory.py
+++ b/services/ci_governance/factory.py
@@ -25,22 +25,75 @@ constructor parameter, while the factory uses the real function name.
 from __future__ import annotations
 
 from functools import lru_cache
+import os
 import time
 
 from services.ci_governance.drift_alert_emitter import DriftAlertEmitter
 from services.ci_governance.drift_detector import DriftDetector
+from services.ci_governance.gh_api_protection_reader import (
+    GitHubApiProtectionReader,
+)
 from services.ci_governance.in_memory_protection_reader import (
     InMemoryProtectionReader,
 )
+from services.ci_governance.protection_reader_port import (
+    GitHubProtectionReaderPort,
+)
 
 _DEFAULT_BASELINE_PATH = ".github/protection-update-v2.json"
+_TOKEN_ENV_PRIORITY: tuple[str, ...] = (
+    "CI_GOVERNANCE_GH_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+)
+
+
+def resolve_gh_token() -> str | None:
+    """Token resolution order: CI_GOVERNANCE_GH_TOKEN → GH_TOKEN → GITHUB_TOKEN.
+
+    Returns the first non-empty value, or None if none are set. Public so
+    tests can exercise the priority order directly.
+    """
+    for key in _TOKEN_ENV_PRIORITY:
+        val = os.environ.get(key)
+        if val:
+            return val
+    return None
 
 
 @lru_cache(maxsize=1)
-def get_protection_reader() -> InMemoryProtectionReader:
-    """Default singleton — an empty InMemoryProtectionReader. The CLI
-    overrides this with a payload-supplied reader at runtime; tests
-    construct readers directly with their fixture data."""
+def get_real_gh_protection_reader() -> GitHubApiProtectionReader:
+    """Singleton real-API reader, wired from CI_GOVERNANCE_* env.
+
+    The token itself is NOT cached on the adapter — token_provider is
+    `resolve_gh_token` so rotated tokens are picked up at read time.
+    """
+    return GitHubApiProtectionReader(
+        owner=os.environ.get("CI_GOVERNANCE_REPO_OWNER", "CarmiBanxe"),
+        repo=os.environ.get("CI_GOVERNANCE_REPO_NAME", "banxe-emi-stack"),
+        branch=os.environ.get("CI_GOVERNANCE_BRANCH", "main"),
+        token_provider=resolve_gh_token,
+    )
+
+
+@lru_cache(maxsize=1)
+def get_protection_reader() -> GitHubProtectionReaderPort:
+    """Env-driven reader selection (S16.7 extension of S16.6 default).
+
+    CI_GOVERNANCE_READER_MODE ∈ {"in_memory", "gh_api", "auto"}:
+      - "in_memory" (or absent) → InMemoryProtectionReader({}) — S16.6 default
+      - "gh_api"                → GitHubApiProtectionReader (real, read-only)
+      - "auto"                  → gh_api if any CI_GOVERNANCE_* / GH_TOKEN /
+                                  GITHUB_TOKEN env present, else in_memory
+    """
+    mode = os.environ.get("CI_GOVERNANCE_READER_MODE", "in_memory").strip().lower()
+    if mode == "gh_api":
+        return get_real_gh_protection_reader()
+    if mode == "auto":
+        if resolve_gh_token() is not None:
+            return get_real_gh_protection_reader()
+        return InMemoryProtectionReader({})
+    # "in_memory" and any unrecognised value fall back to S16.6 default
     return InMemoryProtectionReader({})
 
 

--- a/services/ci_governance/gh_api_protection_reader.py
+++ b/services/ci_governance/gh_api_protection_reader.py
@@ -1,0 +1,113 @@
+"""
+gh_api_protection_reader.py — Real GitHub-API read-only adapter for the
+S16.6 GitHubProtectionReaderPort (S16.7).
+
+Implements `read_main_protection` against:
+
+    GET https://api.github.com/repos/{owner}/{repo}/branches/{branch}/protection
+
+NO mutation. NO PUT / PATCH / DELETE / POST calls. NO `urllib.request`
+opener-installer. The adapter only ever passes `method="GET"` into the
+injected `http_client`; the default `http_client` itself refuses any
+other method.
+
+I/O is routed through an injected callable so unit tests can supply a
+FakeHttpClient that captures (url, headers, method) tuples and returns
+programmed (status, body) without touching the network.
+
+Token handling: the adapter accepts a `token_provider` callable. It is
+invoked on EVERY read (no token caching at the adapter level). This lets
+the factory wire env-driven resolution without the adapter holding stale
+credentials in memory across rotations.
+
+No new dependency: uses `urllib.request` from the stdlib. (`httpx` is in
+requirements.txt but not needed here — read-only single-request flow.)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+from typing import TYPE_CHECKING
+import urllib.error
+import urllib.request
+
+if TYPE_CHECKING:
+    from services.ci_governance.protection_reader_port import (
+        GitHubProtectionReaderPort,  # noqa: F401
+    )
+
+
+HttpClient = Callable[[str, dict[str, str], str], tuple[int, bytes]]
+TokenProvider = Callable[[], "str | None"]
+
+_USER_AGENT = "banxe-ci-governance/1.0"
+_ACCEPT = "application/vnd.github.v3+json"
+
+
+def _default_http_client(url: str, headers: dict[str, str], method: str) -> tuple[int, bytes]:
+    """Stdlib default http_client. Refuses non-GET methods at this seam too —
+    defence in depth so a future code change cannot escalate the adapter
+    into a mutator without the type-checker AND this guard both fighting back.
+    """
+    if method != "GET":
+        raise RuntimeError(
+            f"GitHubApiProtectionReader default http_client is read-only; "
+            f"refusing method={method!r}"
+        )
+    # B310 spirit: only allow https:// to prevent file:/ftp: scheme-shenanigans
+    # even though the adapter always constructs `https://api.github.com/...`
+    # itself; this guards against future code paths or test injections.
+    if not url.startswith("https://"):
+        raise RuntimeError(
+            f"GitHubApiProtectionReader default http_client refuses non-https URL: {url!r}"
+        )
+    req = urllib.request.Request(url, headers=headers, method="GET")  # noqa: S310
+    try:
+        with urllib.request.urlopen(req) as resp:  # noqa: S310  # nosec B310 — https scheme guard above
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+class GitHubApiProtectionReader:
+    """Read-only adapter for branch-protection state on GitHub."""
+
+    def __init__(
+        self,
+        owner: str,
+        repo: str,
+        token_provider: TokenProvider,
+        branch: str = "main",
+        http_client: HttpClient | None = None,
+    ) -> None:
+        self._owner = owner
+        self._repo = repo
+        self._branch = branch
+        self._token_provider = token_provider
+        self._http_client: HttpClient = http_client or _default_http_client
+
+    def read_main_protection(self) -> dict:
+        token = self._token_provider()
+        if not token:
+            raise RuntimeError(
+                "GitHubApiProtectionReader: no token returned by token_provider; "
+                "set CI_GOVERNANCE_GH_TOKEN / GH_TOKEN / GITHUB_TOKEN in env"
+            )
+
+        url = (
+            f"https://api.github.com/repos/{self._owner}/{self._repo}"
+            f"/branches/{self._branch}/protection"
+        )
+        headers = {
+            "Authorization": f"token {token}",
+            "Accept": _ACCEPT,
+            "User-Agent": _USER_AGENT,
+        }
+        status, body = self._http_client(url, headers, "GET")
+        if status == 200:
+            return json.loads(body.decode("utf-8"))
+        body_preview = body[:200].decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"GitHubApiProtectionReader: HTTP {status} from GET {url}; body={body_preview!r}"
+        )

--- a/tests/unit/ci_governance/test_drift_check_script_real_api.py
+++ b/tests/unit/ci_governance/test_drift_check_script_real_api.py
@@ -1,0 +1,181 @@
+"""CLI script extension tests for S16.7 — real-API path."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from services.ci_governance.factory import (
+    get_protection_reader,
+    get_real_gh_protection_reader,
+)
+from services.ci_governance.gh_api_protection_reader import (
+    GitHubApiProtectionReader,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "ci-protection-drift-check.py"
+
+_BASELINE = {
+    "required_status_checks": {
+        "strict": True,
+        "checks": [{"context": "Smoke Gate (mock tier)"}],
+    },
+    "enforce_admins": False,
+    "required_pull_request_reviews": None,
+    "restrictions": None,
+}
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_ci_drift_script_s16_7", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_ci_drift_script_s16_7"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _clean_env_and_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k in (
+        "CI_GOVERNANCE_GH_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "CI_GOVERNANCE_READER_MODE",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    get_protection_reader.cache_clear()
+    get_real_gh_protection_reader.cache_clear()
+    yield
+    get_protection_reader.cache_clear()
+    get_real_gh_protection_reader.cache_clear()
+
+
+def _write_baseline(tmp_path: Path) -> Path:
+    p = tmp_path / "baseline.json"
+    p.write_text(json.dumps(_BASELINE), encoding="utf-8")
+    return p
+
+
+class _FakeHttpClient:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.calls: list[tuple[str, dict, str]] = []
+
+    def __call__(self, url: str, headers: dict[str, str], method: str) -> tuple[int, bytes]:
+        self.calls.append((url, dict(headers), method))
+        return 200, self.body
+
+
+def _install_fake_real_reader(
+    monkeypatch: pytest.MonkeyPatch, body: dict[str, Any]
+) -> _FakeHttpClient:
+    """Replace the lru_cached real-API reader with one wired to a fake HTTP."""
+    fake = _FakeHttpClient(json.dumps(body).encode("utf-8"))
+    import services.ci_governance.factory as factory_mod
+
+    def _fake_factory() -> GitHubApiProtectionReader:
+        return GitHubApiProtectionReader(
+            owner="CarmiBanxe",
+            repo="banxe-emi-stack",
+            token_provider=lambda: "tok-x",
+            branch="main",
+            http_client=fake,
+        )
+
+    monkeypatch.setattr(factory_mod, "get_real_gh_protection_reader", _fake_factory)
+    return fake
+
+
+def test_script_uses_gh_api_reader_when_token_present_and_no_dry_run_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    baseline = _write_baseline(tmp_path)
+    monkeypatch.setenv("CI_GOVERNANCE_GH_TOKEN", "tok-x")
+    fake = _install_fake_real_reader(
+        monkeypatch,
+        {
+            "required_status_checks": {
+                "strict": True,
+                "checks": [{"context": "Smoke Gate (mock tier)"}],
+            },
+            "enforce_admins": {"enabled": False},
+        },
+    )
+    mod = _load_script()
+    rc = mod.main(["--baseline", str(baseline)])
+    out = capsys.readouterr().out
+    result = json.loads(out.strip())
+    assert rc == 0
+    assert result["drift_detected"] is False
+    # FakeHttpClient confirms the real-API reader was actually used.
+    assert fake.calls, "real-API reader was not invoked"
+    assert fake.calls[0][2] == "GET"
+
+
+def test_script_still_exits_2_when_no_token_and_no_dry_run_payload(
+    tmp_path: Path,
+) -> None:
+    baseline = _write_baseline(tmp_path)
+    mod = _load_script()
+    rc = mod.main(["--baseline", str(baseline)])
+    assert rc == 2
+
+
+def test_script_force_real_api_flag_bypasses_in_memory_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    baseline = _write_baseline(tmp_path)
+    # A captured payload that WOULD report no drift if used.
+    payload_file = tmp_path / "payload.json"
+    payload_file.write_text(
+        json.dumps(
+            {
+                "required_status_checks": {
+                    "strict": True,
+                    "checks": [{"context": "Smoke Gate (mock tier)"}],
+                },
+                "enforce_admins": {"enabled": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Real-API would say DRIFT (missing the required Smoke Gate context).
+    monkeypatch.setenv("CI_GOVERNANCE_GH_TOKEN", "tok-x")
+    fake = _install_fake_real_reader(
+        monkeypatch,
+        {
+            "required_status_checks": {"strict": True, "checks": []},
+            "enforce_admins": {"enabled": False},
+        },
+    )
+
+    mod = _load_script()
+    rc = mod.main(
+        [
+            "--baseline",
+            str(baseline),
+            "--dry-run-payload",
+            str(payload_file),
+            "--force-real-api",
+        ]
+    )
+    out = capsys.readouterr().out
+    result = json.loads(out.strip())
+    # Real-API drove the comparison (not the local payload), so drift IS detected.
+    assert rc == 1
+    assert result["drift_detected"] is True
+    assert "Smoke Gate (mock tier)" in result["missing_contexts"]
+    assert fake.calls, "real-API was not invoked under --force-real-api"

--- a/tests/unit/ci_governance/test_factory_real_reader_selection.py
+++ b/tests/unit/ci_governance/test_factory_real_reader_selection.py
@@ -1,0 +1,111 @@
+"""Factory selection tests for S16.7 — real-API reader / in-memory / auto."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.ci_governance.factory import (
+    get_protection_reader,
+    get_real_gh_protection_reader,
+    resolve_gh_token,
+)
+from services.ci_governance.gh_api_protection_reader import (
+    GitHubApiProtectionReader,
+)
+from services.ci_governance.in_memory_protection_reader import (
+    InMemoryProtectionReader,
+)
+
+_TOKEN_ENVS = ("CI_GOVERNANCE_GH_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches_and_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test starts with a clean factory cache + no token env."""
+    for k in _TOKEN_ENVS:
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.delenv("CI_GOVERNANCE_READER_MODE", raising=False)
+    monkeypatch.delenv("CI_GOVERNANCE_REPO_OWNER", raising=False)
+    monkeypatch.delenv("CI_GOVERNANCE_REPO_NAME", raising=False)
+    monkeypatch.delenv("CI_GOVERNANCE_BRANCH", raising=False)
+    get_protection_reader.cache_clear()
+    get_real_gh_protection_reader.cache_clear()
+    yield
+    get_protection_reader.cache_clear()
+    get_real_gh_protection_reader.cache_clear()
+
+
+def test_factory_in_memory_when_READER_MODE_in_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CI_GOVERNANCE_READER_MODE", "in_memory")
+    monkeypatch.setenv("CI_GOVERNANCE_GH_TOKEN", "tok-x")
+    reader = get_protection_reader()
+    assert isinstance(reader, InMemoryProtectionReader)
+
+
+def test_factory_gh_api_when_READER_MODE_gh_api_with_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CI_GOVERNANCE_READER_MODE", "gh_api")
+    monkeypatch.setenv("CI_GOVERNANCE_GH_TOKEN", "tok-x")
+    reader = get_protection_reader()
+    assert isinstance(reader, GitHubApiProtectionReader)
+
+
+def test_factory_gh_api_when_READER_MODE_auto_with_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CI_GOVERNANCE_READER_MODE", "auto")
+    monkeypatch.setenv("CI_GOVERNANCE_GH_TOKEN", "tok-x")
+    reader = get_protection_reader()
+    assert isinstance(reader, GitHubApiProtectionReader)
+
+
+def test_factory_in_memory_when_READER_MODE_auto_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CI_GOVERNANCE_READER_MODE", "auto")
+    # All three token vars left unset by the autouse fixture.
+    reader = get_protection_reader()
+    assert isinstance(reader, InMemoryProtectionReader)
+
+
+def test_factory_uses_CI_GOVERNANCE_GH_TOKEN_first_then_GH_TOKEN_then_GITHUB_TOKEN(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Only GITHUB_TOKEN set → picked.
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-z")
+    assert resolve_gh_token() == "github-token-z"
+
+    # GH_TOKEN overrides GITHUB_TOKEN.
+    monkeypatch.setenv("GH_TOKEN", "gh-token-y")
+    assert resolve_gh_token() == "gh-token-y"
+
+    # CI_GOVERNANCE_GH_TOKEN overrides both.
+    monkeypatch.setenv("CI_GOVERNANCE_GH_TOKEN", "ci-token-x")
+    assert resolve_gh_token() == "ci-token-x"
+
+    # Empty CI_GOVERNANCE_GH_TOKEN falls through to GH_TOKEN.
+    monkeypatch.setenv("CI_GOVERNANCE_GH_TOKEN", "")
+    assert resolve_gh_token() == "gh-token-y"
+
+
+def test_factory_lru_cache_clear_resets_between_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After cache_clear, env changes are honoured by the next call."""
+    monkeypatch.setenv("CI_GOVERNANCE_READER_MODE", "in_memory")
+    first = get_protection_reader()
+    assert isinstance(first, InMemoryProtectionReader)
+
+    # Flip env then cache_clear — next call must reflect new env.
+    monkeypatch.setenv("CI_GOVERNANCE_READER_MODE", "gh_api")
+    monkeypatch.setenv("CI_GOVERNANCE_GH_TOKEN", "tok-x")
+    get_protection_reader.cache_clear()
+    get_real_gh_protection_reader.cache_clear()
+    second = get_protection_reader()
+    assert isinstance(second, GitHubApiProtectionReader)
+    # And without cache_clear, the result is stable (singleton).
+    third = get_protection_reader()
+    assert second is third

--- a/tests/unit/ci_governance/test_gh_api_protection_reader.py
+++ b/tests/unit/ci_governance/test_gh_api_protection_reader.py
@@ -1,0 +1,196 @@
+"""Unit tests for GitHubApiProtectionReader (S16.7).
+
+FakeHttpClient is an in-memory dict mapping URL → (status_code, body_bytes),
+plus a call log capturing every (url, headers, method) tuple. No real
+network; no urllib invocation; no GitHub credentials required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from services.ci_governance.gh_api_protection_reader import (
+    GitHubApiProtectionReader,
+)
+
+_EXPECTED_URL = "https://api.github.com/repos/CarmiBanxe/banxe-emi-stack/branches/main/protection"
+
+
+class _FakeHttpClient:
+    """Callable matching HttpClient signature (url, headers, method) → (status, bytes)."""
+
+    def __init__(
+        self,
+        responses: dict[str, tuple[int, bytes]] | None = None,
+    ) -> None:
+        self._responses = responses or {}
+        # Each entry: (url, headers_snapshot, method)
+        self.calls: list[tuple[str, dict[str, str], str]] = []
+
+    def __call__(self, url: str, headers: dict[str, str], method: str) -> tuple[int, bytes]:
+        self.calls.append((url, dict(headers), method))
+        return self._responses.get(url, (200, b"{}"))
+
+    def methods_invoked(self) -> list[str]:
+        return [m for _u, _h, m in self.calls]
+
+
+def _provider(token: str = "test-token-abc") -> Any:
+    """Build a token_provider callable that returns a fixed token."""
+    return lambda: token
+
+
+def _ok_body() -> bytes:
+    return json.dumps(
+        {
+            "required_status_checks": {"strict": True, "checks": []},
+            "enforce_admins": {"enabled": False},
+        }
+    ).encode("utf-8")
+
+
+def test_reader_calls_correct_protection_url_for_owner_repo_branch() -> None:
+    client = _FakeHttpClient({_EXPECTED_URL: (200, _ok_body())})
+    reader = GitHubApiProtectionReader(
+        owner="CarmiBanxe",
+        repo="banxe-emi-stack",
+        token_provider=_provider(),
+        branch="main",
+        http_client=client,
+    )
+    reader.read_main_protection()
+    assert client.calls, "http_client never called"
+    assert client.calls[0][0] == _EXPECTED_URL
+
+
+def test_reader_sends_authorization_header_with_token() -> None:
+    client = _FakeHttpClient({_EXPECTED_URL: (200, _ok_body())})
+    reader = GitHubApiProtectionReader(
+        owner="CarmiBanxe",
+        repo="banxe-emi-stack",
+        token_provider=_provider("ghp_rotating_77777"),
+        http_client=client,
+    )
+    reader.read_main_protection()
+    _url, headers, _method = client.calls[0]
+    assert headers.get("Authorization") == "token ghp_rotating_77777"
+
+
+def test_reader_sends_github_v3_accept_header() -> None:
+    client = _FakeHttpClient({_EXPECTED_URL: (200, _ok_body())})
+    reader = GitHubApiProtectionReader(
+        owner="CarmiBanxe",
+        repo="banxe-emi-stack",
+        token_provider=_provider(),
+        http_client=client,
+    )
+    reader.read_main_protection()
+    _url, headers, _method = client.calls[0]
+    assert headers.get("Accept") == "application/vnd.github.v3+json"
+    # Also assert User-Agent identifies the sentry per GitHub API requirement.
+    assert headers.get("User-Agent", "").startswith("banxe-ci-governance/")
+
+
+def test_reader_returns_parsed_json_dict_on_200() -> None:
+    payload = {
+        "required_status_checks": {
+            "strict": True,
+            "checks": [{"context": "Smoke Gate (mock tier)"}],
+        },
+        "enforce_admins": {"enabled": False},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    client = _FakeHttpClient({_EXPECTED_URL: (200, body)})
+    reader = GitHubApiProtectionReader(
+        owner="CarmiBanxe",
+        repo="banxe-emi-stack",
+        token_provider=_provider(),
+        http_client=client,
+    )
+    out = reader.read_main_protection()
+    assert isinstance(out, dict)
+    assert out["required_status_checks"]["strict"] is True
+    assert out["enforce_admins"] == {"enabled": False}
+
+
+@pytest.mark.parametrize("status,label", [(401, "401"), (403, "403"), (404, "404"), (500, "500")])
+def test_reader_raises_clear_error_with_status_in_message(status: int, label: str) -> None:
+    client = _FakeHttpClient({_EXPECTED_URL: (status, b'{"message": "synthetic"}')})
+    reader = GitHubApiProtectionReader(
+        owner="CarmiBanxe",
+        repo="banxe-emi-stack",
+        token_provider=_provider(),
+        http_client=client,
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        reader.read_main_protection()
+    assert label in str(exc_info.value)
+
+
+def test_reader_calls_token_provider_each_read() -> None:
+    """No token caching at the adapter level — provider invoked per read."""
+    invocations: list[int] = []
+
+    def counting_provider() -> str:
+        invocations.append(1)
+        return "tok-N"
+
+    client = _FakeHttpClient({_EXPECTED_URL: (200, _ok_body())})
+    reader = GitHubApiProtectionReader(
+        owner="CarmiBanxe",
+        repo="banxe-emi-stack",
+        token_provider=counting_provider,
+        http_client=client,
+    )
+    reader.read_main_protection()
+    reader.read_main_protection()
+    reader.read_main_protection()
+    assert len(invocations) == 3
+
+
+def test_reader_never_calls_mutation_methods() -> None:
+    """Every recorded http_client call must use method='GET'. Also assert
+    by source-text inspection that the adapter never references PUT /
+    PATCH / DELETE / POST as methods."""
+    client = _FakeHttpClient({_EXPECTED_URL: (200, _ok_body())})
+    reader = GitHubApiProtectionReader(
+        owner="CarmiBanxe",
+        repo="banxe-emi-stack",
+        token_provider=_provider(),
+        http_client=client,
+    )
+    for _ in range(5):
+        reader.read_main_protection()
+    assert all(m == "GET" for m in client.methods_invoked())
+    # Defence-in-depth: source-text scan.
+    src = Path(
+        Path(__file__).resolve().parents[3]
+        / "services"
+        / "ci_governance"
+        / "gh_api_protection_reader.py"
+    ).read_text(encoding="utf-8")
+    for forbidden in ("PUT", "PATCH", "DELETE", "POST"):
+        # The string can appear in comments / error messages; assert it
+        # does NOT appear as a Python-string method literal like '"POST"'.
+        for needle in (f'"{forbidden}"', f"'{forbidden}'"):
+            assert needle not in src, (
+                f"forbidden mutation method literal {needle!r} found in gh_api_protection_reader.py"
+            )
+
+
+def test_reader_raises_when_token_provider_returns_empty() -> None:
+    """Empty/None token must be rejected before any HTTP call goes out."""
+    client = _FakeHttpClient({_EXPECTED_URL: (200, _ok_body())})
+    reader = GitHubApiProtectionReader(
+        owner="CarmiBanxe",
+        repo="banxe-emi-stack",
+        token_provider=lambda: "",  # no token
+        http_client=client,
+    )
+    with pytest.raises(RuntimeError, match="no token"):
+        reader.read_main_protection()
+    assert client.calls == [], "http_client called despite missing token"


### PR DESCRIPTION
## S16.7 — real GitHub-API protection reader adapter (read-only)

### What
Adds a real read-only GitHub-API protection reader adapter for CI governance drift monitoring.

### Scope
- Real GitHub protection reader adapter
- Factory wiring for reader mode selection
- CLI updates for token resolution and force-real-api mode
- Tests for adapter, factory, and CLI behavior

### Safety
- Read-only only
- No mutation methods exposed
- GET-only at the HTTP seam
- HTTPS-only URL guard
- No production deploy performed

### Validation
- Targeted pytest PASS
- Full hook chain PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based configuration for CI governance drift detection
  * Enabled GitHub API integration for branch protection monitoring
  * Introduced reader mode selection (`auto`, `in_memory`, `gh_api`)
  * Added `--force-real-api` flag for drift check script

* **Tests**
  * Added tests for reader selection and API integration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CarmiBanxe/banxe-emi-stack/pull/138)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->