### PR TITLE
test: fix PSD2 recon test event-loop for py3.12

### DIFF
--- a/tests/test_integration/test_psd2_recon_pipeline.py
+++ b/tests/test_integration/test_psd2_recon_pipeline.py
@@ -38,13 +38,13 @@ class TestPSD2ReconPipeline:
 
     def test_adorsys_fetch_returns_xml(self, mock_adorsys_client):
         # Verify mock returns the XML string
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             mock_adorsys_client.fetch_statement("GB29NWBK60161331926819")
         )
         assert "BkToCstmrStmt" in result
 
     def test_adorsys_account_list_contains_iban(self, mock_adorsys_client):
-        accounts = asyncio.get_event_loop().run_until_complete(
+        accounts = asyncio.run(
             mock_adorsys_client.get_account_list()
         )
         assert "GB29NWBK60161331926819" in accounts

--- a/tests/test_integration/test_psd2_recon_pipeline.py
+++ b/tests/test_integration/test_psd2_recon_pipeline.py
@@ -38,15 +38,11 @@ class TestPSD2ReconPipeline:
 
     def test_adorsys_fetch_returns_xml(self, mock_adorsys_client):
         # Verify mock returns the XML string
-        result = asyncio.run(
-            mock_adorsys_client.fetch_statement("GB29NWBK60161331926819")
-        )
+        result = asyncio.run(mock_adorsys_client.fetch_statement("GB29NWBK60161331926819"))
         assert "BkToCstmrStmt" in result
 
     def test_adorsys_account_list_contains_iban(self, mock_adorsys_client):
-        accounts = asyncio.run(
-            mock_adorsys_client.get_account_list()
-        )
+        accounts = asyncio.run(mock_adorsys_client.get_account_list())
         assert "GB29NWBK60161331926819" in accounts
 
     def test_blocked_iban_country_ru_rejected(self):


### PR DESCRIPTION
Pre-existing main failure (RuntimeError no current event loop, py3.12). Test-only fix, no services/src/api changes. Unblocks main CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Modernized integration test async execution for the PSD2 reconciliation pipeline; test behavior and assertions remain unchanged—no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->