### PR TITLE
feat(agents): KYC onboarding agent — ADR-049 KYC mask (L2 client-facing) [IL-126]

### DIFF
--- a/services/agents/__init__.py
+++ b/services/agents/__init__.py
@@ -1,0 +1,17 @@
+"""L2 client-facing agents (ADR-049 Intent Layer & Client-Facing Agent Masks).
+
+This package holds the banxe-emi-stack L2 client-facing agents that bind the
+ADR-049 masks for capabilities owned by this repo's CONTRACT ports
+(KYCProviderPort, NotificationProviderPort, CRMProviderPort). It is the
+emi-stack analogue of banxe-payment-core's ``src/agents`` package, which holds
+the Payments and FX/Exchange agents.
+
+Each agent enforces, in the fixed ADR-049 §D2 gate-chain order
+(process_ref → scope → band → cost_cap → compliance → step-up → port call),
+the six mask fields (scope, autonomy_level, confirmation_policy, cost_cap,
+lineage_obligation, compliance_gate) and emits exactly one
+``AgentDecisionRecord`` (ADR-046) on every exit path. Ports and the lineage
+recorder are injected as interfaces; agents never implement them.
+"""
+
+from __future__ import annotations

--- a/services/agents/kyc_onboarding_agent.py
+++ b/services/agents/kyc_onboarding_agent.py
@@ -1,0 +1,858 @@
+"""KYCOnboardingAgent — L2 client-facing KYC onboarding agent (ADR-049 KYC mask).
+
+WHY: ADR-049 (Intent Layer & Client-Facing Agent Masks) specifies the
+client-facing **KYC onboarding mask**: the governed surface through which a
+resolved client intent becomes a bounded identity-verification action. This
+module is the emi-stack analogue of banxe-payment-core's
+``src/agents/payments_agent.py`` / ``fx_exchange_agent.py`` — it implements the
+agent *logic* and *governance enforcement* of the KYC mask; it does NOT
+implement the port, the LLM-orchestration/routing layer (``AGENT_ROUTING_ENABLED``
+stays out of scope — Terminal A infra, ADR-049 §D6/§D7), or the ClickHouse sink.
+
+The KYC mask (ADR-049 §D3), enforced here in the fixed §D2 chain order
+(process_ref → scope → band → cost_cap → compliance → step-up → port call):
+
+* ``scope``                — ``KYCProviderPort`` operations only (the allow-list:
+                             start_session / get_status / handle_webhook /
+                             change_level). The port is injected, never implemented
+                             here; an op not on the allow-list is rejected outright.
+* ``autonomy_level``       — REVIEW (identity decisions are L2 HITL, ADR-049 §D3).
+                             Reads (status) are AUTO-eligible within cap; session
+                             start is REVIEW-biased; an identity acceptance/decline
+                             is a mandatory-HITL decision regardless of confidence.
+* ``confirmation_policy``  — AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70
+                             (ADR-047 thresholds, ADR-049 §D4). Identity decisions
+                             additionally require a human reviewer (mandatory HITL)
+                             and biometric step-up where the KYC flow requires it.
+* ``cost_cap``             — per-request AND per-window hard caps, token AND
+                             monetary (Decimal) dimensions (ADR-047 §D2, ADR-049 §D3).
+* ``lineage_obligation``   — one ``AgentDecisionRecord`` per action (ADR-046),
+                             non-optional, emitted on every exit path.
+* ``compliance_gate``      — KYC + sanctions (Ruflo mandatory, L3); a non-PASS
+                             result halts AND escalates to the MLRO
+                             (``.claude/rules/agents.md`` MLRO escalation).
+
+Any one of {unresolved process_ref, out-of-scope op, below-band confidence,
+missing mandatory HITL, cost-cap breach, compliance fail, missing biometric
+step-up} halts the action (ADR-049 §D4 — independent halt conditions). Mask
+*values* (caps, thresholds, scope, gate, MLRO role) are config-as-data
+(CLAUDE.md §10), carried on :class:`KYCOnboardingMask`, never hardcoded in flow
+logic.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
+import uuid
+
+from services.kyc.kyc_provider_port import (
+    KYCProviderError,
+    KYCProviderPort,
+    KYCTier,
+    TierDowngradeBlocked,
+)
+
+# ---------------------------------------------------------------------------
+# Mask vocabulary
+# ---------------------------------------------------------------------------
+
+
+class ConfirmationDecision(StrEnum):
+    """HITL band selected by the confirmation_policy (ADR-047 / ADR-049 §D4)."""
+
+    AUTO = "auto"
+    REVIEW = "review"
+    BLOCK = "block"
+
+
+class ComplianceResult(StrEnum):
+    """Net L3 compliance-gate outcome carried on the lineage record (ADR-046)."""
+
+    PASS = "PASS"  # nosec B105 # noqa: S105 — compliance verdict, not a credential
+    FAIL = "FAIL"
+    ESCALATE = "ESCALATE"
+    NA = "N/A"
+
+
+class BudgetBreach(StrEnum):
+    """Cost-cap breach flag for the lineage record (ADR-047 §D2/§D4)."""
+
+    NONE = "NONE"
+    WARN = "WARN"
+    BREACH = "BREACH"
+
+
+class AutonomyLevel(StrEnum):
+    """Mask autonomy posture (ADR-049 §D3). KYC is REVIEW-biased: identity
+    decisions are L2 HITL, reads are AUTO-eligible within cap."""
+
+    AUTO_BIASED = "auto_biased"
+    REVIEW_BIASED = "review_biased"
+
+
+class IdentityDecision(StrEnum):
+    """The two terminal identity verdicts a human reviewer commits (ADR-049 §D3)."""
+
+    ACCEPT = "accept"
+    DECLINE = "decline"
+
+
+# ---------------------------------------------------------------------------
+# Value types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProcessRef:
+    """ADR-048 intent→process handle. Both fields required for a resolved intent."""
+
+    process_id: str
+    version: str
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.process_id) and bool(self.version)
+
+
+@dataclass(frozen=True)
+class RequestCost:
+    """Estimated cost of a single agent invocation (ADR-047 per-request dimensions)."""
+
+    tokens: int
+    cost: Decimal
+
+
+@dataclass(frozen=True)
+class CostCap:
+    """Hard caps in both token and monetary (Decimal) dimensions (ADR-047 §D2)."""
+
+    max_request_tokens: int
+    max_request_cost: Decimal
+    max_window_tokens: int
+    max_window_cost: Decimal
+
+
+@dataclass
+class CostWindow:
+    """Rolling per-window usage accumulator (ADR-047 §D2 per-window budget)."""
+
+    used_tokens: int = 0
+    used_cost: Decimal = Decimal("0")
+    window_ref: str = "kyc_onboarding_agent:default"
+
+    def add(self, cost: RequestCost) -> None:
+        self.used_tokens += cost.tokens
+        self.used_cost += cost.cost
+
+
+@dataclass(frozen=True)
+class KYCOnboardingMask:
+    """Config-as-data KYC onboarding mask (ADR-049 §D3). Values are governed
+    config, not hardcoded flow logic; the AUTO/REVIEW/BLOCK *scale* is ADR-047
+    canon. The mask is the allow-list and the gate posture for the capability."""
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    autonomy_level: AutonomyLevel = AutonomyLevel.REVIEW_BIASED
+    lineage_obligation: bool = True
+    # Identity decisions require biometric step-up where the KYC flow requires it
+    # (per-intent ``biometric_required``); this mask toggle can disable it entirely.
+    require_biometric_for_identity: bool = True
+    # The human double notified/escalated to for KYC (`.claude/rules/agents.md`).
+    mlro_role: str = "MLRO"
+    agent_id: str = "kyc_onboarding_agent"
+
+    # The mask scope (ADR-049 §D3 allow-list): the only port ops this mask may reach.
+    scope: tuple[str, ...] = (
+        "KYCProviderPort.start_session",
+        "KYCProviderPort.get_status",
+        "KYCProviderPort.handle_webhook",
+        "KYCProviderPort.change_level",
+    )
+
+    # L3 compliance contour required before any KYC action (Ruflo mandatory).
+    compliance_gate: tuple[str, ...] = ("KYC", "SANCTIONS")
+
+
+@dataclass
+class StartOnboardingIntent:
+    """A resolved client intent to begin KYC onboarding (``start_session``).
+
+    REVIEW-biased (ADR-049 §D3): a session start in the REVIEW band holds for a
+    human reviewer and proceeds only once one is supplied; AUTO proceeds within cap.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    user_id: str
+    tier: KYCTier
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class StatusCheckIntent:
+    """A resolved low-consequence read intent (``get_status``) — the mask's
+    "reads are AUTO-eligible within cap" path (ADR-049 §D3). A read below the AUTO
+    band halts for a re-check, not a HITL hold."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    user_id: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class IdentityDecisionIntent:
+    """A resolved identity acceptance/decline — the mask's mandatory-HITL decision.
+
+    Identity decisions are L2 HITL (ADR-049 §D3): a human reviewer is required
+    regardless of the confidence band, and biometric step-up is required where the
+    KYC flow demands it (``biometric_required``). On ACCEPT the agent calls
+    ``change_level`` to ``target_tier``; on DECLINE no provider mutation is made —
+    the declined verdict is recorded as lineage and the tier is left unchanged.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    user_id: str
+    decision: IdentityDecision
+    target_tier: KYCTier
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    biometric_required: bool = False
+    biometric_verified: bool = False
+
+
+@dataclass
+class AgentDecisionRecord:
+    """Decision-lineage record emitted per action (ADR-046 schema + ADR-047 cost)."""
+
+    record_id: str
+    timestamp: datetime
+    agent_id: str
+    triggering_event: str
+    intent: str
+    policies_evaluated: list[str]
+    compliance_result: ComplianceResult
+    reasoning_summary: str
+    confidence_score: float
+    action_taken: str
+    human_reviewed_by: str | None
+    correlation_id: str
+    # ADR-047 cost lineage (cost is a first-class lineage dimension).
+    cost_tokens: int = 0
+    cost_amount: Decimal = Decimal("0")
+    budget_window_ref: str = ""
+    budget_breach_flag: BudgetBreach = BudgetBreach.NONE
+    # MLRO escalation marker (`.claude/rules/agents.md`); set on compliance
+    # fail/escalate, low-confidence identity decisions, and blocked downgrades.
+    escalated_to: str | None = None
+
+
+@dataclass
+class AgentOutcome:
+    """Result of a masked action: the decision, whether a port was called, and the
+    lineage record that was emitted (always non-None — lineage is non-optional)."""
+
+    decision: ConfirmationDecision
+    executed: bool
+    record: AgentDecisionRecord
+    result: object | None = None
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+class DecisionRecorder(ABC):
+    """Sink for :class:`AgentDecisionRecord` (ADR-046 producer→sink seam).
+
+    Injected, not implemented here: the ClickHouse/lineage wiring is out of scope
+    (ADR-049 §D7). The agent depends only on this interface.
+    """
+
+    @abstractmethod
+    async def record(self, record: AgentDecisionRecord) -> None:
+        """Persist one decision-lineage record. Must be durable before the action
+        is considered complete (ADR-046 §D4 producer obligation)."""
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    """All inputs a single masked action evaluates against."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+    requires_biometric: bool
+    biometric_verified: bool
+    human_reviewed_by: str | None
+    # Money-movement-equivalent for KYC: REVIEW-biased actions (session start,
+    # identity decision) hold for HITL in the REVIEW band; pure reads instead halt
+    # below AUTO. Defaults False so the read path is unchanged.
+    supports_review_hitl: bool = False
+    # Identity decisions require a human reviewer regardless of band (mandatory HITL).
+    mandatory_hitl: bool = False
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class KYCOnboardingAgent:
+    """L2 KYC onboarding agent enforcing the ADR-049 KYC mask.
+
+    The provider port and the lineage recorder are injected as interfaces
+    (constructor injection); the agent contains pure governance logic and is
+    unit-testable without any live infra.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider_port: KYCProviderPort,
+        recorder: DecisionRecorder,
+        mask: KYCOnboardingMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._provider = provider_port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def start_onboarding(
+        self,
+        intent: StartOnboardingIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        """Begin KYC onboarding via ``KYCProviderPort.start_session`` under the mask.
+
+        REVIEW-biased (ADR-049 §D3): the REVIEW band holds for HITL and proceeds
+        only once a human reviewer is supplied; not an identity decision, so no
+        biometric step-up.
+        """
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"start_onboarding:{intent.user_id}:{intent.tier.value}",
+            success_action="START_KYC_SESSION",
+            op="KYCProviderPort.start_session",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            requires_biometric=False,
+            biometric_verified=False,
+            human_reviewed_by=human_reviewed_by,
+            supports_review_hitl=True,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._provider.start_session(
+                intent.user_id, intent.tier, intent.correlation_id
+            ),
+        )
+
+    async def check_status(
+        self,
+        intent: StatusCheckIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Low-consequence read via ``KYCProviderPort.get_status`` — AUTO-eligible,
+        no HITL hold and no step-up (the mask's within-cap read path, ADR-049 §D3)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"check_status:{intent.user_id}",
+            success_action="CHECK_KYC_STATUS",
+            op="KYCProviderPort.get_status",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            requires_biometric=False,
+            biometric_verified=False,
+            human_reviewed_by=None,
+        )
+        return await self._run_action(ctx, lambda: self._provider.get_status(intent.user_id))
+
+    async def accept_or_decline_identity(
+        self,
+        intent: IdentityDecisionIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        """Commit an identity acceptance/decline — the mask's mandatory-HITL decision.
+
+        Identity decisions are L2 HITL (ADR-049 §D3): a human reviewer is required
+        regardless of the confidence band, escalating to the MLRO; biometric step-up
+        is required where the KYC flow demands it. On ACCEPT, ``change_level`` is
+        called to ``target_tier``; on DECLINE no provider mutation is made and the
+        declined verdict is recorded as lineage (the tier is left unchanged).
+        """
+        is_accept = intent.decision is IdentityDecision.ACCEPT
+        success_action = "ACCEPT_IDENTITY" if is_accept else "DECLINE_IDENTITY"
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"identity_decision:{intent.decision.value}:{intent.user_id}",
+            success_action=success_action,
+            op="KYCProviderPort.change_level",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            requires_biometric=intent.biometric_required,
+            biometric_verified=intent.biometric_verified,
+            human_reviewed_by=human_reviewed_by,
+            supports_review_hitl=True,
+            mandatory_hitl=True,
+        )
+        # ACCEPT mutates the provider tier; DECLINE commits the verdict with no
+        # provider call (port_call=None) — both still owe exactly one lineage record.
+        port_call: Callable[[], Awaitable[object]] | None = (
+            (
+                lambda: self._provider.change_level(
+                    intent.user_id, intent.target_tier, intent.correlation_id
+                )
+            )
+            if is_accept
+            else None
+        )
+        return await self._run_action(ctx, port_call)
+
+    async def handle_provider_webhook(
+        self,
+        payload: object,
+        signature: str,
+        *,
+        correlation_id: str | None = None,
+        request_cost: RequestCost | None = None,
+        intent_text: str = "kyc_provider_webhook",
+    ) -> AgentOutcome:
+        """Process a provider-initiated status webhook via ``KYCProviderPort.handle_webhook``.
+
+        Provider-initiated (not a client intent), so it does not traverse the
+        confidence-band chain; it still emits exactly one lineage record (ADR-046)
+        on every exit path. The port verifies the HMAC signature BEFORE any
+        processing (ADR-034): an invalid signature raises :class:`InvalidSignature`,
+        which is recorded as an MLRO-escalated halt and re-raised. Idempotency is the
+        port's contract — a duplicate event returns ``deduped=True`` and applies no
+        state change; the agent records the de-dup without re-processing.
+        """
+        cid = correlation_id or str(uuid.uuid4())
+        cost = request_cost or RequestCost(tokens=0, cost=Decimal("0"))
+        triggering_event = "kyc_provider_webhook"
+        policies = ["ADR-034-webhook-hmac-verify", "ADR-046-lineage", "ADR-049-scope-allow-list"]
+
+        try:
+            outcome = await self._provider.handle_webhook(payload, signature)
+        except KYCProviderError as exc:
+            # InvalidSignature (and any provider error) → record then re-raise. A bad
+            # signature is a possible attack: escalate to the MLRO (port docstring).
+            action_taken = f"HALT_WEBHOOK_ERROR:{type(exc).__name__}"
+            await self._record(
+                triggering_event=triggering_event,
+                intent=intent_text,
+                policies=policies,
+                compliance_result=ComplianceResult.ESCALATE,
+                reasoning=f"Webhook rejected before processing: {exc}",
+                confidence_score=1.0,
+                action_taken=action_taken,
+                human_reviewed_by=None,
+                correlation_id=cid,
+                request_cost=cost,
+                budget_breach=BudgetBreach.NONE,
+                escalated_to=self._mask.mlro_role,
+            )
+            raise
+        # Idempotent replay: deduped event applied no state change (ADR-034).
+        deduped = outcome.deduped
+        action_taken = "WEBHOOK_DEDUPED" if deduped else "WEBHOOK_PROCESSED"
+        reasoning = (
+            "Duplicate provider event id — idempotent replay, no state change applied."
+            if deduped
+            else "Provider event verified and applied; status transition persisted."
+        )
+        record = await self._record(
+            triggering_event=triggering_event,
+            intent=intent_text,
+            policies=policies,
+            compliance_result=ComplianceResult.NA,
+            reasoning=reasoning,
+            confidence_score=1.0,
+            action_taken=action_taken,
+            human_reviewed_by=None,
+            correlation_id=cid,
+            request_cost=cost,
+            budget_breach=BudgetBreach.NONE,
+            escalated_to=None,
+        )
+        if not deduped:
+            self._window.add(cost)
+        return AgentOutcome(
+            decision=ConfirmationDecision.AUTO,
+            executed=not deduped,
+            record=record,
+            result=outcome,
+            halt_reason=None,
+        )
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _step_up_required(self, ctx: _ActionContext) -> bool:
+        # Biometric step-up is required only for identity decisions whose flow demands
+        # it, and only while the mask enables identity step-up (config-as-data).
+        return ctx.requires_biometric and self._mask.require_biometric_for_identity
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be in [0.0, 1.0]")
+        policies = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no port call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. ADR-049 §D3 — mask scope allow-list; an off-list op is refused outright.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op} is not on the KYC mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band (AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70)
+        #    + ADR-049 §D3 mandatory HITL for identity decisions.
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+        if band is ConfirmationDecision.BLOCK:
+            # Low confidence on an identity decision escalates to the MLRO.
+            escalated = self._mask.mlro_role if ctx.mandatory_hitl else None
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+                escalated_to=escalated,
+            )
+        if band is ConfirmationDecision.REVIEW:
+            # Read path: reads are AUTO-only, so a below-AUTO read halts for a
+            # re-check at higher confidence, not a HITL hold (ADR-049 §D3).
+            if not ctx.supports_review_hitl:
+                return _Evaluation(
+                    band,
+                    False,
+                    "HALT_REVIEW_DEFERRED",
+                    "Read intent below AUTO band; reads are AUTO-only, no HITL hold (ADR-049 §D3).",
+                    policies,
+                    ctx.compliance_result,
+                    BudgetBreach.NONE,
+                    halt_reason="review_deferred",
+                    requires_hitl=True,
+                )
+
+        # ADR-049 §D3 — REVIEW-biased / identity actions require a human reviewer.
+        # Reads (no review HITL) skip this; the REVIEW band and every identity
+        # decision (mandatory HITL, even at AUTO) hold until a reviewer is supplied.
+        needs_reviewer = ctx.supports_review_hitl and (
+            band is ConfirmationDecision.REVIEW or ctx.mandatory_hitl
+        )
+        if needs_reviewer and ctx.human_reviewed_by is None:
+            policies.append("ADR-049-D3-identity-HITL")
+            return _Evaluation(
+                band,
+                False,
+                "HOLD_FOR_REVIEW",
+                "Identity/REVIEW-band action paused for HITL; escalates to MLRO on no response.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="hitl_review_required",
+                requires_hitl=True,
+                escalated_to=self._mask.mlro_role if ctx.mandatory_hitl else None,
+            )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window); action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. L3 compliance gate (KYC + sanctions; Ruflo mandatory). A non-PASS
+        #    result halts AND escalates to the MLRO (`.claude/rules/agents.md`).
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"L3 compliance gate returned {ctx.compliance_result}; "
+                f"action blocked and escalated to {self._mask.mlro_role}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=self._mask.mlro_role,
+            )
+
+        # 6. ADR-049 §D4 — biometric step-up where the identity flow requires it.
+        if self._step_up_required(ctx) and not ctx.biometric_verified:
+            policies.append("ADR-049-D4-biometric-step-up")
+            return _Evaluation(
+                band,
+                False,
+                "HALT_STEP_UP_REQUIRED",
+                "Identity decision requires biometric step-up before commit (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="step_up_required",
+                requires_step_up=True,
+            )
+
+        # All gates satisfied — clear to commit the action.
+        reviewer = (
+            "" if ctx.human_reviewed_by is None else f" (reviewed by {ctx.human_reviewed_by})"
+        )
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All mask gates satisfied at {band.value} confidence{reviewer}; committing within scope.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+        compliance_result = ev.compliance_result
+        escalated_to = ev.escalated_to
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except KYCProviderError as exc:
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    # A regulatory-blocked downgrade is an MLRO escalation (port docstring).
+                    if isinstance(exc, TierDowngradeBlocked):
+                        compliance_result = ComplianceResult.ESCALATE
+                        escalated_to = self._mask.mlro_role
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=compliance_result,
+                        reasoning=f"Provider rejected the action: {exc}",
+                        escalated_to=escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_step_up=ev.requires_step_up,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=escalated_to,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        return await self._record(
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies=ev.policies,
+            compliance_result=compliance_result,
+            reasoning=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=ctx.human_reviewed_by,
+            correlation_id=ctx.correlation_id,
+            request_cost=ctx.request_cost,
+            budget_breach=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+
+    async def _record(
+        self,
+        *,
+        triggering_event: str,
+        intent: str,
+        policies: list[str],
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        confidence_score: float,
+        action_taken: str,
+        human_reviewed_by: str | None,
+        correlation_id: str,
+        request_cost: RequestCost,
+        budget_breach: BudgetBreach,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        """Build, persist, and return exactly one ADR-046 lineage record (the single
+        producer→sink seam used by every exit path, including the webhook handler)."""
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=triggering_event,
+            intent=intent,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=human_reviewed_by,
+            correlation_id=correlation_id,
+            cost_tokens=request_cost.tokens,
+            cost_amount=request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "AutonomyLevel",
+    "BudgetBreach",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "IdentityDecision",
+    "IdentityDecisionIntent",
+    "KYCOnboardingAgent",
+    "KYCOnboardingMask",
+    "ProcessRef",
+    "RequestCost",
+    "StartOnboardingIntent",
+    "StatusCheckIntent",
+]

--- a/tests/agents/test_kyc_onboarding_agent.py
+++ b/tests/agents/test_kyc_onboarding_agent.py
@@ -1,0 +1,591 @@
+"""Tests for the ADR-049 KYC onboarding mask agent
+(services/agents/kyc_onboarding_agent.py).
+
+Covers every mask path in the §D2 gate-chain order:
+AUTO read (check_status), REVIEW→HITL hold then proceed for the REVIEW-biased
+session start, identity-decision mandatory HITL (hold + proceed) with MLRO
+escalation, BLOCK on low confidence, out-of-scope refusal, cost-cap breach
+(per-request and per-window), biometric step-up required for identity decisions,
+compliance fail/escalate → MLRO escalation, blocked tier downgrade → MLRO
+escalation, the DECLINE (no provider mutation) path, webhook idempotency +
+signature verification + provider-error escalation, and the lineage-per-action
+obligation (ADR-046). The port and the recorder are fakes — the agent is
+exercised as pure governance logic with no live infra.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents.kyc_onboarding_agent import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    IdentityDecision,
+    IdentityDecisionIntent,
+    KYCOnboardingAgent,
+    KYCOnboardingMask,
+    ProcessRef,
+    RequestCost,
+    StartOnboardingIntent,
+    StatusCheckIntent,
+)
+from services.kyc.kyc_provider_port import (
+    InvalidSignature,
+    KYCProviderPort,
+    KYCResult,
+    KYCSession,
+    KYCStatus,
+    KYCTier,
+    ProviderUnavailable,
+    TierDowngradeBlocked,
+    WebhookOutcome,
+)
+
+# ── Fakes (the port & sink are injected interfaces; never implemented in services) ──
+
+
+class FakeRecorder(DecisionRecorder):
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+class FakeKYCProviderPort(KYCProviderPort):
+    """In-test KYCProviderPort double. Records calls; returns canned results or
+    raises a configured error per op so the agent's governance logic is exercised
+    without any live provider."""
+
+    def __init__(
+        self,
+        *,
+        session: KYCSession | None = None,
+        status: KYCResult | None = None,
+        change_result: KYCResult | None = None,
+        webhook: WebhookOutcome | None = None,
+        change_raises: Exception | None = None,
+        webhook_raises: Exception | None = None,
+    ) -> None:
+        self._session = session or KYCSession(
+            user_id="u1",
+            access_token="tok_1",
+            expires_at="2026-06-08T00:00:00Z",
+            provider_level_id="lvl_basic",
+            correlation_id="corr-1",
+        )
+        self._status = status or KYCResult(
+            user_id="u1",
+            status=KYCStatus.PENDING,
+            tier=KYCTier.BASIC,
+            provider_level_id="lvl_basic",
+        )
+        self._change_result = change_result or KYCResult(
+            user_id="u1",
+            status=KYCStatus.APPROVED,
+            tier=KYCTier.FULL,
+            provider_level_id="lvl_full",
+        )
+        self._webhook = webhook or WebhookOutcome(
+            processed=True, deduped=False, user_id="u1", new_status=KYCStatus.APPROVED
+        )
+        self._change_raises = change_raises
+        self._webhook_raises = webhook_raises
+        self.start_calls: list[tuple[str, KYCTier, str]] = []
+        self.status_calls: list[str] = []
+        self.change_calls: list[tuple[str, KYCTier, str]] = []
+        self.webhook_calls: list[tuple[object, str]] = []
+
+    async def start_session(self, user_id: str, tier: KYCTier, correlation_id: str) -> KYCSession:
+        self.start_calls.append((user_id, tier, correlation_id))
+        return self._session
+
+    async def get_status(self, user_id: str) -> KYCResult:
+        self.status_calls.append(user_id)
+        return self._status
+
+    async def handle_webhook(self, payload: object, signature: str) -> WebhookOutcome:
+        self.webhook_calls.append((payload, signature))
+        if self._webhook_raises is not None:
+            raise self._webhook_raises
+        return self._webhook
+
+    async def change_level(self, user_id: str, new_tier: KYCTier, correlation_id: str) -> KYCResult:
+        self.change_calls.append((user_id, new_tier, correlation_id))
+        if self._change_raises is not None:
+            raise self._change_raises
+        return self._change_result
+
+
+# ── Builders ──────────────────────────────────────────────────────────────────
+
+
+def make_mask(**overrides) -> KYCOnboardingMask:
+    base = {
+        "cost_cap": CostCap(
+            max_request_tokens=10_000,
+            max_request_cost=Decimal("1.00"),
+            max_window_tokens=100_000,
+            max_window_cost=Decimal("10.00"),
+        ),
+    }
+    base.update(overrides)
+    return KYCOnboardingMask(**base)
+
+
+def make_agent(
+    *,
+    mask: KYCOnboardingMask | None = None,
+    port: FakeKYCProviderPort | None = None,
+    recorder: FakeRecorder | None = None,
+    cost_window: CostWindow | None = None,
+) -> tuple[KYCOnboardingAgent, FakeKYCProviderPort, FakeRecorder]:
+    port = port or FakeKYCProviderPort()
+    recorder = recorder or FakeRecorder()
+    agent = KYCOnboardingAgent(
+        provider_port=port,
+        recorder=recorder,
+        mask=mask or make_mask(),
+        cost_window=cost_window,
+    )
+    return agent, port, recorder
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    return (
+        ProcessRef(process_id="PROC-KYC-ONBOARD", version="1")
+        if resolved
+        else ProcessRef(process_id="", version="")
+    )
+
+
+def make_start_intent(
+    *, confidence: float = 0.95, cost: RequestCost | None = None, resolved: bool = True
+) -> StartOnboardingIntent:
+    return StartOnboardingIntent(
+        intent_text="Start my identity verification",
+        process_ref=_ref(resolved),
+        user_id="u1",
+        tier=KYCTier.BASIC,
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=cost or RequestCost(tokens=400, cost=Decimal("0.04")),
+    )
+
+
+def make_status_intent(*, confidence: float = 0.99) -> StatusCheckIntent:
+    return StatusCheckIntent(
+        intent_text="What is my KYC status?",
+        process_ref=_ref(),
+        user_id="u1",
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=RequestCost(tokens=50, cost=Decimal("0.01")),
+    )
+
+
+def make_identity_intent(
+    *,
+    decision: IdentityDecision = IdentityDecision.ACCEPT,
+    confidence: float = 0.95,
+    biometric_required: bool = True,
+    biometric_verified: bool = True,
+    target_tier: KYCTier = KYCTier.FULL,
+) -> IdentityDecisionIntent:
+    return IdentityDecisionIntent(
+        intent_text="Accept this client's identity verification",
+        process_ref=_ref(),
+        user_id="u1",
+        decision=decision,
+        target_tier=target_tier,
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=RequestCost(tokens=600, cost=Decimal("0.06")),
+        biometric_required=biometric_required,
+        biometric_verified=biometric_verified,
+    )
+
+
+# ── AUTO read path (check_status) ──────────────────────────────────────────────
+
+
+async def test_auto_check_status_executes_no_hitl():
+    agent, port, recorder = make_agent()
+    outcome = await agent.check_status(make_status_intent(confidence=0.99))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert outcome.requires_step_up is False
+    assert outcome.requires_hitl is False
+    assert port.status_calls == ["u1"]
+    assert recorder.records[0].action_taken == "CHECK_KYC_STATUS"
+    assert len(recorder.records) == 1
+
+
+async def test_read_below_auto_band_halts_for_recheck():
+    # Reads are AUTO-only: a below-AUTO read halts (re-check), not a HITL hold.
+    agent, port, recorder = make_agent()
+    outcome = await agent.check_status(make_status_intent(confidence=0.80))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert port.status_calls == []
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+# ── REVIEW-biased session start (HITL hold + proceed) ──────────────────────────
+
+
+async def test_start_onboarding_auto_executes():
+    agent, port, recorder = make_agent()
+    outcome = await agent.start_onboarding(make_start_intent(confidence=0.95))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert port.start_calls == [("u1", KYCTier.BASIC, "corr-1")]
+    assert recorder.records[0].action_taken == "START_KYC_SESSION"
+
+
+async def test_start_onboarding_review_band_holds_for_hitl():
+    agent, port, recorder = make_agent()
+    outcome = await agent.start_onboarding(make_start_intent(confidence=0.80))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.requires_hitl is True
+    assert port.start_calls == []
+    assert recorder.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert recorder.records[0].human_reviewed_by is None
+
+
+async def test_start_onboarding_review_with_reviewer_proceeds():
+    agent, port, recorder = make_agent()
+    outcome = await agent.start_onboarding(
+        make_start_intent(confidence=0.80), human_reviewed_by="mlro@banxe"
+    )
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is True
+    assert port.start_calls == [("u1", KYCTier.BASIC, "corr-1")]
+    assert recorder.records[0].human_reviewed_by == "mlro@banxe"
+    assert recorder.records[0].action_taken == "START_KYC_SESSION"
+
+
+# ── Identity decision: mandatory HITL, biometric, change_level ──────────────────
+
+
+async def test_identity_accept_requires_human_even_at_auto():
+    # Mandatory HITL: an identity decision holds even at AUTO confidence with no reviewer.
+    agent, port, recorder = make_agent()
+    outcome = await agent.accept_or_decline_identity(make_identity_intent(confidence=0.99))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is False
+    assert outcome.requires_hitl is True
+    assert outcome.escalated_to == "MLRO"
+    assert port.change_calls == []
+    assert recorder.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert "ADR-049-D3-identity-HITL" in recorder.records[0].policies_evaluated
+
+
+async def test_identity_accept_with_reviewer_and_biometric_changes_level():
+    agent, port, recorder = make_agent()
+    outcome = await agent.accept_or_decline_identity(
+        make_identity_intent(confidence=0.99, biometric_verified=True),
+        human_reviewed_by="mlro@banxe",
+    )
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert port.change_calls == [("u1", KYCTier.FULL, "corr-1")]
+    assert recorder.records[0].action_taken == "ACCEPT_IDENTITY"
+    assert recorder.records[0].human_reviewed_by == "mlro@banxe"
+
+
+async def test_identity_decline_records_verdict_without_provider_call():
+    agent, port, recorder = make_agent()
+    outcome = await agent.accept_or_decline_identity(
+        make_identity_intent(decision=IdentityDecision.DECLINE, biometric_required=False),
+        human_reviewed_by="mlro@banxe",
+    )
+
+    assert outcome.executed is True  # decision committed (recorded), no provider mutation
+    assert outcome.result is None
+    assert port.change_calls == []
+    assert recorder.records[0].action_taken == "DECLINE_IDENTITY"
+
+
+async def test_identity_biometric_required_halts_step_up():
+    agent, port, recorder = make_agent()
+    outcome = await agent.accept_or_decline_identity(
+        make_identity_intent(confidence=0.99, biometric_required=True, biometric_verified=False),
+        human_reviewed_by="mlro@banxe",
+    )
+
+    assert outcome.executed is False
+    assert outcome.requires_step_up is True
+    assert outcome.halt_reason == "step_up_required"
+    assert port.change_calls == []
+    assert recorder.records[0].action_taken == "HALT_STEP_UP_REQUIRED"
+    assert "ADR-049-D4-biometric-step-up" in recorder.records[0].policies_evaluated
+
+
+async def test_identity_biometric_disabled_by_mask_config():
+    # Config-as-data: a mask may disable identity biometric step-up entirely.
+    agent, port, _ = make_agent(mask=make_mask(require_biometric_for_identity=False))
+    outcome = await agent.accept_or_decline_identity(
+        make_identity_intent(confidence=0.99, biometric_required=True, biometric_verified=False),
+        human_reviewed_by="mlro@banxe",
+    )
+    assert outcome.executed is True
+    assert port.change_calls == [("u1", KYCTier.FULL, "corr-1")]
+
+
+async def test_identity_low_confidence_blocks_and_escalates_mlro():
+    agent, port, recorder = make_agent()
+    outcome = await agent.accept_or_decline_identity(
+        make_identity_intent(confidence=0.50), human_reviewed_by="mlro@banxe"
+    )
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert outcome.escalated_to == "MLRO"
+    assert port.change_calls == []
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+    assert recorder.records[0].escalated_to == "MLRO"
+
+
+async def test_identity_tier_downgrade_blocked_escalates_mlro_then_raises():
+    port = FakeKYCProviderPort(
+        change_raises=TierDowngradeBlocked("regulatory hold", correlation_id="corr-1")
+    )
+    agent, port, recorder = make_agent(port=port)
+    with pytest.raises(TierDowngradeBlocked):
+        await agent.accept_or_decline_identity(
+            make_identity_intent(confidence=0.99, target_tier=KYCTier.BASIC),
+            human_reviewed_by="mlro@banxe",
+        )
+    # Lineage emitted even on provider failure, with MLRO escalation.
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken.startswith("HALT_PROVIDER_ERROR:")
+    assert recorder.records[0].compliance_result is ComplianceResult.ESCALATE
+    assert recorder.records[0].escalated_to == "MLRO"
+
+
+# ── BLOCK / scope / process resolution ─────────────────────────────────────────
+
+
+async def test_block_low_confidence_read():
+    agent, port, recorder = make_agent()
+    outcome = await agent.check_status(make_status_intent(confidence=0.40))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert port.status_calls == []
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+async def test_unresolved_process_ref_blocks():
+    agent, port, recorder = make_agent()
+    outcome = await agent.start_onboarding(make_start_intent(resolved=False))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert port.start_calls == []
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+async def test_out_of_scope_op_refused():
+    # An op not on the mask allow-list is refused outright (ADR-049 §D3).
+    agent, port, recorder = make_agent(mask=make_mask(scope=("KYCProviderPort.get_status",)))
+    outcome = await agent.start_onboarding(make_start_intent(confidence=0.95))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "out_of_scope"
+    assert port.start_calls == []
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+@pytest.mark.parametrize(
+    ("confidence", "expected"),
+    [
+        (0.91, ConfirmationDecision.AUTO),
+        (0.90, ConfirmationDecision.REVIEW),
+        (0.70, ConfirmationDecision.REVIEW),
+        (0.6999, ConfirmationDecision.BLOCK),
+    ],
+)
+async def test_confidence_band_boundaries(confidence, expected):
+    agent, _, _ = make_agent()
+    outcome = await agent.start_onboarding(
+        make_start_intent(confidence=confidence), human_reviewed_by="mlro@banxe"
+    )
+    assert outcome.decision is expected
+
+
+# ── Cost-cap breach ────────────────────────────────────────────────────────────
+
+
+async def test_per_request_cost_cap_breach_blocks():
+    agent, port, recorder = make_agent()
+    intent = make_start_intent(cost=RequestCost(tokens=999_999, cost=Decimal("0.01")))
+    outcome = await agent.start_onboarding(intent)
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert port.start_calls == []
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+    assert recorder.records[0].action_taken == "HALT_COST_CAP_BREACH"
+
+
+async def test_per_window_cost_cap_breach_blocks():
+    window = CostWindow(used_tokens=99_900, used_cost=Decimal("0.00"))
+    agent, port, _ = make_agent(cost_window=window)
+    outcome = await agent.start_onboarding(
+        make_start_intent(cost=RequestCost(tokens=200, cost=Decimal("0.01")))
+    )
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert port.start_calls == []
+
+
+async def test_window_accumulates_on_successful_action():
+    window = CostWindow()
+    agent, _, _ = make_agent(cost_window=window)
+    await agent.start_onboarding(
+        make_start_intent(cost=RequestCost(tokens=300, cost=Decimal("0.02")))
+    )
+    assert window.used_tokens == 300
+    assert window.used_cost == Decimal("0.02")
+
+
+# ── Compliance gate → MLRO escalation ──────────────────────────────────────────
+
+
+async def test_compliance_fail_blocks_and_escalates_mlro():
+    agent, port, recorder = make_agent()
+    outcome = await agent.start_onboarding(
+        make_start_intent(), compliance_result=ComplianceResult.FAIL
+    )
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert outcome.escalated_to == "MLRO"
+    assert port.start_calls == []
+    assert recorder.records[0].compliance_result is ComplianceResult.FAIL
+    assert recorder.records[0].action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert recorder.records[0].escalated_to == "MLRO"
+
+
+async def test_compliance_escalate_blocks_and_escalates_mlro():
+    agent, port, recorder = make_agent()
+    outcome = await agent.start_onboarding(
+        make_start_intent(), compliance_result=ComplianceResult.ESCALATE
+    )
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert port.start_calls == []
+    assert recorder.records[0].compliance_result is ComplianceResult.ESCALATE
+    assert recorder.records[0].escalated_to == "MLRO"
+
+
+# ── Webhook: signature + idempotency + provider error ──────────────────────────
+
+
+async def test_webhook_processed_emits_lineage():
+    agent, port, recorder = make_agent()
+    outcome = await agent.handle_provider_webhook(
+        {"event": "review.completed"}, "sig-good", correlation_id="corr-wh"
+    )
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert port.webhook_calls == [({"event": "review.completed"}, "sig-good")]
+    assert recorder.records[0].action_taken == "WEBHOOK_PROCESSED"
+    assert recorder.records[0].correlation_id == "corr-wh"
+    assert len(recorder.records) == 1
+
+
+async def test_webhook_idempotent_replay_no_state_change():
+    port = FakeKYCProviderPort(webhook=WebhookOutcome(processed=False, deduped=True, user_id="u1"))
+    agent, port, recorder = make_agent(port=port)
+    outcome = await agent.handle_provider_webhook({"event": "dup"}, "sig-good")
+
+    assert outcome.executed is False  # idempotent replay applied no state change
+    assert recorder.records[0].action_taken == "WEBHOOK_DEDUPED"
+    assert len(recorder.records) == 1
+
+
+async def test_webhook_invalid_signature_escalates_and_raises():
+    port = FakeKYCProviderPort(
+        webhook_raises=InvalidSignature("bad hmac", correlation_id="corr-wh")
+    )
+    agent, port, recorder = make_agent(port=port)
+    with pytest.raises(InvalidSignature):
+        await agent.handle_provider_webhook({"event": "spoof"}, "sig-bad")
+
+    # Lineage emitted even when the signature is rejected before processing.
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_WEBHOOK_ERROR:InvalidSignature"
+    assert recorder.records[0].escalated_to == "MLRO"
+    assert recorder.records[0].compliance_result is ComplianceResult.ESCALATE
+
+
+async def test_webhook_provider_unavailable_records_then_raises():
+    port = FakeKYCProviderPort(
+        webhook_raises=ProviderUnavailable("provider down", correlation_id="corr-wh")
+    )
+    agent, port, recorder = make_agent(port=port)
+    with pytest.raises(ProviderUnavailable):
+        await agent.handle_provider_webhook({"event": "x"}, "sig")
+
+    assert recorder.records[0].action_taken == "HALT_WEBHOOK_ERROR:ProviderUnavailable"
+
+
+# ── Window accounting on webhook ───────────────────────────────────────────────
+
+
+async def test_webhook_window_accumulates_only_when_processed():
+    window = CostWindow()
+    agent, _, _ = make_agent(cost_window=window)
+    await agent.handle_provider_webhook(
+        {"e": "1"}, "sig", request_cost=RequestCost(tokens=120, cost=Decimal("0.01"))
+    )
+    assert window.used_tokens == 120
+
+
+# ── Lineage obligation (ADR-046) ───────────────────────────────────────────────
+
+
+async def test_lineage_record_emitted_per_action_with_adr046_fields():
+    agent, _, recorder = make_agent()
+    await agent.start_onboarding(make_start_intent())
+    await agent.start_onboarding(make_start_intent(confidence=0.40))  # a halt also records
+    assert len(recorder.records) == 2
+
+    rec = recorder.records[0]
+    assert rec.record_id
+    assert rec.timestamp.tzinfo is not None
+    assert rec.agent_id == "kyc_onboarding_agent"
+    assert rec.intent == "Start my identity verification"
+    assert rec.correlation_id == "corr-1"
+    assert rec.policies_evaluated  # non-empty ordered policy list
+    assert 0.0 <= rec.confidence_score <= 1.0
+    assert rec.cost_tokens == 400
+    assert rec.cost_amount == Decimal("0.04")
+    assert rec.budget_window_ref == "kyc_onboarding_agent:default"
+
+
+async def test_invalid_confidence_raises():
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError):
+        await agent.check_status(make_status_intent(confidence=1.5))


### PR DESCRIPTION
## What

Third L2 client-facing agent (ADR-049 Intent Layer & Client-Facing Agent Masks), after `PaymentsAgent`/`FXExchangeAgent` in banxe-payment-core. Binds the **ADR-049 KYC onboarding mask** to `KYCProviderPort`.

New files only (zero collision — no `services/agents/` existed):
- `services/agents/kyc_onboarding_agent.py` + `services/agents/__init__.py`
- `tests/agents/test_kyc_onboarding_agent.py` + `tests/agents/__init__.py`

## ADR-049 KYC mask (§D3) enforced

| Mask field | This agent |
|---|---|
| `scope` | `KYCProviderPort` ops only (allow-list); off-list op → `REJECT_OUT_OF_SCOPE` |
| `autonomy_level` | REVIEW — identity decisions are L2 HITL; reads AUTO-eligible |
| `confirmation_policy` | AUTO>0.90 / REVIEW 0.70–0.90 / BLOCK<0.70 (ADR-047) + **mandatory HITL** on identity accept/decline + **biometric step-up** where the flow requires |
| `cost_cap` | per-request AND per-window, token + Decimal (ADR-047 §D2) |
| `lineage_obligation` | exactly one `AgentDecisionRecord` (ADR-046) on **every** exit path |
| `compliance_gate` | KYC + sanctions; non-PASS → halt + **MLRO escalation** (Ruflo mandatory for kyc) |

Fixed §D2 chain order on every action: `process_ref → scope → band → cost_cap → compliance → step-up → port call`. Mirrors the merged PaymentsAgent/FXExchangeAgent pattern. Honors ADR-046/047/048 exactly.

## Methods

- `start_onboarding` — REVIEW-biased → `start_session`; REVIEW band holds for HITL, proceeds with reviewer.
- `check_status` — low-consequence read of `get_status`, AUTO-eligible within cap; below-AUTO read halts for re-check.
- `accept_or_decline_identity` — identity DECISION: mandatory human reviewer regardless of band (else hold + MLRO escalate); biometric step-up where required; ACCEPT → `change_level`, DECLINE records the verdict with no provider mutation; blocked downgrade (`TierDowngradeBlocked`) → MLRO-escalated halt + re-raise.
- `handle_provider_webhook` — HMAC verified by the port before processing; idempotent replay (`deduped`) applies no state change; `InvalidSignature`/provider error → MLRO-escalated lineage + re-raise.

## Quality

- `ruff format` + `ruff check` clean; `bandit` clean; full suite **10007 passed, 5 skipped**.
- New module: **31 tests, 100% coverage** (AUTO read, REVIEW→HITL hold+proceed, identity mandatory-HITL, BLOCK low band, out-of-scope, cost-cap breach per-request+per-window, biometric step-up, compliance fail/escalate→MLRO, downgrade-blocked→MLRO, decline path, webhook idempotent+signature+error, lineage-per-action).

## Scope discipline

Existing `kyc_provider_port.py` and `kyc_port.py` are **untouched**. Change is additive: `services/agents/**` + its tests only. The port and `DecisionRecorder` are injected interfaces, never implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)