### PR TITLE
feat(s16-11): drift metrics exporter for CI governance history

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,3 +164,8 @@ CI_GOVERNANCE_SNAPSHOT_PATH=/var/cache/banxe/last-protection-snapshot.json
 # Append-only JSONL file for drift detection audit trail.
 # Each run of ci-protection-drift-check.py appends one line (unless --no-history).
 CI_GOVERNANCE_DRIFT_HISTORY_PATH=/var/cache/banxe/drift-history.jsonl
+
+# === CI governance drift metrics exporter (S16.11) ===
+# Prometheus textfile path for node_exporter --collector.textfile.directory scraping.
+# Atomic write (tmpfile + rename); read-only against drift history.
+CI_GOVERNANCE_METRICS_TEXTFILE_PATH=/var/lib/node_exporter/textfile_collector/banxe_ci_drift.prom

--- a/scripts/ci-protection-drift-metrics-export.py
+++ b/scripts/ci-protection-drift-metrics-export.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+ci-protection-drift-metrics-export.py — CLI for cron-driven Prometheus textfile export (S16.11).
+
+Reads the S16.9 drift-history JSONL and writes a .prom file that
+node_exporter --collector.textfile.directory can scrape. No HTTP server,
+no push gateway, no new dependency.
+
+Exit codes:
+  0 : export succeeded (or no history — empty metrics emitted)
+  1 : write failure
+
+Refs: S16.11; S16.9 (#140); S16.6 (#137).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import sys
+
+_DEFAULT_TEXTFILE_PATH = "/var/lib/node_exporter/textfile_collector/banxe_ci_drift.prom"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Export drift history metrics as Prometheus textfile (S16.11).",
+    )
+    p.add_argument(
+        "--textfile-path",
+        default=None,
+        help=(
+            "Path to write .prom file. "
+            "Default: env CI_GOVERNANCE_METRICS_TEXTFILE_PATH or "
+            f"{_DEFAULT_TEXTFILE_PATH}"
+        ),
+    )
+    p.add_argument(
+        "--window-seconds",
+        type=int,
+        default=86400,
+        help="History window in seconds. Default: 86400 (24h).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    textfile_path = args.textfile_path or os.environ.get(
+        "CI_GOVERNANCE_METRICS_TEXTFILE_PATH",
+        _DEFAULT_TEXTFILE_PATH,
+    )
+
+    from services.ci_governance.factory import get_drift_metrics_exporter
+
+    exporter = get_drift_metrics_exporter()
+    result = exporter.export(
+        textfile_path=textfile_path,
+        window_seconds=args.window_seconds,
+    )
+
+    print(json.dumps(dataclasses.asdict(result), default=str))
+    return 0 if result.success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/ci_governance/drift_metrics_exporter.py
+++ b/services/ci_governance/drift_metrics_exporter.py
@@ -1,0 +1,138 @@
+"""
+drift_metrics_exporter.py — Prometheus textfile-format metrics from S16.9 drift history (S16.11).
+
+Reads the append-only JSONL history written by DriftHistoryStore and produces a
+Prometheus textfile (.prom) that node_exporter --collector.textfile.directory
+can scrape. No HTTP server, no push gateway, no new dependency — stdlib only.
+
+Design constraints:
+  - READ-ONLY against history JSONL — never mutates it.
+  - Atomic write: tmpfile in same dir + os.replace (matches S16.8 pattern).
+  - Always emits all 7 metric series (zero when no entries).
+  - Never raises on empty history; returns ExportResult success=True.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import time
+
+from services.ci_governance.drift_history_store import DriftHistoryStore
+
+FileWriter = Callable[[str, str], None]
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    """Outcome of a single export operation."""
+
+    success: bool
+    textfile_path: str
+    exported_at: float
+    entries_scanned: int
+    byte_size: int | None = None
+    error: str | None = None
+
+
+def _default_file_writer(target_path: str, body: str) -> None:
+    """Atomic write: tmpfile sibling -> fsync -> os.replace."""
+    target = Path(target_path)
+    parent = target.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp = parent / f"{target.name}.tmp.{os.getpid()}.{int(time.time_ns())}"
+    try:
+        tmp.write_text(body, encoding="utf-8")
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def _render_metrics(
+    entries: list[dict],
+    window_seconds: int,
+    export_ts: float,
+) -> str:
+    drift_count = sum(1 for e in entries if e.get("drift_detected") is True)
+    strict_count = sum(1 for e in entries if e.get("strict_weakened") is True)
+
+    if entries:
+        latest = max(entries, key=lambda e: e.get("ts", 0))
+        last_check_ts = latest.get("ts", 0.0)
+        missing_last = len(latest.get("missing_rules", []))
+        extra_last = len(latest.get("extra_rules", []))
+    else:
+        last_check_ts = 0.0
+        missing_last = 0
+        extra_last = 0
+
+    ws = str(window_seconds)
+    lines = [
+        "# HELP banxe_ci_drift_events_total Drift events scanned in window",
+        "# TYPE banxe_ci_drift_events_total counter",
+        f'banxe_ci_drift_events_total{{window_seconds="{ws}"}} {len(entries)}',
+        "# HELP banxe_ci_drift_detected_total Drift events with drift_detected=true",
+        "# TYPE banxe_ci_drift_detected_total counter",
+        f'banxe_ci_drift_detected_total{{window_seconds="{ws}"}} {drift_count}',
+        "# HELP banxe_ci_drift_strict_weakened_total Drift events with strict_weakened=true",
+        "# TYPE banxe_ci_drift_strict_weakened_total counter",
+        f'banxe_ci_drift_strict_weakened_total{{window_seconds="{ws}"}} {strict_count}',
+        "# HELP banxe_ci_drift_missing_contexts_last_count Latest missing_contexts count",
+        "# TYPE banxe_ci_drift_missing_contexts_last_count gauge",
+        f"banxe_ci_drift_missing_contexts_last_count {missing_last}",
+        "# HELP banxe_ci_drift_extra_contexts_last_count Latest extra_contexts count",
+        "# TYPE banxe_ci_drift_extra_contexts_last_count gauge",
+        f"banxe_ci_drift_extra_contexts_last_count {extra_last}",
+        "# HELP banxe_ci_drift_last_check_timestamp_seconds Unix ts of latest drift record",
+        "# TYPE banxe_ci_drift_last_check_timestamp_seconds gauge",
+        f"banxe_ci_drift_last_check_timestamp_seconds {last_check_ts}",
+        "# HELP banxe_ci_drift_exporter_last_export_timestamp_seconds Unix ts of this export",
+        "# TYPE banxe_ci_drift_exporter_last_export_timestamp_seconds gauge",
+        f"banxe_ci_drift_exporter_last_export_timestamp_seconds {export_ts}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+class DriftMetricsExporter:
+    """Export S16.9 drift history as Prometheus textfile-format metrics."""
+
+    def __init__(
+        self,
+        history_store: DriftHistoryStore,
+        clock: Callable[[], float],
+        file_writer: FileWriter | None = None,
+    ) -> None:
+        self._history_store = history_store
+        self._clock = clock
+        self._file_writer: FileWriter = file_writer or _default_file_writer
+
+    def export(
+        self,
+        textfile_path: str,
+        window_seconds: int = 86400,
+    ) -> ExportResult:
+        """Read history, aggregate metrics, write .prom file. Never raises."""
+        now = self._clock()
+        try:
+            since_ts = now - window_seconds
+            entries = self._history_store.read_since(since_ts)
+            body = _render_metrics(entries, window_seconds, now)
+            self._file_writer(textfile_path, body)
+            return ExportResult(
+                success=True,
+                textfile_path=textfile_path,
+                exported_at=now,
+                entries_scanned=len(entries),
+                byte_size=len(body.encode("utf-8")),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ExportResult(
+                success=False,
+                textfile_path=textfile_path,
+                exported_at=now,
+                entries_scanned=0,
+                error=str(exc),
+            )

--- a/services/ci_governance/factory.py
+++ b/services/ci_governance/factory.py
@@ -131,6 +131,17 @@ def get_drift_history_store():
 
 
 @lru_cache(maxsize=1)
+def get_drift_metrics_exporter():
+    """Singleton DriftMetricsExporter wired to the shared history store (S16.11)."""
+    from services.ci_governance.drift_metrics_exporter import DriftMetricsExporter
+
+    return DriftMetricsExporter(
+        history_store=get_drift_history_store(),
+        clock=time.time,
+    )
+
+
+@lru_cache(maxsize=1)
 def get_snapshot_writer():
     """Singleton ProtectionSnapshotWriter wired to the configured reader.
 

--- a/tests/unit/ci_governance/test_drift_metrics_export_script.py
+++ b/tests/unit/ci_governance/test_drift_metrics_export_script.py
@@ -1,0 +1,153 @@
+"""
+Tests for scripts/ci-protection-drift-metrics-export.py — S16.11 CLI.
+
+The script has a hyphenated filename; we load it via importlib.util.
+All tests are deterministic: monkeypatched factory, tmp_path, no network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+from services.ci_governance.drift_metrics_exporter import (
+    DriftMetricsExporter,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "ci-protection-drift-metrics-export.py"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_ci_drift_metrics_export_script",
+        _SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_ci_drift_metrics_export_script"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_script_module()
+
+_FIXED_CLOCK = 100_000.0
+
+
+# ---------------------------------------------------------------------------
+# FakeHistoryStore for deterministic exporter
+# ---------------------------------------------------------------------------
+
+
+class _FakeHistoryStore:
+    def read_all(self, limit: int | None = None) -> list[dict]:
+        return []
+
+    def read_since(self, since_ts: float) -> list[dict]:
+        return []
+
+
+def _make_exporter(file_writer=None):
+    return DriftMetricsExporter(
+        history_store=_FakeHistoryStore(),
+        clock=lambda: _FIXED_CLOCK,
+        file_writer=file_writer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_script_uses_default_textfile_path_when_env_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("CI_GOVERNANCE_METRICS_TEXTFILE_PATH", raising=False)
+
+    captured_paths: list[str] = []
+
+    def spy_writer(path: str, body: str) -> None:
+        captured_paths.append(path)
+
+    exp = _make_exporter(file_writer=spy_writer)
+    monkeypatch.setattr(
+        "services.ci_governance.factory.get_drift_metrics_exporter",
+        lambda: exp,
+    )
+    rc = mod.main([])
+    assert rc == 0
+    assert captured_paths[0] == mod._DEFAULT_TEXTFILE_PATH
+
+
+def test_script_uses_env_path_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    custom = str(tmp_path / "custom.prom")
+    monkeypatch.setenv("CI_GOVERNANCE_METRICS_TEXTFILE_PATH", custom)
+
+    captured_paths: list[str] = []
+
+    def spy_writer(path: str, body: str) -> None:
+        captured_paths.append(path)
+
+    exp = _make_exporter(file_writer=spy_writer)
+    monkeypatch.setattr(
+        "services.ci_governance.factory.get_drift_metrics_exporter",
+        lambda: exp,
+    )
+    rc = mod.main([])
+    assert rc == 0
+    assert captured_paths[0] == custom
+
+
+def test_script_uses_default_window_86400_when_flag_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = str(tmp_path / "metrics.prom")
+
+    captured_windows: list[int] = []
+    original_export = DriftMetricsExporter.export
+
+    def tracking_export(self, textfile_path, window_seconds=86400):
+        captured_windows.append(window_seconds)
+        return original_export(self, textfile_path, window_seconds)
+
+    exp = _make_exporter(file_writer=lambda p, b: None)
+    monkeypatch.setattr(
+        "services.ci_governance.factory.get_drift_metrics_exporter",
+        lambda: exp,
+    )
+    monkeypatch.setattr(DriftMetricsExporter, "export", tracking_export)
+    rc = mod.main(["--textfile-path", target])
+    assert rc == 0
+    assert captured_windows[0] == 86400
+
+
+def test_script_exits_0_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = str(tmp_path / "metrics.prom")
+    exp = _make_exporter(file_writer=lambda p, b: None)
+    monkeypatch.setattr(
+        "services.ci_governance.factory.get_drift_metrics_exporter",
+        lambda: exp,
+    )
+    rc = mod.main(["--textfile-path", target])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["success"] is True

--- a/tests/unit/ci_governance/test_drift_metrics_exporter.py
+++ b/tests/unit/ci_governance/test_drift_metrics_exporter.py
@@ -1,0 +1,238 @@
+"""
+Tests for services/ci_governance/drift_metrics_exporter.py — S16.11.
+
+All tests are deterministic: FakeHistoryStore with canned entries, fixed clock.
+No network, no mutation, no side effects beyond tmp_path writes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from services.ci_governance.drift_metrics_exporter import (
+    DriftMetricsExporter,
+)
+
+# ---------------------------------------------------------------------------
+# FakeHistoryStore — deterministic substitute for DriftHistoryStore
+# ---------------------------------------------------------------------------
+
+
+class FakeHistoryStore:
+    """In-memory history store for test isolation."""
+
+    def __init__(self, entries: list[dict]) -> None:
+        self._entries = list(entries)
+
+    def read_all(self, limit: int | None = None) -> list[dict]:
+        if limit is not None:
+            return self._entries[:limit]
+        return list(self._entries)
+
+    def read_since(self, since_ts: float) -> list[dict]:
+        return [e for e in self._entries if e.get("ts", 0) >= since_ts]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_FIXED_CLOCK = 100_000.0
+
+_ENTRIES: list[dict] = [
+    {
+        "ts": 90_000.0,
+        "drift_detected": False,
+        "strict_weakened": False,
+        "missing_rules": [],
+        "extra_rules": [],
+        "summary": "no drift",
+    },
+    {
+        "ts": 95_000.0,
+        "drift_detected": True,
+        "strict_weakened": False,
+        "missing_rules": ["r1"],
+        "extra_rules": [],
+        "summary": "drift found",
+    },
+    {
+        "ts": 98_000.0,
+        "drift_detected": True,
+        "strict_weakened": True,
+        "missing_rules": ["r1", "r2"],
+        "extra_rules": ["x1"],
+        "summary": "critical drift",
+    },
+    {
+        "ts": 99_000.0,
+        "drift_detected": False,
+        "strict_weakened": False,
+        "missing_rules": [],
+        "extra_rules": ["x2"],
+        "summary": "resolved",
+    },
+]
+
+
+@pytest.fixture()
+def store() -> FakeHistoryStore:
+    return FakeHistoryStore(_ENTRIES)
+
+
+@pytest.fixture()
+def exporter(store: FakeHistoryStore) -> DriftMetricsExporter:
+    return DriftMetricsExporter(
+        history_store=store,
+        clock=lambda: _FIXED_CLOCK,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_export_writes_textfile_at_target_path(
+    exporter: DriftMetricsExporter,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "metrics.prom"
+    result = exporter.export(str(target))
+    assert result.success is True
+    assert target.is_file()
+    assert result.textfile_path == str(target)
+
+
+def test_export_uses_atomic_tmpfile_then_rename(
+    store: FakeHistoryStore,
+    tmp_path: Path,
+) -> None:
+    """Verify custom file_writer is called (proves injection slot works)."""
+    calls: list[tuple[str, str]] = []
+
+    def tracking_writer(path: str, body: str) -> None:
+        calls.append((path, body))
+
+    exp = DriftMetricsExporter(
+        history_store=store,
+        clock=lambda: _FIXED_CLOCK,
+        file_writer=tracking_writer,
+    )
+    target = str(tmp_path / "metrics.prom")
+    result = exp.export(target)
+    assert result.success is True
+    assert len(calls) == 1
+    assert calls[0][0] == target
+
+
+def test_export_emits_all_metric_help_and_type_lines(
+    exporter: DriftMetricsExporter,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "metrics.prom"
+    exporter.export(str(target))
+    content = target.read_text(encoding="utf-8")
+
+    expected_metrics = [
+        "banxe_ci_drift_events_total",
+        "banxe_ci_drift_detected_total",
+        "banxe_ci_drift_strict_weakened_total",
+        "banxe_ci_drift_missing_contexts_last_count",
+        "banxe_ci_drift_extra_contexts_last_count",
+        "banxe_ci_drift_last_check_timestamp_seconds",
+        "banxe_ci_drift_exporter_last_export_timestamp_seconds",
+    ]
+    for metric in expected_metrics:
+        assert f"# HELP {metric}" in content
+        assert f"# TYPE {metric}" in content
+
+
+def test_export_counts_drift_detected_correctly(
+    exporter: DriftMetricsExporter,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "metrics.prom"
+    exporter.export(str(target), window_seconds=86400)
+    content = target.read_text(encoding="utf-8")
+    # 2 entries have drift_detected=True (ts=95000, ts=98000)
+    assert 'banxe_ci_drift_detected_total{window_seconds="86400"} 2' in content
+
+
+def test_export_counts_strict_weakened_correctly(
+    exporter: DriftMetricsExporter,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "metrics.prom"
+    exporter.export(str(target), window_seconds=86400)
+    content = target.read_text(encoding="utf-8")
+    # 1 entry has strict_weakened=True (ts=98000)
+    assert 'banxe_ci_drift_strict_weakened_total{window_seconds="86400"} 1' in content
+
+
+def test_export_uses_window_seconds_to_filter_history(
+    exporter: DriftMetricsExporter,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "metrics.prom"
+    # window=5000 → since_ts = 100000 - 5000 = 95000 → entries at 95k, 98k, 99k
+    exporter.export(str(target), window_seconds=5000)
+    content = target.read_text(encoding="utf-8")
+    assert 'banxe_ci_drift_events_total{window_seconds="5000"} 3' in content
+
+
+def test_export_emits_zero_metrics_when_history_empty(
+    tmp_path: Path,
+) -> None:
+    empty_store = FakeHistoryStore([])
+    exp = DriftMetricsExporter(
+        history_store=empty_store,
+        clock=lambda: _FIXED_CLOCK,
+    )
+    target = tmp_path / "metrics.prom"
+    result = exp.export(str(target))
+    assert result.success is True
+    assert result.entries_scanned == 0
+    content = target.read_text(encoding="utf-8")
+    assert 'banxe_ci_drift_events_total{window_seconds="86400"} 0' in content
+    assert "banxe_ci_drift_last_check_timestamp_seconds 0.0" in content
+
+
+def test_export_emits_last_check_timestamp_from_latest_entry(
+    exporter: DriftMetricsExporter,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "metrics.prom"
+    exporter.export(str(target), window_seconds=86400)
+    content = target.read_text(encoding="utf-8")
+    # Latest entry ts = 99000.0
+    assert "banxe_ci_drift_last_check_timestamp_seconds 99000.0" in content
+
+
+def test_export_includes_exporter_last_export_timestamp_from_clock(
+    exporter: DriftMetricsExporter,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "metrics.prom"
+    exporter.export(str(target))
+    content = target.read_text(encoding="utf-8")
+    assert f"banxe_ci_drift_exporter_last_export_timestamp_seconds {_FIXED_CLOCK}" in content
+
+
+def test_export_returns_failure_when_write_raises_clear_error(
+    store: FakeHistoryStore,
+) -> None:
+    def failing_writer(path: str, body: str) -> None:
+        raise OSError("disk full")
+
+    exp = DriftMetricsExporter(
+        history_store=store,
+        clock=lambda: _FIXED_CLOCK,
+        file_writer=failing_writer,
+    )
+    result = exp.export("/nonexistent/metrics.prom")
+    assert result.success is False
+    assert result.error is not None
+    assert "disk full" in result.error


### PR DESCRIPTION
## S16.11 — drift metrics exporter

### What
Adds a read-only drift metrics exporter for CI governance history, with atomic Prometheus `.prom` output and no mutation of history, GitHub API state, or repository state.

### Scope
- services/ci_governance/drift_metrics_exporter.py
- services/ci_governance/factory.py
- scripts/ci-protection-drift-metrics-export.py
- .env.example
- tests/unit/ci_governance/test_drift_metrics_exporter.py
- tests/unit/ci_governance/test_drift_metrics_export_script.py

### Validation
- 14/14 targeted tests PASS
- 88/88 full suite PASS
- ruff PASS
- bandit PASS
- semgrep PASS
- Spec-First Auditor v2 PASS

### Metrics
- banxe_ci_drift_events_total
- banxe_ci_drift_detected_total
- banxe_ci_drift_strict_weakened_total
- banxe_ci_drift_missing_contexts_last_count
- banxe_ci_drift_extra_contexts_last_count
- banxe_ci_drift_last_check_timestamp_seconds
- banxe_ci_drift_exporter_last_export_timestamp_seconds

### Safety
- Read-only history input
- Atomic `.prom` write
- No production deploy performed
