### PR TITLE
feat(s16-8): drift snapshot capture pipeline (read-only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,3 +153,9 @@ CI_GOVERNANCE_BRANCH=main
 # Reader selector: "in_memory" (S16.6 default) | "gh_api" (force real) |
 # "auto" (real if any token env present, else in_memory).
 CI_GOVERNANCE_READER_MODE=auto
+
+# === CI governance snapshot capture (S16.8) ===
+# Path of the snapshot file written by scripts/ci-protection-snapshot-capture.py
+# and consumed by scripts/ci-protection-drift-check.py --dry-run-payload.
+# Atomic write (tmpfile + rename); readers never observe a partial file.
+CI_GOVERNANCE_SNAPSHOT_PATH=/var/cache/banxe/last-protection-snapshot.json

--- a/scripts/ci-protection-snapshot-capture.py
+++ b/scripts/ci-protection-snapshot-capture.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+ci-protection-snapshot-capture.py — Snapshot capture CLI (S16.8).
+
+Captures GitHub branch-protection state on `main` into a local JSON file
+that the S16.6 drift-sentry CLI can later consume via its
+`--dry-run-payload <file>` path. Read-only.
+
+Typical operator wiring:
+  1. Run THIS script on a host with outbound GitHub access on a cron
+     (e.g. every 30 minutes). The script writes
+     /var/cache/banxe/last-protection-snapshot.json atomically.
+  2. Run `scripts/ci-protection-drift-check.py --dry-run-payload
+     /var/cache/banxe/last-protection-snapshot.json` on the drift-sentry
+     host (which may not have outbound GitHub access).
+
+Flags
+-----
+- `--snapshot-path <path>` : override the snapshot output path. Default:
+                              env CI_GOVERNANCE_SNAPSHOT_PATH, falling
+                              back to /var/cache/banxe/last-protection-snapshot.json.
+- `--force-real-api`       : force the real GitHub-API reader regardless
+                              of CI_GOVERNANCE_READER_MODE. Useful when
+                              the cron host has a token but operator env
+                              chose `in_memory` by mistake.
+- `--pretty`               : reserved for future human-readable output;
+                              JSON output is already sort-keyed +
+                              indent=2 in the snapshot file.
+
+Exit codes
+----------
+- 0 : capture succeeded; SnapshotResult.success == True
+- 1 : capture failed (reader raised, or file_writer raised); details in
+       SnapshotResult.error
+- 2 : reader is in `in_memory` mode AND no token env present (cron-safe;
+       the cron should not silently write a stub snapshot)
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import os
+import sys
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+logger = logging.getLogger("banxe.ci-protection-snapshot-capture")
+
+_DEFAULT_SNAPSHOT_PATH = "/var/cache/banxe/last-protection-snapshot.json"
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--snapshot-path",
+        default=os.environ.get("CI_GOVERNANCE_SNAPSHOT_PATH", _DEFAULT_SNAPSHOT_PATH),
+        help=(
+            "target file for the captured snapshot "
+            "(default: env CI_GOVERNANCE_SNAPSHOT_PATH or "
+            f"{_DEFAULT_SNAPSHOT_PATH})"
+        ),
+    )
+    p.add_argument(
+        "--force-real-api",
+        action="store_true",
+        help="force the real GitHub-API reader regardless of CI_GOVERNANCE_READER_MODE",
+    )
+    p.add_argument(
+        "--pretty",
+        action="store_true",
+        help="reserved (snapshot file is already pretty-printed)",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+
+    # Reader selection guard: refuse to write a stub snapshot from the
+    # in_memory reader unless the operator explicitly --force-real-api'd
+    # AND has a token. This keeps the cron cron-safe — better an empty
+    # SnapshotResult on stdout (exit 2) than an empty file on disk.
+    from services.ci_governance.factory import (
+        get_protection_reader,
+        get_real_gh_protection_reader,
+        get_snapshot_writer,
+        resolve_gh_token,
+    )
+    from services.ci_governance.in_memory_protection_reader import (
+        InMemoryProtectionReader,
+    )
+    from services.ci_governance.snapshot_writer import ProtectionSnapshotWriter
+
+    if args.force_real_api:
+        if resolve_gh_token() is None:
+            logger.error(
+                "--force-real-api set but no token env (CI_GOVERNANCE_GH_TOKEN / "
+                "GH_TOKEN / GITHUB_TOKEN) is present"
+            )
+            return 2
+        writer = ProtectionSnapshotWriter(reader=get_real_gh_protection_reader())
+    else:
+        reader = get_protection_reader()
+        if isinstance(reader, InMemoryProtectionReader) and resolve_gh_token() is None:
+            logger.error(
+                "reader is in_memory mode and no token env present; refusing to "
+                "write a stub snapshot. Set CI_GOVERNANCE_READER_MODE=gh_api (or "
+                "=auto with a token) OR pass --force-real-api with a token."
+            )
+            return 2
+        writer = get_snapshot_writer()
+
+    result = writer.capture(args.snapshot_path)
+    print(json.dumps(dataclasses.asdict(result), default=str))
+
+    if result.success:
+        logger.info("snapshot OK: %s (%s bytes)", result.snapshot_path, result.byte_size)
+        return 0
+
+    logger.error("snapshot FAIL: %s", result.error)
+    # Distinguish a deliberate cron-safe stop (exit 2) from a real I/O failure (1).
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/ci_governance/factory.py
+++ b/services/ci_governance/factory.py
@@ -116,3 +116,16 @@ def get_drift_alert_emitter() -> DriftAlertEmitter:
     from services.alerting.di import get_alert_adapter
 
     return DriftAlertEmitter(alert_router=get_alert_adapter(), clock=time.time)
+
+
+@lru_cache(maxsize=1)
+def get_snapshot_writer():
+    """Singleton ProtectionSnapshotWriter wired to the configured reader.
+
+    Reuses the env-driven get_protection_reader() so the snapshot host
+    can be in_memory / gh_api / auto mode independently of the drift-
+    sentry host that consumes the snapshot file (S16.6 + S16.7 paths).
+    """
+    from services.ci_governance.snapshot_writer import ProtectionSnapshotWriter
+
+    return ProtectionSnapshotWriter(reader=get_protection_reader(), clock=time.time)

--- a/services/ci_governance/snapshot_writer.py
+++ b/services/ci_governance/snapshot_writer.py
@@ -1,0 +1,114 @@
+"""
+snapshot_writer.py — Periodic protection-state snapshot capture (S16.8).
+
+Pairs with:
+  - S16.6 DriftDetector (#137) — the CLI consumes snapshots via the
+    `--dry-run-payload` path on hosts without outbound GitHub access.
+  - S16.7 GitHubApiProtectionReader (#138) — the snapshot source on hosts
+    WITH outbound GitHub access (the capture cron runs there; the file
+    propagates to the drift-sentry host via existing infra).
+
+Contract:
+  - Read-only on the GitHub side: delegates to the injected
+    GitHubProtectionReaderPort. NO PUT / PATCH / DELETE / POST anywhere.
+  - Atomic write on the filesystem side: serialised payload is written
+    to a sibling temp file (`<target>.tmp.<pid>.<epoch>`) then renamed
+    over the destination. Readers never observe a partially-written file.
+  - Deterministic output: JSON `sort_keys=True` + trailing newline.
+
+`file_writer` injection slot is for tests; the default writes through the
+`pathlib` + `os.replace` atomic-rename combo.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from services.ci_governance.protection_reader_port import (
+        GitHubProtectionReaderPort,
+    )
+
+
+FileWriter = Callable[[str, str], None]
+
+
+@dataclass(frozen=True)
+class SnapshotResult:
+    """Outcome of one capture cycle."""
+
+    success: bool
+    snapshot_path: str
+    captured_at: float
+    byte_size: int | None = None
+    error: str | None = None
+
+
+def _default_file_writer(target_path: str, body: str) -> None:
+    """Atomic write: tmpfile sibling → fsync → os.replace.
+
+    Sibling is on the same filesystem as the target so rename is atomic.
+    Parent directory is created if missing (0755).
+    """
+    target = Path(target_path)
+    parent = target.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp = parent / f"{target.name}.tmp.{os.getpid()}.{int(time.time_ns())}"
+    try:
+        tmp.write_text(body, encoding="utf-8")
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+class ProtectionSnapshotWriter:
+    """Capture a single snapshot of GitHub branch-protection state."""
+
+    def __init__(
+        self,
+        reader: GitHubProtectionReaderPort,
+        clock: Callable[[], float] = time.time,
+        file_writer: FileWriter | None = None,
+    ) -> None:
+        self._reader = reader
+        self._clock = clock
+        self._file_writer: FileWriter = file_writer or _default_file_writer
+
+    def capture(self, snapshot_path: str) -> SnapshotResult:
+        try:
+            payload = self._reader.read_main_protection()
+        except Exception as exc:
+            return SnapshotResult(
+                success=False,
+                snapshot_path=snapshot_path,
+                captured_at=self._clock(),
+                byte_size=None,
+                error=f"reader: {type(exc).__name__}: {exc}",
+            )
+
+        body = json.dumps(payload, sort_keys=True, indent=2) + "\n"
+        try:
+            self._file_writer(snapshot_path, body)
+        except Exception as exc:
+            return SnapshotResult(
+                success=False,
+                snapshot_path=snapshot_path,
+                captured_at=self._clock(),
+                byte_size=None,
+                error=f"file_writer: {type(exc).__name__}: {exc}",
+            )
+
+        return SnapshotResult(
+            success=True,
+            snapshot_path=snapshot_path,
+            captured_at=self._clock(),
+            byte_size=len(body.encode("utf-8")),
+            error=None,
+        )

--- a/tests/unit/ci_governance/test_snapshot_capture_script.py
+++ b/tests/unit/ci_governance/test_snapshot_capture_script.py
@@ -1,0 +1,140 @@
+"""CLI script tests for S16.8 snapshot-capture."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from services.ci_governance.factory import (
+    get_protection_reader,
+    get_real_gh_protection_reader,
+    get_snapshot_writer,
+)
+from services.ci_governance.gh_api_protection_reader import (
+    GitHubApiProtectionReader,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "ci-protection-snapshot-capture.py"
+
+_DEFAULT_SNAPSHOT_PATH = "/var/cache/banxe/last-protection-snapshot.json"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_snapshot_capture_script", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_snapshot_capture_script"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _clean_env_and_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k in (
+        "CI_GOVERNANCE_GH_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "CI_GOVERNANCE_READER_MODE",
+        "CI_GOVERNANCE_SNAPSHOT_PATH",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    get_protection_reader.cache_clear()
+    get_real_gh_protection_reader.cache_clear()
+    get_snapshot_writer.cache_clear()
+    yield
+    get_protection_reader.cache_clear()
+    get_real_gh_protection_reader.cache_clear()
+    get_snapshot_writer.cache_clear()
+
+
+class _FakeHttp:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.calls: list[tuple[str, dict, str]] = []
+
+    def __call__(self, url: str, headers: dict[str, str], method: str) -> tuple[int, bytes]:
+        self.calls.append((url, dict(headers), method))
+        return 200, self.body
+
+
+def _wire_fake_real_reader(monkeypatch: pytest.MonkeyPatch, body: dict[str, Any]) -> _FakeHttp:
+    fake = _FakeHttp(json.dumps(body).encode("utf-8"))
+    import services.ci_governance.factory as factory_mod
+
+    def _fake_factory() -> GitHubApiProtectionReader:
+        return GitHubApiProtectionReader(
+            owner="CarmiBanxe",
+            repo="banxe-emi-stack",
+            token_provider=lambda: "tok-x",
+            branch="main",
+            http_client=fake,
+        )
+
+    monkeypatch.setattr(factory_mod, "get_real_gh_protection_reader", _fake_factory)
+    return fake
+
+
+def test_script_uses_default_snapshot_path_when_env_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """argparse default for --snapshot-path matches the documented constant."""
+    mod = _load_script()
+    parser = mod._build_arg_parser()
+    args = parser.parse_args([])
+    assert args.snapshot_path == _DEFAULT_SNAPSHOT_PATH
+
+
+def test_script_uses_env_path_when_present(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    target = tmp_path / "alt.json"
+    monkeypatch.setenv("CI_GOVERNANCE_SNAPSHOT_PATH", str(target))
+    mod = _load_script()
+    parser = mod._build_arg_parser()
+    args = parser.parse_args([])
+    assert args.snapshot_path == str(target)
+
+
+def test_script_exits_2_when_in_memory_mode_and_no_token(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "snap.json"
+    mod = _load_script()
+    rc = mod.main(["--snapshot-path", str(target)])
+    assert rc == 2
+    assert not target.exists(), "no snapshot must be written in cron-safe mode"
+
+
+def test_script_exits_0_on_capture_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = tmp_path / "snap.json"
+    monkeypatch.setenv("CI_GOVERNANCE_GH_TOKEN", "tok-x")
+    monkeypatch.setenv("CI_GOVERNANCE_READER_MODE", "gh_api")
+    payload = {
+        "required_status_checks": {
+            "strict": True,
+            "checks": [{"context": "Smoke Gate (mock tier)"}],
+        },
+        "enforce_admins": {"enabled": False},
+    }
+    fake = _wire_fake_real_reader(monkeypatch, payload)
+    mod = _load_script()
+    rc = mod.main(["--snapshot-path", str(target)])
+    out = capsys.readouterr().out
+    result = json.loads(out.strip())
+    assert rc == 0
+    assert result["success"] is True
+    assert target.is_file()
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written == payload
+    # FakeHttp confirms the real-API reader was actually used.
+    assert fake.calls, "real-API reader was not invoked"
+    assert fake.calls[0][2] == "GET"

--- a/tests/unit/ci_governance/test_snapshot_writer.py
+++ b/tests/unit/ci_governance/test_snapshot_writer.py
@@ -1,0 +1,157 @@
+"""Unit tests for ProtectionSnapshotWriter (S16.8)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from services.ci_governance.snapshot_writer import (
+    ProtectionSnapshotWriter,
+    SnapshotResult,
+)
+
+
+class _FakeReader:
+    """In-memory GitHubProtectionReaderPort double + mutation-call ledger."""
+
+    _ALL_METHODS = ("read_main_protection",)
+
+    def __init__(self, payload: dict, raise_exc: Exception | None = None) -> None:
+        self._payload = payload
+        self._raise = raise_exc
+        self.calls: list[str] = []
+
+    def read_main_protection(self) -> dict:
+        self.calls.append("read_main_protection")
+        if self._raise is not None:
+            raise self._raise
+        return dict(self._payload)
+
+
+_CANONICAL_PAYLOAD: dict[str, Any] = {
+    "required_status_checks": {
+        "strict": True,
+        "checks": [
+            {"context": "Smoke Gate (mock tier)"},
+            {"context": "guardian-factory"},
+        ],
+    },
+    "enforce_admins": {"enabled": False},
+}
+
+
+def test_capture_writes_payload_as_json_to_target_path(tmp_path: Path) -> None:
+    target = tmp_path / "snap.json"
+    writer = ProtectionSnapshotWriter(
+        reader=_FakeReader(_CANONICAL_PAYLOAD),
+        clock=lambda: 1715000000.0,
+    )
+    result = writer.capture(str(target))
+    assert result.success is True
+    assert target.is_file()
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written == _CANONICAL_PAYLOAD
+
+
+def test_capture_uses_atomic_tmpfile_then_rename(tmp_path: Path) -> None:
+    """The default file_writer must write through a sibling tmpfile and
+    atomically rename. After capture: target exists, no leftover tmpfiles
+    in the parent directory."""
+    target = tmp_path / "snap.json"
+    writer = ProtectionSnapshotWriter(
+        reader=_FakeReader(_CANONICAL_PAYLOAD),
+        clock=lambda: 1715000000.0,
+    )
+    result = writer.capture(str(target))
+    assert result.success is True
+    leftovers = [p for p in tmp_path.iterdir() if p.name.startswith("snap.json.tmp.")]
+    assert leftovers == [], f"tmpfile leftovers after rename: {leftovers}"
+    assert target.is_file()
+
+
+def test_capture_serialises_with_sorted_keys(tmp_path: Path) -> None:
+    target = tmp_path / "snap.json"
+    payload = {"b": 2, "a": 1, "c": {"y": 1, "x": 0}}
+    writer = ProtectionSnapshotWriter(
+        reader=_FakeReader(payload),
+        clock=lambda: 1715000000.0,
+    )
+    writer.capture(str(target))
+    raw = target.read_text(encoding="utf-8")
+    # First key in raw output must be 'a' (sorted alphabetically).
+    first_a = raw.find('"a"')
+    first_b = raw.find('"b"')
+    first_c = raw.find('"c"')
+    assert -1 < first_a < first_b < first_c
+    # Nested objects sorted too.
+    nested_x = raw.find('"x"')
+    nested_y = raw.find('"y"')
+    assert -1 < nested_x < nested_y
+
+
+def test_capture_appends_trailing_newline(tmp_path: Path) -> None:
+    target = tmp_path / "snap.json"
+    writer = ProtectionSnapshotWriter(
+        reader=_FakeReader(_CANONICAL_PAYLOAD),
+        clock=lambda: 1715000000.0,
+    )
+    writer.capture(str(target))
+    body = target.read_text(encoding="utf-8")
+    assert body.endswith("\n"), "snapshot must end with a trailing newline"
+
+
+def test_capture_returns_byte_size_in_result(tmp_path: Path) -> None:
+    target = tmp_path / "snap.json"
+    writer = ProtectionSnapshotWriter(
+        reader=_FakeReader(_CANONICAL_PAYLOAD),
+        clock=lambda: 1715000000.0,
+    )
+    result = writer.capture(str(target))
+    assert isinstance(result.byte_size, int)
+    assert result.byte_size > 0
+    assert result.byte_size == os.path.getsize(target)
+
+
+def test_capture_uses_injected_clock_for_captured_at(tmp_path: Path) -> None:
+    fixed = 1715111111.0
+    writer = ProtectionSnapshotWriter(
+        reader=_FakeReader(_CANONICAL_PAYLOAD),
+        clock=lambda: fixed,
+    )
+    result = writer.capture(str(tmp_path / "snap.json"))
+    assert result.captured_at == fixed
+
+
+def test_capture_returns_failure_when_reader_raises(tmp_path: Path) -> None:
+    target = tmp_path / "snap.json"
+    writer = ProtectionSnapshotWriter(
+        reader=_FakeReader({}, raise_exc=RuntimeError("HTTP 401 from GitHub")),
+        clock=lambda: 1715000000.0,
+    )
+    result: SnapshotResult = writer.capture(str(target))
+    assert result.success is False
+    assert result.byte_size is None
+    assert "reader" in (result.error or "")
+    assert "RuntimeError" in (result.error or "")
+    assert not target.exists(), "target file must NOT be written when reader fails"
+
+
+def test_capture_never_calls_mutation_methods_on_reader(tmp_path: Path) -> None:
+    target = tmp_path / "snap.json"
+    reader = _FakeReader(_CANONICAL_PAYLOAD)
+    writer = ProtectionSnapshotWriter(reader=reader, clock=lambda: 1715000000.0)
+    for _ in range(3):
+        writer.capture(str(target))
+    # Only read_main_protection ever called.
+    assert set(reader.calls) == {"read_main_protection"}
+    # Defence-in-depth: source-text scan for forbidden mutation literals.
+    src = Path(
+        Path(__file__).resolve().parents[3] / "services" / "ci_governance" / "snapshot_writer.py"
+    ).read_text(encoding="utf-8")
+    for forbidden in ("PUT", "PATCH", "DELETE", "POST"):
+        for needle in (f'"{forbidden}"', f"'{forbidden}'"):
+            assert needle not in src, (
+                f"forbidden mutation method literal {needle!r} found in snapshot_writer.py"
+            )


### PR DESCRIPTION
S16.8 — drift snapshot capture pipeline. Pairs with S16.6 CLI dry-run path (#137) and S16.7 real-API reader (#138); enables cron-safe drift sentry on hosts without outbound GH access. Files (6 / +566 / -0): services/ci_governance/snapshot_writer.py (atomic tmpfile+rename, JSON sorted keys, trailing newline), services/ci_governance/factory.py extension (get_snapshot_writer lru_cache singleton), scripts/ci-protection-snapshot-capture.py (CLI with --snapshot-path, --force-real-api, --pretty), .env.example (append CI_GOVERNANCE_SNAPSHOT_PATH), 8 writer unit tests + 4 CLI tests. Pre-commit: 50 PASS / 0 FAIL + full hook chain PASS. READ-ONLY; no mutation methods anywhere. NO PRODUCTION DEPLOY. Operator merge: gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added `CI_GOVERNANCE_SNAPSHOT_PATH` environment variable for snapshot path configuration
  * Introduced new snapshot capture utility for GitHub branch protection state tracking
  * Added comprehensive test coverage for snapshot capture and writing functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CarmiBanxe/banxe-emi-stack/pull/139)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->