### PR TITLE
feat(s16-12): drift HTML report renderer (read-only static page)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -169,3 +169,8 @@ CI_GOVERNANCE_DRIFT_HISTORY_PATH=/var/cache/banxe/drift-history.jsonl
 # Prometheus textfile path for node_exporter --collector.textfile.directory scraping.
 # Atomic write (tmpfile + rename); read-only against drift history.
 CI_GOVERNANCE_METRICS_TEXTFILE_PATH=/var/lib/node_exporter/textfile_collector/banxe_ci_drift.prom
+
+# === CI governance drift HTML report (S16.12) ===
+# Static HTML5 report rendered from drift history. Open in browser, no server.
+# Atomic write (tmpfile + rename); read-only against drift history.
+CI_GOVERNANCE_HTML_REPORT_PATH=/var/cache/banxe/drift-report.html

--- a/scripts/ci-protection-drift-html-render.py
+++ b/scripts/ci-protection-drift-html-render.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+ci-protection-drift-html-render.py — CLI for cron-driven HTML drift report (S16.12).
+
+Reads the S16.9 drift-history JSONL and writes a static HTML5 report file
+that operators can open in any browser. No server, no JS, no new dependency.
+
+Exit codes:
+  0 : render succeeded (or no history — placeholder page emitted)
+  1 : write failure
+
+Refs: S16.12; S16.9 (#140); S16.6 (#137).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import sys
+
+_DEFAULT_REPORT_PATH = "/var/cache/banxe/drift-report.html"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Render drift history as static HTML report (S16.12).",
+    )
+    p.add_argument(
+        "--report-path",
+        default=None,
+        help=(
+            "Path to write HTML report. "
+            "Default: env CI_GOVERNANCE_HTML_REPORT_PATH or "
+            f"{_DEFAULT_REPORT_PATH}"
+        ),
+    )
+    p.add_argument(
+        "--window-seconds",
+        type=int,
+        default=604800,
+        help="History window in seconds. Default: 604800 (7 days).",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=500,
+        help="Max entries to render. Default: 500.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    report_path = args.report_path or os.environ.get(
+        "CI_GOVERNANCE_HTML_REPORT_PATH",
+        _DEFAULT_REPORT_PATH,
+    )
+
+    from services.ci_governance.factory import get_drift_html_renderer
+
+    renderer = get_drift_html_renderer()
+    result = renderer.render(
+        report_path=report_path,
+        window_seconds=args.window_seconds,
+        limit=args.limit,
+    )
+
+    print(json.dumps(dataclasses.asdict(result), default=str))
+    return 0 if result.success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/ci_governance/drift_html_renderer.py
+++ b/services/ci_governance/drift_html_renderer.py
@@ -1,0 +1,206 @@
+"""
+drift_html_renderer.py — Static HTML report from S16.9 drift history (S16.12).
+
+Renders the append-only JSONL history into a single static HTML5 page that
+operators can open in any browser. No server, no JS, no external assets.
+
+Design constraints:
+  - READ-ONLY against history JSONL — never mutates it.
+  - Atomic write: tmpfile in same dir + os.replace (matches S16.8 pattern).
+  - All user-controlled fields pass through html.escape() — XSS-safe.
+  - Empty history → valid HTML with "no entries" placeholder; success=True.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import html
+import os
+from pathlib import Path
+import time
+
+from services.ci_governance.drift_history_store import DriftHistoryStore
+
+FileWriter = Callable[[str, str], None]
+
+
+@dataclass(frozen=True)
+class RenderResult:
+    """Outcome of a single render operation."""
+
+    success: bool
+    report_path: str
+    rendered_at: float
+    entries_rendered: int
+    byte_size: int | None = None
+    error: str | None = None
+
+
+def _default_file_writer(target_path: str, body: str) -> None:
+    """Atomic write: tmpfile sibling -> os.replace."""
+    target = Path(target_path)
+    parent = target.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp = parent / f"{target.name}.tmp.{os.getpid()}.{int(time.time_ns())}"
+    try:
+        tmp.write_text(body, encoding="utf-8")
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+_STYLE = """\
+body{font-family:system-ui,sans-serif;margin:2em;background:#fafafa;color:#222}
+h1{font-size:1.4em}
+.meta{color:#666;font-size:.85em;margin-bottom:1.5em}
+.cards{display:flex;gap:1em;flex-wrap:wrap;margin-bottom:1.5em}
+.card{background:#fff;border:1px solid #ddd;border-radius:6px;padding:1em 1.4em;min-width:140px}
+.card .val{font-size:1.6em;font-weight:700}
+.card .lbl{font-size:.8em;color:#888}
+table{border-collapse:collapse;width:100%;font-size:.88em}
+th,td{border:1px solid #ddd;padding:6px 10px;text-align:left}
+th{background:#f0f0f0}
+tr:nth-child(even){background:#f9f9f9}
+.badge{display:inline-block;padding:2px 8px;border-radius:3px;font-size:.8em;font-weight:600}
+.badge-yes{background:#fee;color:#c00}
+.badge-no{background:#efe;color:#060}
+.empty{text-align:center;padding:3em;color:#999;font-style:italic}
+"""
+
+
+def _badge(value: bool) -> str:
+    cls = "badge-yes" if value else "badge-no"
+    text = "YES" if value else "no"
+    return f'<span class="badge {cls}">{text}</span>'
+
+
+def _ts_iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=UTC).isoformat()
+
+
+def _render_html(
+    entries: list[dict],
+    window_seconds: int,
+    rendered_at: float,
+) -> str:
+    rendered_iso = _ts_iso(rendered_at)
+    drift_count = sum(1 for e in entries if e.get("drift_detected") is True)
+    strict_count = sum(1 for e in entries if e.get("strict_weakened") is True)
+    latest_ts = max((e.get("ts", 0) for e in entries), default=0.0)
+    latest_iso = _ts_iso(latest_ts) if latest_ts > 0 else "n/a"
+
+    parts: list[str] = []
+    parts.append("<!doctype html>")
+    parts.append('<html lang="en"><head>')
+    parts.append('<meta charset="utf-8">')
+    parts.append("<title>Banxe CI drift report</title>")
+    parts.append(f"<style>{_STYLE}</style>")
+    parts.append("</head><body>")
+    parts.append("<h1>Banxe CI drift report</h1>")
+    parts.append(
+        f'<div class="meta">Generated: {rendered_iso} &middot; '
+        f"Window: {window_seconds}s &middot; "
+        f"Entries: {len(entries)}</div>"
+    )
+
+    # Summary cards
+    parts.append('<div class="cards">')
+    for label, val in [
+        ("Total events", str(len(entries))),
+        ("Drift detected", str(drift_count)),
+        ("Strict weakened", str(strict_count)),
+        ("Latest check", latest_iso),
+    ]:
+        parts.append(
+            f'<div class="card"><div class="val">{html.escape(val)}</div>'
+            f'<div class="lbl">{html.escape(label)}</div></div>'
+        )
+    parts.append("</div>")
+
+    # Table
+    if entries:
+        parts.append("<table><thead><tr>")
+        for hdr in [
+            "Timestamp",
+            "Drift",
+            "Missing contexts",
+            "Extra contexts",
+            "Strict weakened",
+            "Summary",
+        ]:
+            parts.append(f"<th>{hdr}</th>")
+        parts.append("</tr></thead><tbody>")
+        for e in entries:
+            ts_str = _ts_iso(e.get("ts", 0))
+            drift = e.get("drift_detected", False)
+            missing = ", ".join(html.escape(str(c)) for c in e.get("missing_rules", []))
+            extra = ", ".join(html.escape(str(c)) for c in e.get("extra_rules", []))
+            strict = e.get("strict_weakened", False)
+            summary_raw = str(e.get("summary", ""))
+            if len(summary_raw) > 120:
+                summary_raw = summary_raw[:117] + "..."
+            summary = html.escape(summary_raw)
+            parts.append("<tr>")
+            parts.append(f"<td>{ts_str}</td>")
+            parts.append(f"<td>{_badge(drift)}</td>")
+            parts.append(f"<td>{missing}</td>")
+            parts.append(f"<td>{extra}</td>")
+            parts.append(f"<td>{_badge(strict)}</td>")
+            parts.append(f"<td>{summary}</td>")
+            parts.append("</tr>")
+        parts.append("</tbody></table>")
+    else:
+        parts.append('<div class="empty">No drift entries in window.</div>')
+
+    parts.append("</body></html>\n")
+    return "\n".join(parts)
+
+
+class DriftHtmlRenderer:
+    """Render S16.9 drift history as a static HTML5 report page."""
+
+    def __init__(
+        self,
+        history_store: DriftHistoryStore,
+        clock: Callable[[], float],
+        file_writer: FileWriter | None = None,
+    ) -> None:
+        self._history_store = history_store
+        self._clock = clock
+        self._file_writer: FileWriter = file_writer or _default_file_writer
+
+    def render(
+        self,
+        report_path: str,
+        window_seconds: int = 604800,
+        limit: int = 500,
+    ) -> RenderResult:
+        """Read history, render HTML, write file. Never raises."""
+        now = self._clock()
+        try:
+            since_ts = now - window_seconds
+            entries = self._history_store.read_since(since_ts)
+            # most-recent first, cap to limit
+            entries.sort(key=lambda e: e.get("ts", 0), reverse=True)
+            if limit > 0:
+                entries = entries[:limit]
+            body = _render_html(entries, window_seconds, now)
+            self._file_writer(report_path, body)
+            return RenderResult(
+                success=True,
+                report_path=report_path,
+                rendered_at=now,
+                entries_rendered=len(entries),
+                byte_size=len(body.encode("utf-8")),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return RenderResult(
+                success=False,
+                report_path=report_path,
+                rendered_at=now,
+                entries_rendered=0,
+                error=str(exc),
+            )

--- a/services/ci_governance/factory.py
+++ b/services/ci_governance/factory.py
@@ -142,6 +142,17 @@ def get_drift_metrics_exporter():
 
 
 @lru_cache(maxsize=1)
+def get_drift_html_renderer():
+    """Singleton DriftHtmlRenderer wired to the shared history store (S16.12)."""
+    from services.ci_governance.drift_html_renderer import DriftHtmlRenderer
+
+    return DriftHtmlRenderer(
+        history_store=get_drift_history_store(),
+        clock=time.time,
+    )
+
+
+@lru_cache(maxsize=1)
 def get_snapshot_writer():
     """Singleton ProtectionSnapshotWriter wired to the configured reader.
 

--- a/tests/unit/ci_governance/test_drift_html_render_script.py
+++ b/tests/unit/ci_governance/test_drift_html_render_script.py
@@ -1,0 +1,142 @@
+"""
+Tests for scripts/ci-protection-drift-html-render.py — S16.12 CLI.
+
+The script has a hyphenated filename; we load it via importlib.util.
+All tests are deterministic: monkeypatched factory, tmp_path, no network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+from services.ci_governance.drift_html_renderer import (
+    DriftHtmlRenderer,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "ci-protection-drift-html-render.py"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_ci_drift_html_render_script",
+        _SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_ci_drift_html_render_script"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_script_module()
+
+_FIXED_CLOCK = 100_000.0
+
+
+class _FakeHistoryStore:
+    def read_all(self, limit: int | None = None) -> list[dict]:
+        return []
+
+    def read_since(self, since_ts: float) -> list[dict]:
+        return []
+
+
+def _make_renderer(file_writer=None):
+    return DriftHtmlRenderer(
+        history_store=_FakeHistoryStore(),
+        clock=lambda: _FIXED_CLOCK,
+        file_writer=file_writer,
+    )
+
+
+def test_script_uses_default_report_path_when_env_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("CI_GOVERNANCE_HTML_REPORT_PATH", raising=False)
+
+    captured_paths: list[str] = []
+
+    def spy_writer(path: str, body: str) -> None:
+        captured_paths.append(path)
+
+    rend = _make_renderer(file_writer=spy_writer)
+    monkeypatch.setattr(
+        "services.ci_governance.factory.get_drift_html_renderer",
+        lambda: rend,
+    )
+    rc = mod.main([])
+    assert rc == 0
+    assert captured_paths[0] == mod._DEFAULT_REPORT_PATH
+
+
+def test_script_uses_env_path_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    custom = str(tmp_path / "custom.html")
+    monkeypatch.setenv("CI_GOVERNANCE_HTML_REPORT_PATH", custom)
+
+    captured_paths: list[str] = []
+
+    def spy_writer(path: str, body: str) -> None:
+        captured_paths.append(path)
+
+    rend = _make_renderer(file_writer=spy_writer)
+    monkeypatch.setattr(
+        "services.ci_governance.factory.get_drift_html_renderer",
+        lambda: rend,
+    )
+    rc = mod.main([])
+    assert rc == 0
+    assert captured_paths[0] == custom
+
+
+def test_script_uses_default_window_604800_and_limit_500(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = str(tmp_path / "report.html")
+
+    captured_args: list[tuple[int, int]] = []
+    original_render = DriftHtmlRenderer.render
+
+    def tracking_render(self, report_path, window_seconds=604800, limit=500):
+        captured_args.append((window_seconds, limit))
+        return original_render(self, report_path, window_seconds, limit)
+
+    rend = _make_renderer(file_writer=lambda p, b: None)
+    monkeypatch.setattr(
+        "services.ci_governance.factory.get_drift_html_renderer",
+        lambda: rend,
+    )
+    monkeypatch.setattr(DriftHtmlRenderer, "render", tracking_render)
+    rc = mod.main(["--report-path", target])
+    assert rc == 0
+    assert captured_args[0] == (604800, 500)
+
+
+def test_script_exits_0_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = str(tmp_path / "report.html")
+    rend = _make_renderer(file_writer=lambda p, b: None)
+    monkeypatch.setattr(
+        "services.ci_governance.factory.get_drift_html_renderer",
+        lambda: rend,
+    )
+    rc = mod.main(["--report-path", target])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["success"] is True

--- a/tests/unit/ci_governance/test_drift_html_renderer.py
+++ b/tests/unit/ci_governance/test_drift_html_renderer.py
@@ -1,0 +1,282 @@
+"""
+Tests for services/ci_governance/drift_html_renderer.py — S16.12.
+
+All tests are deterministic: FakeHistoryStore with canned entries, fixed clock.
+No network, no mutation, no side effects beyond tmp_path writes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from services.ci_governance.drift_html_renderer import (
+    DriftHtmlRenderer,
+)
+
+# ---------------------------------------------------------------------------
+# FakeHistoryStore
+# ---------------------------------------------------------------------------
+
+
+class FakeHistoryStore:
+    """In-memory history store for test isolation."""
+
+    def __init__(self, entries: list[dict]) -> None:
+        self._entries = list(entries)
+
+    def read_all(self, limit: int | None = None) -> list[dict]:
+        if limit is not None:
+            return self._entries[:limit]
+        return list(self._entries)
+
+    def read_since(self, since_ts: float) -> list[dict]:
+        return [e for e in self._entries if e.get("ts", 0) >= since_ts]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_FIXED_CLOCK = 100_000.0
+
+_ENTRIES: list[dict] = [
+    {
+        "ts": 90_000.0,
+        "drift_detected": False,
+        "strict_weakened": False,
+        "missing_rules": [],
+        "extra_rules": [],
+        "summary": "no drift",
+    },
+    {
+        "ts": 95_000.0,
+        "drift_detected": True,
+        "strict_weakened": False,
+        "missing_rules": ["ctx-a"],
+        "extra_rules": [],
+        "summary": "drift found",
+    },
+    {
+        "ts": 98_000.0,
+        "drift_detected": True,
+        "strict_weakened": True,
+        "missing_rules": ["ctx-b", "ctx-c"],
+        "extra_rules": ["ctx-x"],
+        "summary": "critical drift",
+    },
+    {
+        "ts": 99_000.0,
+        "drift_detected": False,
+        "strict_weakened": False,
+        "missing_rules": [],
+        "extra_rules": ["ctx-y"],
+        "summary": "resolved",
+    },
+]
+
+
+@pytest.fixture()
+def store() -> FakeHistoryStore:
+    return FakeHistoryStore(_ENTRIES)
+
+
+@pytest.fixture()
+def renderer(store: FakeHistoryStore) -> DriftHtmlRenderer:
+    return DriftHtmlRenderer(
+        history_store=store,
+        clock=lambda: _FIXED_CLOCK,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_render_writes_html_file_at_target_path(
+    renderer: DriftHtmlRenderer,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "report.html"
+    result = renderer.render(str(target))
+    assert result.success is True
+    assert target.is_file()
+    assert result.report_path == str(target)
+
+
+def test_render_uses_atomic_tmpfile_then_rename(
+    store: FakeHistoryStore,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def tracking_writer(path: str, body: str) -> None:
+        calls.append((path, body))
+
+    rend = DriftHtmlRenderer(
+        history_store=store,
+        clock=lambda: _FIXED_CLOCK,
+        file_writer=tracking_writer,
+    )
+    target = str(tmp_path / "report.html")
+    result = rend.render(target)
+    assert result.success is True
+    assert len(calls) == 1
+    assert calls[0][0] == target
+
+
+def test_render_emits_doctype_html_meta_charset_utf8(
+    renderer: DriftHtmlRenderer,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "report.html"
+    renderer.render(str(target))
+    content = target.read_text(encoding="utf-8")
+    assert "<!doctype html>" in content
+    assert '<meta charset="utf-8">' in content
+    assert "<title>Banxe CI drift report</title>" in content
+
+
+def test_render_escapes_html_in_summary_text_xss_safe(
+    tmp_path: Path,
+) -> None:
+    xss_store = FakeHistoryStore(
+        [
+            {
+                "ts": 99_000.0,
+                "drift_detected": True,
+                "strict_weakened": False,
+                "missing_rules": [],
+                "extra_rules": [],
+                "summary": '<script>alert("xss")</script>',
+            },
+        ]
+    )
+    rend = DriftHtmlRenderer(
+        history_store=xss_store,
+        clock=lambda: _FIXED_CLOCK,
+    )
+    target = tmp_path / "report.html"
+    rend.render(str(target))
+    content = target.read_text(encoding="utf-8")
+    assert "<script>" not in content
+    assert "&lt;script&gt;" in content
+
+
+def test_render_escapes_html_in_context_names_xss_safe(
+    tmp_path: Path,
+) -> None:
+    xss_store = FakeHistoryStore(
+        [
+            {
+                "ts": 99_000.0,
+                "drift_detected": True,
+                "strict_weakened": False,
+                "missing_rules": ['<img src=x onerror="alert(1)">'],
+                "extra_rules": [],
+                "summary": "ctx xss test",
+            },
+        ]
+    )
+    rend = DriftHtmlRenderer(
+        history_store=xss_store,
+        clock=lambda: _FIXED_CLOCK,
+    )
+    target = tmp_path / "report.html"
+    rend.render(str(target))
+    content = target.read_text(encoding="utf-8")
+    assert "<img " not in content
+    assert "&lt;img " in content
+
+
+def test_render_emits_summary_cards_with_correct_counts(
+    renderer: DriftHtmlRenderer,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "report.html"
+    renderer.render(str(target), window_seconds=86400)
+    content = target.read_text(encoding="utf-8")
+    # 4 total, 2 drift, 1 strict
+    assert ">4<" in content
+    assert ">2<" in content
+    assert ">1<" in content
+
+
+def test_render_uses_window_seconds_to_filter_history(
+    renderer: DriftHtmlRenderer,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "report.html"
+    # window=5000 → since_ts = 100000-5000 = 95000 → 3 entries (95k, 98k, 99k)
+    result = renderer.render(str(target), window_seconds=5000)
+    assert result.entries_rendered == 3
+
+
+def test_render_caps_entries_to_limit(
+    renderer: DriftHtmlRenderer,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "report.html"
+    result = renderer.render(str(target), window_seconds=86400, limit=2)
+    assert result.entries_rendered == 2
+
+
+def test_render_empty_history_emits_no_entries_placeholder(
+    tmp_path: Path,
+) -> None:
+    empty_store = FakeHistoryStore([])
+    rend = DriftHtmlRenderer(
+        history_store=empty_store,
+        clock=lambda: _FIXED_CLOCK,
+    )
+    target = tmp_path / "report.html"
+    result = rend.render(str(target))
+    assert result.success is True
+    assert result.entries_rendered == 0
+    content = target.read_text(encoding="utf-8")
+    assert "No drift entries" in content
+    assert "<!doctype html>" in content
+
+
+def test_render_emits_iso_timestamp_for_each_entry(
+    renderer: DriftHtmlRenderer,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "report.html"
+    renderer.render(str(target), window_seconds=86400)
+    content = target.read_text(encoding="utf-8")
+    for entry in _ENTRIES:
+        iso = datetime.fromtimestamp(entry["ts"], tz=UTC).isoformat()
+        assert iso in content
+
+
+def test_render_returns_byte_size_in_result(
+    renderer: DriftHtmlRenderer,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "report.html"
+    result = renderer.render(str(target))
+    assert result.byte_size is not None
+    assert result.byte_size > 0
+    actual = len(target.read_text(encoding="utf-8").encode("utf-8"))
+    assert result.byte_size == actual
+
+
+def test_render_returns_failure_when_write_raises_clear_error(
+    store: FakeHistoryStore,
+) -> None:
+    def failing_writer(path: str, body: str) -> None:
+        raise OSError("disk full")
+
+    rend = DriftHtmlRenderer(
+        history_store=store,
+        clock=lambda: _FIXED_CLOCK,
+        file_writer=failing_writer,
+    )
+    result = rend.render("/nonexistent/report.html")
+    assert result.success is False
+    assert result.error is not None
+    assert "disk full" in result.error


### PR DESCRIPTION
S16.12 — drift HTML report renderer. Single static HTML5 page from S16.9 history (#140) for operator browser review. Files: services/ci_governance/drift_html_renderer.py (new, atomic tmpfile+rename, html.escape XSS-safe), services/ci_governance/factory.py extension (get_drift_html_renderer lru_cache), scripts/ci-protection-drift-html-render.py (new CLI with --report-path / --window-seconds / --limit), .env.example (CI_GOVERNANCE_HTML_REPORT_PATH), 12 renderer + 4 CLI unit tests. XSS-safety asserted via injected payloads in context names and summary. No server, no JS, no new dep (stdlib + html.escape only). READ-ONLY against history; atomic local write. Operator merge: gh pr merge <N> -R CarmiBanxe/banxe-emi-stack --squash --delete-branch --admin