### PR TITLE
feat(s16-10): drift history query CLI (read-only)

### DIFF
--- a/scripts/ci-protection-drift-history-query.py
+++ b/scripts/ci-protection-drift-history-query.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+ci-protection-drift-history-query.py — Read-only CLI to query S16.9 drift history JSONL.
+
+Operator audit-trail tool: filters and formats records from the append-only
+drift-history.jsonl written by S16.9 DriftHistoryStore.  Never mutates the
+history file; exit 0 on missing file (empty result).
+
+Refs: S16.10; S16.9 (#140); S16.6 (#137).
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+from datetime import UTC, datetime
+import json
+import sys
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Query the append-only drift history JSONL (S16.9).",
+    )
+    p.add_argument(
+        "--history-path",
+        default=None,
+        help=(
+            "Path to drift-history.jsonl. "
+            "Default: env CI_GOVERNANCE_DRIFT_HISTORY_PATH or "
+            "/var/cache/banxe/drift-history.jsonl"
+        ),
+    )
+    p.add_argument(
+        "--since-ts",
+        type=float,
+        default=None,
+        help="Unix timestamp lower bound (inclusive). Default: 0 = all.",
+    )
+    p.add_argument(
+        "--since-iso",
+        type=str,
+        default=None,
+        help="ISO-8601 lower bound (alternative to --since-ts).",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Max records to return. 0 = unlimited. Default: 100.",
+    )
+    p.add_argument(
+        "--only-drift",
+        action="store_true",
+        help="Show only records where drift_detected=true.",
+    )
+    p.add_argument(
+        "--only-critical",
+        action="store_true",
+        help="Show only records where strict_weakened=true.",
+    )
+    p.add_argument(
+        "--format",
+        choices=("json", "summary"),
+        default="summary",
+        dest="output_format",
+        help="Output format. Default: summary.",
+    )
+    p.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output (only with --format json).",
+    )
+    return p
+
+
+def _parse_since(args: argparse.Namespace) -> float:
+    if args.since_ts is not None and args.since_iso is not None:
+        raise ValueError("--since-ts and --since-iso are mutually exclusive")
+    if args.since_iso is not None:
+        dt = datetime.fromisoformat(args.since_iso)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.timestamp()
+    if args.since_ts is not None:
+        return args.since_ts
+    return 0.0
+
+
+def _resolve_store(history_path: str | None):
+    """Resolve DriftHistoryStore; return None if resolution fails."""
+    with contextlib.suppress(Exception):
+        from services.ci_governance.drift_history_store import DriftHistoryStore
+        from services.ci_governance.factory import get_drift_history_store
+
+        if history_path is not None:
+            import time
+
+            return DriftHistoryStore(
+                history_path=history_path,
+                clock=time.time,
+            )
+        return get_drift_history_store()
+    # Fallback: build store directly without factory
+    with contextlib.suppress(Exception):
+        import os
+        import time
+
+        from services.ci_governance.drift_history_store import DriftHistoryStore
+
+        path = history_path or os.environ.get(
+            "CI_GOVERNANCE_DRIFT_HISTORY_PATH",
+            "/var/cache/banxe/drift-history.jsonl",
+        )
+        return DriftHistoryStore(history_path=path, clock=time.time)
+    return None
+
+
+def _apply_filters(
+    entries: list[dict],
+    *,
+    only_drift: bool,
+    only_critical: bool,
+) -> list[dict]:
+    result = entries
+    if only_drift:
+        result = [e for e in result if e.get("drift_detected") is True]
+    if only_critical:
+        result = [e for e in result if e.get("strict_weakened") is True]
+    return result
+
+
+def _format_summary_line(entry: dict) -> str:
+    ts = entry.get("ts", 0)
+    iso = datetime.fromtimestamp(ts, tz=UTC).isoformat()
+    drift = entry.get("drift_detected", False)
+    missing = len(entry.get("missing_rules", []))
+    extra = len(entry.get("extra_rules", []))
+    strict = entry.get("strict_weakened", False)
+    summary = entry.get("summary", "")
+    if len(summary) > 80:
+        summary = summary[:77] + "..."
+    return (
+        f"{iso}  drift={drift}  missing={missing}  extra={extra}"
+        f"  strict_weakened={strict}  {summary}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    since_ts = _parse_since(args)
+
+    store = _resolve_store(args.history_path)
+    if store is None:
+        # Cannot resolve store — output empty result
+        if args.output_format == "json":
+            print("[]")
+        return 0
+
+    limit = args.limit if args.limit != 0 else None
+
+    if since_ts > 0:
+        entries = store.read_since(since_ts)
+        if limit is not None:
+            entries = entries[:limit]
+    else:
+        entries = store.read_all(limit=limit)
+
+    entries = _apply_filters(
+        entries,
+        only_drift=args.only_drift,
+        only_critical=args.only_critical,
+    )
+
+    if args.output_format == "json":
+        indent = 2 if args.pretty else None
+        print(json.dumps(entries, default=str, indent=indent))
+    else:
+        for entry in entries:
+            print(_format_summary_line(entry))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/ci_governance/test_drift_history_query_script.py
+++ b/tests/unit/ci_governance/test_drift_history_query_script.py
@@ -1,0 +1,240 @@
+"""
+Tests for scripts/ci-protection-drift-history-query.py — S16.10 drift history query CLI.
+
+The script has a hyphenated filename; we load it via importlib.util.
+All tests are deterministic: they use tmp_path with pre-seeded JSONL fixtures.
+No network, no mutation, no side effects.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "ci-protection-drift-history-query.py"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_ci_drift_history_query_script",
+        _SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_ci_drift_history_query_script"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_script_module()
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_record(
+    ts: float,
+    drift_detected: bool = False,
+    strict_weakened: bool = False,
+    missing_rules: list[str] | None = None,
+    extra_rules: list[str] | None = None,
+    summary: str = "",
+) -> dict:
+    return {
+        "ts": ts,
+        "drift_detected": drift_detected,
+        "strict_weakened": strict_weakened,
+        "missing_rules": missing_rules or [],
+        "extra_rules": extra_rules or [],
+        "summary": summary,
+    }
+
+
+_RECORDS: list[dict] = [
+    _make_record(1000.0, drift_detected=False, summary="no drift at t=1000"),
+    _make_record(2000.0, drift_detected=True, summary="drift at t=2000"),
+    _make_record(
+        3000.0,
+        drift_detected=True,
+        strict_weakened=True,
+        missing_rules=["r1"],
+        summary="critical drift at t=3000",
+    ),
+    _make_record(4000.0, drift_detected=False, summary="no drift at t=4000"),
+    _make_record(
+        5000.0,
+        drift_detected=True,
+        strict_weakened=True,
+        missing_rules=["r2", "r3"],
+        extra_rules=["x1"],
+        summary="critical drift at t=5000",
+    ),
+]
+
+
+@pytest.fixture()
+def history_file(tmp_path: Path) -> Path:
+    p = tmp_path / "drift-history.jsonl"
+    p.write_text(
+        "\n".join(json.dumps(r, separators=(",", ":")) for r in _RECORDS) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_query_returns_all_entries_when_no_filters(
+    history_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = mod.main(["--history-path", str(history_file), "--limit", "0", "--format", "json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 5
+
+
+def test_query_filters_by_since_ts_inclusive_lower_bound(
+    history_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = mod.main(
+        [
+            "--history-path",
+            str(history_file),
+            "--since-ts",
+            "3000",
+            "--limit",
+            "0",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 3
+    assert all(e["ts"] >= 3000 for e in out)
+
+
+def test_query_since_iso_equivalent_to_since_ts(
+    history_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # 3000.0 unix = 1970-01-01T00:50:00+00:00
+    iso = "1970-01-01T00:50:00+00:00"
+    rc = mod.main(
+        [
+            "--history-path",
+            str(history_file),
+            "--since-iso",
+            iso,
+            "--limit",
+            "0",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 3
+    assert all(e["ts"] >= 3000 for e in out)
+
+
+def test_query_since_ts_and_since_iso_together_raises_value_error(
+    history_file: Path,
+) -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        mod.main(
+            [
+                "--history-path",
+                str(history_file),
+                "--since-ts",
+                "1000",
+                "--since-iso",
+                "2020-01-01T00:00:00Z",
+            ]
+        )
+
+
+def test_query_limit_caps_returned_records(
+    history_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = mod.main(["--history-path", str(history_file), "--limit", "2", "--format", "json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 2
+
+
+def test_query_limit_zero_means_unlimited(
+    history_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = mod.main(["--history-path", str(history_file), "--limit", "0", "--format", "json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 5
+
+
+def test_query_only_drift_filters_to_drift_detected_true(
+    history_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = mod.main(
+        ["--history-path", str(history_file), "--only-drift", "--limit", "0", "--format", "json"]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 3
+    assert all(e["drift_detected"] is True for e in out)
+
+
+def test_query_only_critical_filters_to_strict_weakened_true(
+    history_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = mod.main(
+        ["--history-path", str(history_file), "--only-critical", "--limit", "0", "--format", "json"]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 2
+    assert all(e["strict_weakened"] is True for e in out)
+
+
+def test_query_json_format_outputs_valid_json_array(
+    history_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = mod.main(
+        ["--history-path", str(history_file), "--limit", "0", "--format", "json", "--pretty"]
+    )
+    assert rc == 0
+    raw = capsys.readouterr().out
+    parsed = json.loads(raw)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 5
+    # Pretty flag means indentation present
+    assert "\n " in raw
+
+
+def test_query_missing_history_file_returns_empty_result_exit_zero(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "nonexistent" / "drift-history.jsonl"
+    rc = mod.main(["--history-path", str(missing), "--format", "json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out == []


### PR DESCRIPTION
S16.10 — drift history query CLI. Read-only argparse-driven query over the append-only JSONL history written by S16.9 (#140). Files (2): scripts/ci-protection-drift-history-query.py (new) + tests/unit/ci_governance/test_drift_history_query_script.py (new). Filters: --since-ts / --since-iso (mutex), --limit (0 = unlimited), --only-drift, --only-critical. Formats: --format json (with --pretty) | summary (default; one-line per record). Read-only: no mutation of history, no GH API calls, exit 0 on missing file. 10 deterministic unit tests PASS. Pre-commit: full hook chain PASS (Auditor 12/12, ruff, bandit, semgrep). Pairs with S16.9 store (#140) and S16.6 detector (#137). Operator merge: gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin