### PR TITLE
feat(agents): notification agent — ADR-049 Notifications mask (L2 client-facing) [IL-127]

### DIFF
--- a/services/agents/__init__.py
+++ b/services/agents/__init__.py
@@ -15,3 +15,39 @@ recorder are injected as interfaces; agents never implement them.
 """
 
 from __future__ import annotations
+
+from services.agents.notification_agent import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    AutonomyLevel,
+    BudgetBreach,
+    ChannelCheckIntent,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    NotificationAgent,
+    NotificationMask,
+    NotificationSendIntent,
+    ProcessRef,
+    RequestCost,
+)
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "AutonomyLevel",
+    "BudgetBreach",
+    "ChannelCheckIntent",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "NotificationAgent",
+    "NotificationMask",
+    "NotificationSendIntent",
+    "ProcessRef",
+    "RequestCost",
+]

--- a/services/agents/notification_agent.py
+++ b/services/agents/notification_agent.py
@@ -1,0 +1,696 @@
+"""NotificationAgent — L2 client-facing notification agent (ADR-049 Notifications mask).
+
+WHY: ADR-049 (Intent Layer & Client-Facing Agent Masks) specifies the
+client-facing **Notifications mask** (§D3 row "Notifications"): the governed
+surface through which a resolved client intent becomes a bounded, multi-channel
+notification dispatch. This module is the emi-stack sibling of
+``services/agents/kyc_onboarding_agent.py`` and the analogue of
+banxe-payment-core's ``src/agents/payments_agent.py`` / ``fx_exchange_agent.py``
+— it implements the agent *logic* and *governance enforcement* of the
+Notifications mask; it does NOT implement the port, the LLM-orchestration/routing
+layer (``AGENT_ROUTING_ENABLED`` stays out of scope — Terminal A infra,
+ADR-049 §D6/§D7), or the ClickHouse sink.
+
+The Notifications mask (ADR-049 §D3 row 178), enforced here in the fixed §D2
+chain order (process_ref → scope → band → cost_cap → compliance(PII) → port call;
+biometric step-up is N/A — a notification never moves client funds):
+
+* ``scope``                — ``NotificationProviderPort`` operations only (the
+                             allow-list: send / is_channel_available). The port
+                             is injected, never implemented here; an op not on the
+                             allow-list is rejected outright.
+* ``autonomy_level``       — AUTO-biased (low consequence, ADR-049 §D3): an
+                             INFORMATIONAL send defaults to AUTO within cap and a
+                             channel-availability read is AUTO-eligible.
+* ``confirmation_policy``  — AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70
+                             (ADR-047 thresholds, ADR-049 §D4). **Override:** a
+                             message that templates CLIENT FUNDS DATA
+                             (amounts/balances/transactions) is forced to the
+                             REVIEW band and held for a human reviewer
+                             *regardless of confidence* (ADR-049 §D3). No
+                             biometric step-up (not money movement, ADR-049 §D4).
+* ``cost_cap``             — per-request AND per-window hard caps, token AND
+                             monetary (Decimal) dimensions (ADR-047 §D2, ADR-049 §D3).
+* ``lineage_obligation``   — one ``AgentDecisionRecord`` per action (ADR-046),
+                             non-optional, emitted on every exit path.
+* ``compliance_gate``      — the PII-handling overlay (ADR-016): the L3 PII check
+                             MUST pass before a send; a non-PASS PII verdict halts
+                             (BLOCK) and escalates to the DPO.
+
+Any one of {unresolved process_ref, out-of-scope op, below-band confidence,
+funds-data REVIEW with no reviewer, cost-cap breach, PII-gate fail} halts the
+action (ADR-049 §D4 — independent halt conditions). Mask *values* (caps,
+thresholds, scope, gate, DPO role) are config-as-data (CLAUDE.md §10), carried on
+:class:`NotificationMask`, never hardcoded in flow logic.
+
+FUNDS-DATA DETECTION (assumption, documented):
+The "does this message template client funds data?" classification is performed
+**upstream** (the intent-resolution / templating layer) and carried into the agent
+as a single structured boolean — :attr:`NotificationSendIntent.contains_funds_data`.
+The agent HONORS that signal and never parses free text for amounts/balances
+(fragile-regex detection is explicitly out of scope, config-as-data per CLAUDE.md
+§10). A template that renders amounts, balances, or transaction lines sets
+``contains_funds_data=True`` at the call site; the agent then forces REVIEW.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
+import uuid
+
+from services.notifications.notification_provider_port import (
+    NotificationChannel,
+    NotificationError,
+    NotificationMessage,
+    NotificationProviderPort,
+    Recipient,
+)
+
+# ---------------------------------------------------------------------------
+# Mask vocabulary
+# ---------------------------------------------------------------------------
+
+
+class ConfirmationDecision(StrEnum):
+    """HITL band selected by the confirmation_policy (ADR-047 / ADR-049 §D4)."""
+
+    AUTO = "auto"
+    REVIEW = "review"
+    BLOCK = "block"
+
+
+class ComplianceResult(StrEnum):
+    """Net L3 compliance-gate (PII overlay, ADR-016) outcome on the lineage record."""
+
+    PASS = "PASS"  # nosec B105 # noqa: S105 — compliance verdict, not a credential
+    FAIL = "FAIL"
+    ESCALATE = "ESCALATE"
+    NA = "N/A"
+
+
+class BudgetBreach(StrEnum):
+    """Cost-cap breach flag for the lineage record (ADR-047 §D2/§D4)."""
+
+    NONE = "NONE"
+    WARN = "WARN"
+    BREACH = "BREACH"
+
+
+class AutonomyLevel(StrEnum):
+    """Mask autonomy posture (ADR-049 §D3). Notifications are AUTO-biased:
+    informational sends and channel reads are AUTO-eligible within cap; only a
+    funds-data send is forced down to REVIEW."""
+
+    AUTO_BIASED = "auto_biased"
+    REVIEW_BIASED = "review_biased"
+
+
+# ---------------------------------------------------------------------------
+# Value types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProcessRef:
+    """ADR-048 intent→process handle. Both fields required for a resolved intent."""
+
+    process_id: str
+    version: str
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.process_id) and bool(self.version)
+
+
+@dataclass(frozen=True)
+class RequestCost:
+    """Estimated cost of a single agent invocation (ADR-047 per-request dimensions)."""
+
+    tokens: int
+    cost: Decimal
+
+
+@dataclass(frozen=True)
+class CostCap:
+    """Hard caps in both token and monetary (Decimal) dimensions (ADR-047 §D2)."""
+
+    max_request_tokens: int
+    max_request_cost: Decimal
+    max_window_tokens: int
+    max_window_cost: Decimal
+
+
+@dataclass
+class CostWindow:
+    """Rolling per-window usage accumulator (ADR-047 §D2 per-window budget)."""
+
+    used_tokens: int = 0
+    used_cost: Decimal = Decimal("0")
+    window_ref: str = "notification_agent:default"
+
+    def add(self, cost: RequestCost) -> None:
+        self.used_tokens += cost.tokens
+        self.used_cost += cost.cost
+
+
+@dataclass(frozen=True)
+class NotificationMask:
+    """Config-as-data Notifications mask (ADR-049 §D3 row 178). Values are governed
+    config, not hardcoded flow logic; the AUTO/REVIEW/BLOCK *scale* is ADR-047
+    canon. The mask is the allow-list and the gate posture for the capability."""
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    autonomy_level: AutonomyLevel = AutonomyLevel.AUTO_BIASED
+    lineage_obligation: bool = True
+    # The data-protection role notified/escalated to on a PII-gate failure
+    # (ADR-016 PII-handling overlay). Config-as-data, never hardcoded in flow logic.
+    dpo_role: str = "DPO"
+    agent_id: str = "notification_agent"
+
+    # The mask scope (ADR-049 §D3 allow-list): the only port ops this mask may reach.
+    scope: tuple[str, ...] = (
+        "NotificationProviderPort.send",
+        "NotificationProviderPort.is_channel_available",
+    )
+
+    # L3 compliance contour required before any send: the PII overlay (ADR-016).
+    compliance_gate: tuple[str, ...] = ("PII",)
+
+
+@dataclass
+class NotificationSendIntent:
+    """A resolved client intent to dispatch a notification (``send``).
+
+    AUTO-biased (ADR-049 §D3): an informational send proceeds AUTO within cap.
+    **Override:** when :attr:`contains_funds_data` is True the message templates
+    client funds data (amounts/balances/transactions), so the action is forced to
+    the REVIEW band and held for a human reviewer regardless of confidence
+    (ADR-049 §D3). The funds-data classification is an upstream, structured signal
+    — the agent honors it and never regex-parses free text (see module docstring).
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    recipient: Recipient
+    message: NotificationMessage
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    contains_funds_data: bool = False
+
+
+@dataclass
+class ChannelCheckIntent:
+    """A resolved low-consequence read intent (``is_channel_available``) — the
+    mask's "reads are AUTO-eligible within cap" path (ADR-049 §D3). A read below
+    the AUTO band halts for a re-check, not a HITL hold; never carries funds data."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    channel: NotificationChannel
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class AgentDecisionRecord:
+    """Decision-lineage record emitted per action (ADR-046 schema + ADR-047 cost)."""
+
+    record_id: str
+    timestamp: datetime
+    agent_id: str
+    triggering_event: str
+    intent: str
+    policies_evaluated: list[str]
+    compliance_result: ComplianceResult
+    reasoning_summary: str
+    confidence_score: float
+    action_taken: str
+    human_reviewed_by: str | None
+    correlation_id: str
+    # ADR-047 cost lineage (cost is a first-class lineage dimension).
+    cost_tokens: int = 0
+    cost_amount: Decimal = Decimal("0")
+    budget_window_ref: str = ""
+    budget_breach_flag: BudgetBreach = BudgetBreach.NONE
+    # DPO escalation marker (ADR-016); set on a PII-gate fail/escalate.
+    escalated_to: str | None = None
+
+
+@dataclass
+class AgentOutcome:
+    """Result of a masked action: the decision, whether a port was called, and the
+    lineage record that was emitted (always non-None — lineage is non-optional).
+
+    ``requires_step_up`` is carried for shape-parity with the sibling agents'
+    outcome; the Notifications mask never sets it (biometric step-up is N/A, a
+    notification never moves client funds — ADR-049 §D4)."""
+
+    decision: ConfirmationDecision
+    executed: bool
+    record: AgentDecisionRecord
+    result: object | None = None
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+class DecisionRecorder(ABC):
+    """Sink for :class:`AgentDecisionRecord` (ADR-046 producer→sink seam).
+
+    Injected, not implemented here: the ClickHouse/lineage wiring is out of scope
+    (ADR-049 §D7). The agent depends only on this interface.
+    """
+
+    @abstractmethod
+    async def record(self, record: AgentDecisionRecord) -> None:
+        """Persist one decision-lineage record. Must be durable before the action
+        is considered complete (ADR-046 §D4 producer obligation)."""
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    """All inputs a single masked action evaluates against."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+    human_reviewed_by: str | None
+    # A send supports a REVIEW-band HITL hold; a channel read is AUTO-only and
+    # instead halts below the AUTO band. Defaults False so the read path is unchanged.
+    supports_review_hitl: bool = False
+    # Funds-data override: a send templating client funds data is forced to the
+    # REVIEW band and held for a reviewer regardless of confidence (ADR-049 §D3).
+    force_review: bool = False
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class NotificationAgent:
+    """L2 notification agent enforcing the ADR-049 Notifications mask.
+
+    The provider port and the lineage recorder are injected as interfaces
+    (constructor injection); the agent contains pure governance logic and is
+    unit-testable without any live infra.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider_port: NotificationProviderPort,
+        recorder: DecisionRecorder,
+        mask: NotificationMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._provider = provider_port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def send_notification(
+        self,
+        intent: NotificationSendIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        """Dispatch a notification via ``NotificationProviderPort.send`` under the mask.
+
+        AUTO-biased (ADR-049 §D3): an informational send within cap proceeds AUTO.
+        If ``intent.contains_funds_data`` is set the message templates client funds
+        data, so the action is forced to the REVIEW band and held for a human
+        reviewer regardless of confidence; supply ``human_reviewed_by`` to proceed.
+        The PII overlay (ADR-016) gate (``compliance_result``) must PASS before the
+        port is called; a non-PASS PII verdict blocks and escalates to the DPO.
+        """
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=(
+                f"send_notification:{intent.recipient.user_id}:{intent.message.severity.value}"
+            ),
+            success_action="SEND_NOTIFICATION",
+            op="NotificationProviderPort.send",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=human_reviewed_by,
+            supports_review_hitl=True,
+            force_review=intent.contains_funds_data,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._provider.send(intent.recipient, intent.message),
+        )
+
+    async def check_channel(
+        self,
+        intent: ChannelCheckIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Low-consequence read via ``NotificationProviderPort.is_channel_available``
+        — AUTO-eligible, no HITL hold (the mask's within-cap read path, ADR-049 §D3).
+        A read below the AUTO band halts for a re-check, not a HITL hold."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"check_channel:{intent.channel.value}",
+            success_action="CHECK_CHANNEL_AVAILABLE",
+            op="NotificationProviderPort.is_channel_available",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=None,
+        )
+        return await self._run_action(
+            ctx, lambda: self._provider.is_channel_available(intent.channel)
+        )
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be in [0.0, 1.0]")
+        policies = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no port call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. ADR-049 §D3 — mask scope allow-list; an off-list op is refused outright.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op} is not on the Notifications mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band (AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70)
+        #    + ADR-049 §D3 funds-data override (force REVIEW regardless of confidence).
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+        if ctx.force_review and band is ConfirmationDecision.AUTO:
+            # Funds-data send: an otherwise-AUTO send is pulled down to REVIEW so a
+            # human confirms anything templating client funds (ADR-049 §D3).
+            policies.append("ADR-049-D3-funds-data-REVIEW")
+            band = ConfirmationDecision.REVIEW
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+        if band is ConfirmationDecision.REVIEW:
+            # Read path: reads are AUTO-only, so a below-AUTO read halts for a
+            # re-check at higher confidence, not a HITL hold (ADR-049 §D3).
+            if not ctx.supports_review_hitl:
+                return _Evaluation(
+                    band,
+                    False,
+                    "HALT_REVIEW_DEFERRED",
+                    "Read intent below AUTO band; reads are AUTO-only, no HITL hold (ADR-049 §D3).",
+                    policies,
+                    ctx.compliance_result,
+                    BudgetBreach.NONE,
+                    halt_reason="review_deferred",
+                    requires_hitl=True,
+                )
+            # Send in the REVIEW band (low confidence OR funds-data) holds for HITL.
+            if ctx.human_reviewed_by is None:
+                reason = (
+                    "Funds-data send pulled to REVIEW; paused for HITL regardless of confidence."
+                    if ctx.force_review
+                    else "Send in REVIEW band; paused for HITL confirmation (ADR-049 §D4)."
+                )
+                return _Evaluation(
+                    band,
+                    False,
+                    "HOLD_FOR_REVIEW",
+                    reason,
+                    policies,
+                    ctx.compliance_result,
+                    BudgetBreach.NONE,
+                    halt_reason="hitl_review_required",
+                    requires_hitl=True,
+                )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window); action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. L3 compliance gate — PII-handling overlay (ADR-016). A non-PASS PII
+        #    verdict halts AND escalates to the DPO.
+        policies.append("ADR-016-PII-overlay:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"PII overlay returned {ctx.compliance_result}; "
+                f"send blocked and escalated to {self._mask.dpo_role} (ADR-016).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=self._mask.dpo_role,
+            )
+
+        # Biometric step-up: N/A for notifications (no money movement, ADR-049 §D4).
+        # All gates satisfied — clear to commit the action.
+        reviewer = (
+            "" if ctx.human_reviewed_by is None else f" (reviewed by {ctx.human_reviewed_by})"
+        )
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All mask gates satisfied at {band.value} confidence{reviewer}; committing within scope.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except NotificationError as exc:
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=ev.compliance_result,
+                        reasoning=f"Provider rejected the action: {exc}",
+                        escalated_to=ev.escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        return await self._record(
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies=ev.policies,
+            compliance_result=compliance_result,
+            reasoning=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=ctx.human_reviewed_by,
+            correlation_id=ctx.correlation_id,
+            request_cost=ctx.request_cost,
+            budget_breach=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+
+    async def _record(
+        self,
+        *,
+        triggering_event: str,
+        intent: str,
+        policies: list[str],
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        confidence_score: float,
+        action_taken: str,
+        human_reviewed_by: str | None,
+        correlation_id: str,
+        request_cost: RequestCost,
+        budget_breach: BudgetBreach,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        """Build, persist, and return exactly one ADR-046 lineage record (the single
+        producer→sink seam used by every exit path)."""
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=triggering_event,
+            intent=intent,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=human_reviewed_by,
+            correlation_id=correlation_id,
+            cost_tokens=request_cost.tokens,
+            cost_amount=request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "AutonomyLevel",
+    "BudgetBreach",
+    "ChannelCheckIntent",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "NotificationAgent",
+    "NotificationMask",
+    "NotificationSendIntent",
+    "ProcessRef",
+    "RequestCost",
+]

--- a/tests/agents/test_notification_agent.py
+++ b/tests/agents/test_notification_agent.py
@@ -1,0 +1,498 @@
+"""Tests for the ADR-049 Notifications mask agent
+(services/agents/notification_agent.py).
+
+Covers every mask path in the §D2 gate-chain order:
+AUTO informational send, the funds-data override → forced REVIEW HITL hold then
+proceed-with-reviewer (regardless of confidence), PII-gate fail → BLOCK + DPO
+escalation, cost-cap breach (per-request and per-window), the AUTO channel-read
+(check_channel) and its below-AUTO re-check halt, BLOCK on low confidence,
+out-of-scope refusal, unresolved process_ref, provider-error lineage, and the
+lineage-per-action obligation (ADR-046). The port and the recorder are fakes —
+the agent is exercised as pure governance logic with no live infra.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents.notification_agent import (
+    AgentDecisionRecord,
+    AutonomyLevel,
+    BudgetBreach,
+    ChannelCheckIntent,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    NotificationAgent,
+    NotificationMask,
+    NotificationSendIntent,
+    ProcessRef,
+    RequestCost,
+)
+from services.notifications.notification_provider_port import (
+    DeliveryResult,
+    NotificationChannel,
+    NotificationMessage,
+    NotificationProviderPort,
+    Recipient,
+    Severity,
+    ValidationError,
+)
+
+# ── Fakes (the port & sink are injected interfaces; never implemented in services) ──
+
+
+class FakeRecorder(DecisionRecorder):
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+class FakeNotificationProviderPort(NotificationProviderPort):
+    """In-test NotificationProviderPort double. Records calls; returns canned
+    results or raises a configured error so the agent's governance logic is
+    exercised without any live provider."""
+
+    def __init__(
+        self,
+        *,
+        send_result: list[DeliveryResult] | None = None,
+        available: bool = True,
+        send_raises: Exception | None = None,
+    ) -> None:
+        self._send_result = send_result or [
+            DeliveryResult(
+                channel=NotificationChannel.EMAIL,
+                delivered=True,
+                deduped=False,
+                provider_message_id="msg-1",
+            )
+        ]
+        self._available = available
+        self._send_raises = send_raises
+        self.send_calls: list[tuple[Recipient, NotificationMessage]] = []
+        self.available_calls: list[NotificationChannel] = []
+
+    async def send(
+        self, recipient: Recipient, message: NotificationMessage
+    ) -> list[DeliveryResult]:
+        self.send_calls.append((recipient, message))
+        if self._send_raises is not None:
+            raise self._send_raises
+        return self._send_result
+
+    async def is_channel_available(self, channel: NotificationChannel) -> bool:
+        self.available_calls.append(channel)
+        return self._available
+
+
+# ── Builders ──────────────────────────────────────────────────────────────────
+
+
+def make_mask(**overrides) -> NotificationMask:
+    base = {
+        "cost_cap": CostCap(
+            max_request_tokens=10_000,
+            max_request_cost=Decimal("1.00"),
+            max_window_tokens=100_000,
+            max_window_cost=Decimal("10.00"),
+        ),
+    }
+    base.update(overrides)
+    return NotificationMask(**base)
+
+
+def make_agent(
+    *,
+    mask: NotificationMask | None = None,
+    port: FakeNotificationProviderPort | None = None,
+    recorder: FakeRecorder | None = None,
+    cost_window: CostWindow | None = None,
+) -> tuple[NotificationAgent, FakeNotificationProviderPort, FakeRecorder]:
+    port = port or FakeNotificationProviderPort()
+    recorder = recorder or FakeRecorder()
+    agent = NotificationAgent(
+        provider_port=port,
+        recorder=recorder,
+        mask=mask or make_mask(),
+        cost_window=cost_window,
+    )
+    return agent, port, recorder
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    return (
+        ProcessRef(process_id="PROC-NOTIFY", version="1")
+        if resolved
+        else ProcessRef(process_id="", version="")
+    )
+
+
+def _recipient() -> Recipient:
+    return Recipient(user_id="u1", channel_preferences=[NotificationChannel.EMAIL])
+
+
+def _message(severity: Severity = Severity.INFO) -> NotificationMessage:
+    return NotificationMessage(
+        severity=severity,
+        subject="Your weekly summary",
+        body="Here is an update for you.",
+        correlation_id="corr-1",
+        dedupe_key="dk-1",
+    )
+
+
+def make_send_intent(
+    *,
+    confidence: float = 0.95,
+    cost: RequestCost | None = None,
+    resolved: bool = True,
+    contains_funds_data: bool = False,
+    severity: Severity = Severity.INFO,
+) -> NotificationSendIntent:
+    return NotificationSendIntent(
+        intent_text="Send my account notification",
+        process_ref=_ref(resolved),
+        recipient=_recipient(),
+        message=_message(severity),
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=cost or RequestCost(tokens=200, cost=Decimal("0.02")),
+        contains_funds_data=contains_funds_data,
+    )
+
+
+def make_channel_intent(
+    *, confidence: float = 0.99, channel: NotificationChannel = NotificationChannel.EMAIL
+) -> ChannelCheckIntent:
+    return ChannelCheckIntent(
+        intent_text="Is email delivery available?",
+        process_ref=_ref(),
+        channel=channel,
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=RequestCost(tokens=20, cost=Decimal("0.005")),
+    )
+
+
+# ── AUTO informational send ─────────────────────────────────────────────────────
+
+
+async def test_auto_informational_send_executes_no_hitl():
+    agent, port, recorder = make_agent()
+    outcome = await agent.send_notification(make_send_intent(confidence=0.95))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert outcome.requires_hitl is False
+    assert outcome.requires_step_up is False
+    assert len(port.send_calls) == 1
+    assert recorder.records[0].action_taken == "SEND_NOTIFICATION"
+    assert len(recorder.records) == 1
+
+
+async def test_send_result_surfaced_on_outcome():
+    port = FakeNotificationProviderPort(
+        send_result=[
+            DeliveryResult(
+                channel=NotificationChannel.SMS,
+                delivered=True,
+                deduped=False,
+                provider_message_id="m9",
+            )
+        ]
+    )
+    agent, port, _ = make_agent(port=port)
+    outcome = await agent.send_notification(make_send_intent())
+    assert isinstance(outcome.result, list)
+    assert outcome.result[0].channel is NotificationChannel.SMS
+
+
+# ── Funds-data override: forced REVIEW regardless of confidence ──────────────────
+
+
+async def test_funds_data_forces_review_hold_even_at_auto_confidence():
+    agent, port, recorder = make_agent()
+    outcome = await agent.send_notification(
+        make_send_intent(confidence=0.99, contains_funds_data=True)
+    )
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.requires_hitl is True
+    assert outcome.halt_reason == "hitl_review_required"
+    assert port.send_calls == []
+    assert recorder.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert recorder.records[0].human_reviewed_by is None
+    assert "ADR-049-D3-funds-data-REVIEW" in recorder.records[0].policies_evaluated
+
+
+async def test_funds_data_proceeds_with_reviewer():
+    agent, port, recorder = make_agent()
+    outcome = await agent.send_notification(
+        make_send_intent(confidence=0.99, contains_funds_data=True),
+        human_reviewed_by="ops@banxe",
+    )
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is True
+    assert len(port.send_calls) == 1
+    assert recorder.records[0].action_taken == "SEND_NOTIFICATION"
+    assert recorder.records[0].human_reviewed_by == "ops@banxe"
+
+
+async def test_non_funds_data_review_band_holds_for_hitl():
+    # A plain informational send in the REVIEW band still holds for HITL.
+    agent, port, recorder = make_agent()
+    outcome = await agent.send_notification(make_send_intent(confidence=0.80))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.requires_hitl is True
+    assert port.send_calls == []
+    assert recorder.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert "ADR-049-D3-funds-data-REVIEW" not in recorder.records[0].policies_evaluated
+
+
+async def test_review_band_with_reviewer_proceeds():
+    agent, port, recorder = make_agent()
+    outcome = await agent.send_notification(
+        make_send_intent(confidence=0.80), human_reviewed_by="ops@banxe"
+    )
+    assert outcome.executed is True
+    assert recorder.records[0].action_taken == "SEND_NOTIFICATION"
+    assert recorder.records[0].human_reviewed_by == "ops@banxe"
+
+
+# ── PII overlay (ADR-016) compliance gate ────────────────────────────────────────
+
+
+async def test_pii_fail_blocks_and_escalates_dpo():
+    agent, port, recorder = make_agent()
+    outcome = await agent.send_notification(
+        make_send_intent(), compliance_result=ComplianceResult.FAIL
+    )
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert outcome.escalated_to == "DPO"
+    assert port.send_calls == []
+    assert recorder.records[0].action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert recorder.records[0].compliance_result is ComplianceResult.FAIL
+    assert recorder.records[0].escalated_to == "DPO"
+
+
+async def test_pii_escalate_blocks_and_escalates_dpo():
+    agent, port, recorder = make_agent()
+    outcome = await agent.send_notification(
+        make_send_intent(), compliance_result=ComplianceResult.ESCALATE
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert port.send_calls == []
+    assert recorder.records[0].escalated_to == "DPO"
+
+
+# ── check_channel: AUTO read + below-AUTO re-check ───────────────────────────────
+
+
+async def test_check_channel_auto_read_executes():
+    agent, port, recorder = make_agent()
+    outcome = await agent.check_channel(make_channel_intent(confidence=0.99))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert outcome.requires_hitl is False
+    assert port.available_calls == [NotificationChannel.EMAIL]
+    assert outcome.result is True
+    assert recorder.records[0].action_taken == "CHECK_CHANNEL_AVAILABLE"
+    assert len(recorder.records) == 1
+
+
+async def test_check_channel_below_auto_halts_for_recheck():
+    # Reads are AUTO-only: a below-AUTO read halts (re-check), not a HITL hold.
+    agent, port, recorder = make_agent()
+    outcome = await agent.check_channel(make_channel_intent(confidence=0.80))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert port.available_calls == []
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+async def test_check_channel_unavailable_returns_false_result():
+    port = FakeNotificationProviderPort(available=False)
+    agent, port, _ = make_agent(port=port)
+    outcome = await agent.check_channel(make_channel_intent(confidence=0.99))
+    assert outcome.executed is True
+    assert outcome.result is False
+
+
+# ── BLOCK / scope / process resolution ───────────────────────────────────────────
+
+
+async def test_block_low_confidence_send():
+    agent, port, recorder = make_agent()
+    outcome = await agent.send_notification(make_send_intent(confidence=0.40))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert port.send_calls == []
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+async def test_block_low_confidence_read():
+    agent, port, recorder = make_agent()
+    outcome = await agent.check_channel(make_channel_intent(confidence=0.40))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert port.available_calls == []
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+async def test_unresolved_process_ref_blocks():
+    agent, port, recorder = make_agent()
+    outcome = await agent.send_notification(make_send_intent(resolved=False))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert port.send_calls == []
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+async def test_out_of_scope_op_refused():
+    # An op not on the mask allow-list is refused outright (ADR-049 §D3).
+    agent, port, recorder = make_agent(
+        mask=make_mask(scope=("NotificationProviderPort.is_channel_available",))
+    )
+    outcome = await agent.send_notification(make_send_intent(confidence=0.95))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "out_of_scope"
+    assert port.send_calls == []
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+@pytest.mark.parametrize(
+    ("confidence", "expected"),
+    [
+        (0.91, ConfirmationDecision.AUTO),
+        (0.90, ConfirmationDecision.REVIEW),
+        (0.70, ConfirmationDecision.REVIEW),
+        (0.6999, ConfirmationDecision.BLOCK),
+    ],
+)
+async def test_confidence_band_boundaries(confidence, expected):
+    agent, _, _ = make_agent()
+    outcome = await agent.send_notification(
+        make_send_intent(confidence=confidence), human_reviewed_by="ops@banxe"
+    )
+    assert outcome.decision is expected
+
+
+# ── Cost-cap breach ──────────────────────────────────────────────────────────────
+
+
+async def test_per_request_cost_cap_breach_blocks():
+    agent, port, recorder = make_agent()
+    intent = make_send_intent(cost=RequestCost(tokens=999_999, cost=Decimal("0.01")))
+    outcome = await agent.send_notification(intent)
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert port.send_calls == []
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+    assert recorder.records[0].action_taken == "HALT_COST_CAP_BREACH"
+
+
+async def test_per_window_cost_cap_breach_blocks():
+    window = CostWindow(used_tokens=99_900, used_cost=Decimal("0.00"))
+    agent, port, _ = make_agent(cost_window=window)
+    outcome = await agent.send_notification(
+        make_send_intent(cost=RequestCost(tokens=200, cost=Decimal("0.01")))
+    )
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert port.send_calls == []
+
+
+async def test_window_accumulates_on_successful_send():
+    window = CostWindow()
+    agent, _, _ = make_agent(cost_window=window)
+    await agent.send_notification(
+        make_send_intent(cost=RequestCost(tokens=300, cost=Decimal("0.02")))
+    )
+    assert window.used_tokens == 300
+    assert window.used_cost == Decimal("0.02")
+
+
+# ── Provider error → lineage then re-raise ───────────────────────────────────────
+
+
+async def test_provider_validation_error_records_then_raises():
+    port = FakeNotificationProviderPort(
+        send_raises=ValidationError("empty body", correlation_id="corr-1", dedupe_key="dk-1")
+    )
+    agent, port, recorder = make_agent(port=port)
+    with pytest.raises(ValidationError):
+        await agent.send_notification(make_send_intent(confidence=0.95))
+
+    # Lineage emitted even when the provider rejects the send.
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_PROVIDER_ERROR:ValidationError"
+
+
+# ── Lineage obligation (ADR-046) ─────────────────────────────────────────────────
+
+
+async def test_lineage_record_emitted_per_action_with_adr046_fields():
+    agent, _, recorder = make_agent()
+    await agent.send_notification(make_send_intent())
+    await agent.send_notification(make_send_intent(confidence=0.40))  # a halt also records
+    assert len(recorder.records) == 2
+
+    rec = recorder.records[0]
+    assert rec.record_id
+    assert rec.timestamp.tzinfo is not None
+    assert rec.agent_id == "notification_agent"
+    assert rec.intent == "Send my account notification"
+    assert rec.correlation_id == "corr-1"
+    assert rec.policies_evaluated  # non-empty ordered policy list
+    assert 0.0 <= rec.confidence_score <= 1.0
+    assert rec.cost_tokens == 200
+    assert rec.cost_amount == Decimal("0.02")
+    assert rec.budget_window_ref == "notification_agent:default"
+
+
+async def test_invalid_confidence_raises():
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError):
+        await agent.send_notification(make_send_intent(confidence=1.5))
+
+
+# ── Mask config-as-data ──────────────────────────────────────────────────────────
+
+
+async def test_mask_is_auto_biased_with_pii_gate():
+    mask = make_mask()
+    assert mask.autonomy_level is AutonomyLevel.AUTO_BIASED
+    assert mask.compliance_gate == ("PII",)
+    assert mask.dpo_role == "DPO"
+    assert "NotificationProviderPort.send" in mask.scope
+
+
+async def test_custom_dpo_role_used_on_pii_block():
+    agent, _, recorder = make_agent(mask=make_mask(dpo_role="DataOfficer"))
+    outcome = await agent.send_notification(
+        make_send_intent(), compliance_result=ComplianceResult.FAIL
+    )
+    assert outcome.escalated_to == "DataOfficer"
+    assert recorder.records[0].escalated_to == "DataOfficer"


### PR DESCRIPTION
## What

4th L2 client-facing agent: **NotificationAgent**, binding the ADR-049 §D3 **Notifications mask** (line 178: scope=`NotificationProviderPort`; AUTO-biased, low consequence; PII-handling overlay ADR-016). Sibling of the merged `KYCOnboardingAgent` (#151); same fixed §D2 gate chain.

## Gate chain (§D2)
`process_ref` (ADR-048) → `scope` allow-list (ADR-049 §D3) → confidence `band` (ADR-047) → `cost_cap` per-request **and** per-window (ADR-047) → `compliance` PII overlay (ADR-016) → port call. Exactly one `AgentDecisionRecord` (ADR-046) per action on every exit path.

## Methods
- **`send_notification`** — AUTO within cap for informational sends. A message templating **client funds data** (amounts/balances/transactions) is forced to **REVIEW** (HITL hold) **regardless of confidence**; proceeds only with a reviewer. Funds-data is an upstream **structured signal** (`contains_funds_data`) — no fragile regex on free text. PII gate must `PASS`; a non-PASS verdict **BLOCKs** and escalates to the **DPO**. Calls `NotificationProviderPort.send`.
- **`check_channel`** — low-consequence AUTO-eligible read via `is_channel_available`; below-AUTO halts for re-check (no HITL).
- No biometric step-up (not money movement, ADR-049 §D4).

## Files
- `services/agents/notification_agent.py` (new)
- `services/agents/__init__.py` (extend package exports)
- `tests/agents/test_notification_agent.py` (new — 27 tests, all mask paths)

Ports (`notification_provider_port.py`, `notification_port.py`) **injected as interfaces, never implemented; untouched**. Changes are confined to `services/agents/**` + tests.

## Tests
27 tests, **100%** coverage on `notification_agent.py`: AUTO send, funds-data→forced-REVIEW hold + proceed-with-reviewer, PII-fail→BLOCK+DPO, cost-cap breach (per-request + per-window), check_channel AUTO read + below-AUTO re-check, BLOCK low band (send + read), unresolved process_ref, out-of-scope, provider-error lineage, lineage-per-action, band boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a governance agent for notification operations with built-in cost controls, compliance checks, and autonomy levels.
  * Added cost cap enforcement (per-request and per-window), channel availability verification, and human review workflows.
  * Includes audit trail and decision recording for compliance tracking.

* **Tests**
  * Added comprehensive test coverage for notification governance agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->