### PR TITLE
feat(s16-9): drift history store (append-only JSONL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,3 +159,8 @@ CI_GOVERNANCE_READER_MODE=auto
 # and consumed by scripts/ci-protection-drift-check.py --dry-run-payload.
 # Atomic write (tmpfile + rename); readers never observe a partial file.
 CI_GOVERNANCE_SNAPSHOT_PATH=/var/cache/banxe/last-protection-snapshot.json
+
+# === CI governance drift history (S16.9) ===
+# Append-only JSONL file for drift detection audit trail.
+# Each run of ci-protection-drift-check.py appends one line (unless --no-history).
+CI_GOVERNANCE_DRIFT_HISTORY_PATH=/var/cache/banxe/drift-history.jsonl

--- a/scripts/ci-protection-drift-check.py
+++ b/scripts/ci-protection-drift-check.py
@@ -29,6 +29,10 @@ Flags
                                 operator-driven validation runs that must
                                 hit the live state, ignoring any local
                                 payload snapshot.
+- `--history-path <path>`    : path to the append-only JSONL drift history
+                                file (default: env CI_GOVERNANCE_DRIFT_HISTORY_PATH
+                                or /var/cache/banxe/drift-history.jsonl).
+- `--no-history`             : skip appending to the drift history file.
 
 Exit codes
 ----------
@@ -83,6 +87,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--force-real-api",
         action="store_true",
         help="force the real GitHub-API reader (overrides --dry-run-payload)",
+    )
+    p.add_argument(
+        "--history-path",
+        default=None,
+        help="path to append-only JSONL drift history file "
+        "(default: env CI_GOVERNANCE_DRIFT_HISTORY_PATH "
+        "or /var/cache/banxe/drift-history.jsonl)",
+    )
+    p.add_argument(
+        "--no-history",
+        action="store_true",
+        help="skip appending to the drift history file",
     )
     return p
 
@@ -156,6 +172,21 @@ def main(argv: list[str] | None = None) -> int:
 
         with contextlib.suppress(Exception):
             get_drift_alert_emitter().emit(result)
+
+    # S16.9 — append to drift history store
+    if not args.no_history:
+        with contextlib.suppress(Exception):
+            from services.ci_governance.drift_history_store import DriftHistoryStore
+
+            history_path = (
+                args.history_path
+                or os.environ.get("CI_GOVERNANCE_DRIFT_HISTORY_PATH")
+                or "/var/cache/banxe/drift-history.jsonl"
+            )
+            import time
+
+            store = DriftHistoryStore(history_path=history_path, clock=time.time)
+            store.append_result(result)
 
     return 1
 

--- a/services/ci_governance/drift_history_store.py
+++ b/services/ci_governance/drift_history_store.py
@@ -1,0 +1,112 @@
+"""
+drift_history_store.py — Append-only JSONL history for DriftResult outcomes (S16.9).
+
+Persists each DriftResult from S16.6 detect_drift() as a single JSON line so
+operators can audit drift events over time without re-running detection.
+
+Design constraints:
+  - Append-only: no deletes, no updates, no truncate.
+  - Cross-process safe: fcntl.flock(LOCK_EX) during write.
+  - Atomic line: single write() call after serialisation.
+  - read_all / read_since skip malformed lines silently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import dataclasses
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+
+from services.ci_governance.drift_detector import DriftResult
+
+
+@dataclass(frozen=True)
+class AppendResult:
+    """Outcome of a single append operation."""
+
+    success: bool
+    history_path: str
+    appended_at: float
+    bytes_written: int | None = None
+    error: str | None = None
+
+
+def _default_file_appender(path: str, line: str) -> int:
+    """Append *line* to *path* under an exclusive flock; return bytes written."""
+    parent = Path(path).parent
+    parent.mkdir(parents=True, exist_ok=True)
+
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        encoded = line.encode("utf-8")
+        os.write(fd, encoded)
+        return len(encoded)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+class DriftHistoryStore:
+    """Append-only JSONL store for drift detection results."""
+
+    def __init__(
+        self,
+        history_path: str,
+        clock: Callable[[], float],
+        file_appender: Callable[[str, str], int] | None = None,
+    ) -> None:
+        self._history_path = history_path
+        self._clock = clock
+        self._file_appender = file_appender or _default_file_appender
+
+    def append_result(self, result: DriftResult) -> AppendResult:
+        """Serialise *result* and append one JSONL line. Never raises."""
+        now = self._clock()
+        try:
+            record = dataclasses.asdict(result)
+            record["ts"] = now
+            line = json.dumps(record, default=str, separators=(",", ":")) + "\n"
+            written = self._file_appender(self._history_path, line)
+            return AppendResult(
+                success=True,
+                history_path=self._history_path,
+                appended_at=now,
+                bytes_written=written,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return AppendResult(
+                success=False,
+                history_path=self._history_path,
+                appended_at=now,
+                error=str(exc),
+            )
+
+    def read_all(self, limit: int | None = None) -> list[dict]:
+        """Return well-formed entries in file order; skip malformed lines."""
+        path = Path(self._history_path)
+        if not path.is_file():
+            return []
+        entries: list[dict] = []
+        for raw_line in path.read_text(encoding="utf-8").splitlines():
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(obj, dict):
+                continue
+            entries.append(obj)
+            if limit is not None and len(entries) >= limit:
+                break
+        return entries
+
+    def read_since(self, since_ts: float) -> list[dict]:
+        """Return entries where ts >= *since_ts* (inclusive lower bound)."""
+        return [e for e in self.read_all() if e.get("ts", 0) >= since_ts]

--- a/services/ci_governance/factory.py
+++ b/services/ci_governance/factory.py
@@ -119,6 +119,18 @@ def get_drift_alert_emitter() -> DriftAlertEmitter:
 
 
 @lru_cache(maxsize=1)
+def get_drift_history_store():
+    """Singleton DriftHistoryStore; path from CI_GOVERNANCE_DRIFT_HISTORY_PATH env."""
+    from services.ci_governance.drift_history_store import DriftHistoryStore
+
+    history_path = os.environ.get(
+        "CI_GOVERNANCE_DRIFT_HISTORY_PATH",
+        "/var/cache/banxe/drift-history.jsonl",
+    )
+    return DriftHistoryStore(history_path=history_path, clock=time.time)
+
+
+@lru_cache(maxsize=1)
 def get_snapshot_writer():
     """Singleton ProtectionSnapshotWriter wired to the configured reader.
 

--- a/tests/unit/ci_governance/test_drift_check_script_history.py
+++ b/tests/unit/ci_governance/test_drift_check_script_history.py
@@ -1,0 +1,144 @@
+"""Tests for drift history integration in ci-protection-drift-check.py (S16.9).
+
+Loads the hyphenated script via importlib.util (same pattern as
+test_drift_check_script.py).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "ci-protection-drift-check.py"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_ci_drift_script_hist", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_ci_drift_script_hist"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_BASELINE_MATCH = {
+    "required_status_checks": {
+        "strict": True,
+        "checks": [{"context": "ci/lint"}],
+    },
+    "enforce_admins": False,
+}
+
+_BASELINE_DRIFT = {
+    "required_status_checks": {
+        "strict": True,
+        "checks": [{"context": "ci/lint"}, {"context": "ci/deploy"}],
+    },
+    "enforce_admins": True,
+}
+
+_LIVE_PAYLOAD = {
+    "required_status_checks": {
+        "strict": True,
+        "checks": [{"context": "ci/lint", "app_id": 1}],
+    },
+    "enforce_admins": {"enabled": False},
+}
+
+
+def _write(path: Path, data: dict) -> Path:
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+class TestDriftCheckScriptHistory:
+    def test_script_appends_to_history_when_flag_present(self, tmp_path: Path) -> None:
+        mod = _load_script_module()
+        baseline = _write(tmp_path / "baseline.json", _BASELINE_DRIFT)
+        live = _write(tmp_path / "live.json", _LIVE_PAYLOAD)
+        history = tmp_path / "history.jsonl"
+
+        rc = mod.main(
+            [
+                "--baseline",
+                str(baseline),
+                "--dry-run-payload",
+                str(live),
+                "--history-path",
+                str(history),
+            ]
+        )
+        assert rc == 1  # drift
+        lines = [ln for ln in history.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["drift_detected"] is True
+
+    def test_script_skips_history_when_no_history_flag(self, tmp_path: Path) -> None:
+        mod = _load_script_module()
+        baseline = _write(tmp_path / "baseline.json", _BASELINE_DRIFT)
+        live = _write(tmp_path / "live.json", _LIVE_PAYLOAD)
+        history = tmp_path / "history.jsonl"
+
+        rc = mod.main(
+            [
+                "--baseline",
+                str(baseline),
+                "--dry-run-payload",
+                str(live),
+                "--history-path",
+                str(history),
+                "--no-history",
+            ]
+        )
+        assert rc == 1
+        assert not history.exists()
+
+    def test_script_uses_env_path_when_history_path_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mod = _load_script_module()
+        baseline = _write(tmp_path / "baseline.json", _BASELINE_DRIFT)
+        live = _write(tmp_path / "live.json", _LIVE_PAYLOAD)
+        history = tmp_path / "env-history.jsonl"
+        monkeypatch.setenv("CI_GOVERNANCE_DRIFT_HISTORY_PATH", str(history))
+
+        rc = mod.main(
+            [
+                "--baseline",
+                str(baseline),
+                "--dry-run-payload",
+                str(live),
+            ]
+        )
+        assert rc == 1
+        lines = [ln for ln in history.read_text().splitlines() if ln.strip()]
+        assert len(lines) >= 1
+
+    def test_script_does_not_crash_when_history_append_fails(self, tmp_path: Path) -> None:
+        mod = _load_script_module()
+        baseline = _write(tmp_path / "baseline.json", _BASELINE_DRIFT)
+        live = _write(tmp_path / "live.json", _LIVE_PAYLOAD)
+
+        with patch(
+            "services.ci_governance.drift_history_store.DriftHistoryStore.append_result",
+            side_effect=RuntimeError("BrokenStore"),
+        ):
+            rc = mod.main(
+                [
+                    "--baseline",
+                    str(baseline),
+                    "--dry-run-payload",
+                    str(live),
+                    "--history-path",
+                    "/nonexistent/path/h.jsonl",
+                ]
+            )
+            assert rc == 1  # drift detected, no crash

--- a/tests/unit/ci_governance/test_drift_history_store.py
+++ b/tests/unit/ci_governance/test_drift_history_store.py
@@ -1,0 +1,142 @@
+"""Tests for services.ci_governance.drift_history_store (S16.9)."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from services.ci_governance.drift_detector import DriftResult
+from services.ci_governance.drift_history_store import AppendResult, DriftHistoryStore
+
+
+def _make_result(**overrides) -> DriftResult:
+    defaults = dict(
+        drift_detected=True,
+        missing_contexts=["ci/lint"],
+        extra_contexts=["ci/extra"],
+        strict_differs=True,
+        strict_weakened=False,
+        enforce_admins_differs=True,
+        baseline_path=".github/protection-update-v2.json",
+        checked_at=1000.0,
+        summary="missing_contexts=['ci/lint']",
+    )
+    defaults.update(overrides)
+    return DriftResult(**defaults)
+
+
+class TestAppend:
+    def test_append_writes_single_jsonl_line_per_call(self, tmp_path: Path) -> None:
+        history = tmp_path / "h.jsonl"
+        store = DriftHistoryStore(str(history), clock=lambda: 1.0)
+        store.append_result(_make_result())
+        store.append_result(_make_result(drift_detected=False))
+        lines = history.read_text().splitlines()
+        assert len(lines) == 2
+
+    def test_append_returns_success_with_byte_count(self, tmp_path: Path) -> None:
+        history = tmp_path / "h.jsonl"
+        store = DriftHistoryStore(str(history), clock=lambda: 2.0)
+        res = store.append_result(_make_result())
+        assert isinstance(res, AppendResult)
+        assert res.success is True
+        assert res.bytes_written is not None
+        assert res.bytes_written > 0
+
+    def test_append_serialises_all_DriftResult_fields(self, tmp_path: Path) -> None:
+        history = tmp_path / "h.jsonl"
+        store = DriftHistoryStore(str(history), clock=lambda: 3.0)
+        result = _make_result()
+        store.append_result(result)
+        record = json.loads(history.read_text().strip())
+        assert record["drift_detected"] is True
+        assert record["missing_contexts"] == ["ci/lint"]
+        assert record["extra_contexts"] == ["ci/extra"]
+        assert record["strict_differs"] is True
+        assert record["strict_weakened"] is False
+        assert record["enforce_admins_differs"] is True
+        assert record["baseline_path"] == ".github/protection-update-v2.json"
+        assert record["checked_at"] == 1000.0
+        assert "summary" in record
+        assert record["ts"] == 3.0
+
+    def test_append_uses_injected_clock_for_appended_at(self, tmp_path: Path) -> None:
+        history = tmp_path / "h.jsonl"
+        clock = MagicMock(return_value=42.5)
+        store = DriftHistoryStore(str(history), clock=clock)
+        res = store.append_result(_make_result())
+        assert res.appended_at == 42.5
+        record = json.loads(history.read_text().strip())
+        assert record["ts"] == 42.5
+
+    def test_append_does_not_truncate_existing_history(self, tmp_path: Path) -> None:
+        history = tmp_path / "h.jsonl"
+        history.write_text('{"old":"entry","ts":0}\n')
+        store = DriftHistoryStore(str(history), clock=lambda: 5.0)
+        store.append_result(_make_result())
+        lines = history.read_text().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["old"] == "entry"
+        assert json.loads(lines[1])["drift_detected"] is True
+
+    def test_append_creates_parent_directory_if_missing(self, tmp_path: Path) -> None:
+        history = tmp_path / "sub" / "dir" / "h.jsonl"
+        store = DriftHistoryStore(str(history), clock=lambda: 6.0)
+        res = store.append_result(_make_result())
+        assert res.success is True
+        assert history.is_file()
+
+
+class TestRead:
+    def test_read_all_returns_well_formed_entries_in_order(self, tmp_path: Path) -> None:
+        history = tmp_path / "h.jsonl"
+        store = DriftHistoryStore(str(history), clock=MagicMock(side_effect=[1.0, 2.0, 3.0]))
+        for _ in range(3):
+            store.append_result(_make_result())
+        entries = store.read_all()
+        assert len(entries) == 3
+        assert entries[0]["ts"] == 1.0
+        assert entries[2]["ts"] == 3.0
+
+    def test_read_all_skips_malformed_lines_without_raising(self, tmp_path: Path) -> None:
+        history = tmp_path / "h.jsonl"
+        history.write_text(
+            '{"ts":1.0,"drift_detected":true}\nNOT JSON\n{"ts":2.0,"drift_detected":false}\n'
+        )
+        store = DriftHistoryStore(str(history), clock=lambda: 0)
+        entries = store.read_all()
+        assert len(entries) == 2
+        assert entries[0]["ts"] == 1.0
+        assert entries[1]["ts"] == 2.0
+
+    def test_read_since_filters_by_ts_inclusive_lower_bound(self, tmp_path: Path) -> None:
+        history = tmp_path / "h.jsonl"
+        history.write_text(
+            '{"ts":10.0,"drift_detected":true}\n'
+            '{"ts":20.0,"drift_detected":false}\n'
+            '{"ts":30.0,"drift_detected":true}\n'
+        )
+        store = DriftHistoryStore(str(history), clock=lambda: 0)
+        entries = store.read_since(20.0)
+        assert len(entries) == 2
+        assert entries[0]["ts"] == 20.0
+        assert entries[1]["ts"] == 30.0
+
+
+class TestFlock:
+    def test_append_uses_flock_LOCK_EX_for_cross_process_safety(self, tmp_path: Path) -> None:
+        history = tmp_path / "h.jsonl"
+        store = DriftHistoryStore(str(history), clock=lambda: 7.0)
+        with patch("services.ci_governance.drift_history_store.fcntl") as mock_fcntl:
+            mock_fcntl.LOCK_EX = fcntl.LOCK_EX
+            mock_fcntl.LOCK_UN = fcntl.LOCK_UN
+            mock_fcntl.flock = MagicMock()
+            # Use default appender — it calls fcntl.flock
+            store_patched = DriftHistoryStore(str(history), clock=lambda: 7.0)
+            store_patched.append_result(_make_result())
+            lock_calls = mock_fcntl.flock.call_args_list
+            assert len(lock_calls) == 2
+            assert lock_calls[0][0][1] == fcntl.LOCK_EX
+            assert lock_calls[1][0][1] == fcntl.LOCK_UN


### PR DESCRIPTION
S16.9 — drift history store. Persists DriftResult outcomes from S16.6 detector (#137) into local append-only JSONL for operator audit trail. Files (6 / +446 / -0): services/ci_governance/drift_history_store.py (DriftHistoryStore with append_result/read_all/read_since; flock LOCK_EX cross-process safety; no delete/update/truncate), services/ci_governance/factory.py extension (get_drift_history_store lru_cache singleton), scripts/ci-protection-drift-check.py extension (--history-path / --no-history flags; contextlib.suppress for cron safety), .env.example (append CI_GOVERNANCE_DRIFT_HISTORY_PATH), 10 store + 4 CLI unit tests. Pre-commit: full hook chain PASS (Auditor 12/12, ruff lint+format, bandit, IAM guard, semgrep, pytest). READ-ONLY against GitHub API; local file mutation only via atomic append. Operator merge: gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CI protection drift detection results can now be persisted to an append-only history file for auditing and analysis.
  * Added `--history-path` CLI flag to specify a custom history file location.
  * Added `--no-history` CLI flag to disable history recording.
  * Added `CI_GOVERNANCE_DRIFT_HISTORY_PATH` environment variable to configure the default history file path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CarmiBanxe/banxe-emi-stack/pull/140)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->