### PR TITLE
feat(agents): CRM agent — ADR-049 Referral/CRM mask (L2 client-facing) [IL-128]

### DIFF
--- a/services/agents/__init__.py
+++ b/services/agents/__init__.py
@@ -16,6 +16,15 @@ recorder are injected as interfaces; agents never implement them.
 
 from __future__ import annotations
 
+from services.agents.crm_agent import (
+    ComplianceOverlay,
+    CRMAgent,
+    CRMMask,
+    GetUserIntent,
+    RegisterReferralIntent,
+    ResolveCodeIntent,
+    UpdateTierIntent,
+)
 from services.agents.notification_agent import (
     AgentDecisionRecord,
     AgentOutcome,
@@ -34,20 +43,34 @@ from services.agents.notification_agent import (
     RequestCost,
 )
 
+# NOTE: the agents share structurally-identical governance primitives
+# (ProcessRef, RequestCost, CostCap, CostWindow, DecisionRecorder, ComplianceResult,
+# ConfirmationDecision, BudgetBreach, AutonomyLevel, AgentDecisionRecord,
+# AgentOutcome). The package re-exports one canonical set (from notification_agent);
+# the CRM-specific public types are re-exported alongside. Import the per-agent
+# module directly (e.g. ``services.agents.crm_agent``) when the module-local
+# identity of a shared primitive matters.
 __all__ = [
     "AgentDecisionRecord",
     "AgentOutcome",
     "AutonomyLevel",
     "BudgetBreach",
+    "CRMAgent",
+    "CRMMask",
     "ChannelCheckIntent",
+    "ComplianceOverlay",
     "ComplianceResult",
     "ConfirmationDecision",
     "CostCap",
     "CostWindow",
     "DecisionRecorder",
+    "GetUserIntent",
     "NotificationAgent",
     "NotificationMask",
     "NotificationSendIntent",
     "ProcessRef",
+    "RegisterReferralIntent",
     "RequestCost",
+    "ResolveCodeIntent",
+    "UpdateTierIntent",
 ]

--- a/services/agents/crm_agent.py
+++ b/services/agents/crm_agent.py
@@ -1,0 +1,850 @@
+"""CRMAgent — L2 client-facing referral/CRM agent (ADR-049 Referral / CRM mask).
+
+WHY: ADR-049 (Intent Layer & Client-Facing Agent Masks) specifies the
+client-facing **Referral / CRM mask** (§D3 row "Referral / CRM"): the governed
+surface through which a resolved client intent becomes a bounded referral or CRM
+profile action. This module is the emi-stack sibling of
+``services/agents/kyc_onboarding_agent.py`` and
+``services/agents/notification_agent.py`` and the analogue of banxe-payment-core's
+``src/agents/payments_agent.py`` / ``fx_exchange_agent.py`` — it implements the
+agent *logic* and *governance enforcement* of the Referral / CRM mask; it does
+NOT implement the port (``services/crm/crm_provider_port.py`` is UNTOUCHED), the
+legacy referral domain (``services/referral/*`` is UNTOUCHED), the
+LLM-orchestration/routing layer (``AGENT_ROUTING_ENABLED`` stays out of scope —
+Terminal A infra, ADR-049 §D6/§D7), or the ClickHouse sink.
+
+The Referral / CRM mask (ADR-049 §D3 row "Referral / CRM"), enforced here in the
+fixed §D2 chain order (process_ref → scope → band → cost_cap →
+compliance(PII + anti-abuse) → [step-up N/A] → port call; biometric step-up is
+N/A — a referral/CRM update never moves client funds):
+
+* ``scope``                — ``CRMProviderPort`` operations only (the allow-list:
+                             register_referral / resolve_referral_code / get_user
+                             / update_user_tier). The port is injected, never
+                             implemented here; an op not on the allow-list is
+                             rejected outright.
+* ``autonomy_level``       — AUTO-biased (ADR-049 §D3): a routine referral
+                             registration or tier update proceeds AUTO within cap
+                             and a code-resolution/profile read is AUTO-eligible.
+* ``confirmation_policy``  — AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70
+                             (ADR-047 thresholds, ADR-049 §D4). **Override:** an
+                             incentive/payout-linked action (register_referral or
+                             update_user_tier carrying ``payout_linked``) is forced
+                             to the REVIEW band and held for a human reviewer
+                             *regardless of confidence* (ADR-049 §D3 "REVIEW for
+                             incentive/payout-linked actions"). No biometric
+                             step-up (not money movement, ADR-049 §D4).
+* ``cost_cap``             — per-request AND per-window hard caps, token AND
+                             monetary (Decimal) dimensions (ADR-047 §D2, ADR-049 §D3).
+* ``lineage_obligation``   — one ``AgentDecisionRecord`` per action (ADR-046),
+                             non-optional, emitted on every exit path.
+* ``compliance_gate``      — the PII + anti-abuse overlay (ADR-016 PII-handling +
+                             referral anti-abuse, R-COMP-FCA-03): the L3 check MUST
+                             pass before a port call; a non-PASS verdict halts
+                             (BLOCK). A PII failure escalates to the DPO; an
+                             anti-abuse failure (self-referral / duplicate pair,
+                             defined by the CONTRACT) escalates to AML.
+
+Any one of {unresolved process_ref, out-of-scope op, below-band confidence,
+payout-linked REVIEW with no reviewer, cost-cap breach, compliance(PII/anti-abuse)
+fail} halts the action (ADR-049 §D4 — independent halt conditions). Mask *values*
+(caps, thresholds, scope, gate, escalation roles) are config-as-data (CLAUDE.md
+§10), carried on :class:`CRMMask`, never hardcoded in flow logic.
+
+PAYOUT / INCENTIVE DETECTION (assumption, documented):
+The "is this referral/tier action incentive- or payout-linked?" classification is
+performed **upstream** (the intent-resolution layer) and carried into the agent as
+a single structured boolean — :attr:`RegisterReferralIntent.payout_linked` /
+:attr:`UpdateTierIntent.payout_linked`. The agent HONORS that signal and never
+parses free text for amounts/incentives (fragile-regex detection is explicitly out
+of scope, config-as-data per CLAUDE.md §10). When the upstream layer marks an
+action payout-linked it sets ``payout_linked=True`` at the call site; the agent
+then forces REVIEW.
+
+ANTI-ABUSE (assumption, documented):
+Self-referral and duplicate-pair are CONTRACT-defined abuse conditions
+(``crm_provider_port.py``: SelfReferral / AlreadyRegistered). The L3 anti-abuse
+overlay classifies them upstream and the verdict is carried in as the
+``compliance_result`` (PII + anti-abuse net verdict); a non-PASS verdict BLOCKs
+the action before the port is ever called and escalates to AML. The port enforces
+the same conditions as defense-in-depth (a CONTRACT ``RegisterReferralResult`` with
+``accepted=False`` / ``reason`` is surfaced verbatim on the outcome).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
+import uuid
+
+from services.crm.crm_provider_port import (
+    CRMProviderError,
+    CRMProviderPort,
+    CRMUserId,
+    ReferralCode,
+    ReferralEvent,
+)
+
+# ---------------------------------------------------------------------------
+# Mask vocabulary
+# ---------------------------------------------------------------------------
+
+
+class ConfirmationDecision(StrEnum):
+    """HITL band selected by the confirmation_policy (ADR-047 / ADR-049 §D4)."""
+
+    AUTO = "auto"
+    REVIEW = "review"
+    BLOCK = "block"
+
+
+class ComplianceResult(StrEnum):
+    """Net L3 compliance-gate (PII + anti-abuse overlay) outcome on the lineage record."""
+
+    PASS = "PASS"  # nosec B105 # noqa: S105 — compliance verdict, not a credential
+    FAIL = "FAIL"
+    ESCALATE = "ESCALATE"
+    NA = "N/A"
+
+
+class BudgetBreach(StrEnum):
+    """Cost-cap breach flag for the lineage record (ADR-047 §D2/§D4)."""
+
+    NONE = "NONE"
+    WARN = "WARN"
+    BREACH = "BREACH"
+
+
+class AutonomyLevel(StrEnum):
+    """Mask autonomy posture (ADR-049 §D3). Referral / CRM is AUTO-biased: routine
+    referral/tier updates and reads are AUTO-eligible within cap; only an
+    incentive/payout-linked action is forced down to REVIEW."""
+
+    AUTO_BIASED = "auto_biased"
+    REVIEW_BIASED = "review_biased"
+
+
+class ComplianceOverlay(StrEnum):
+    """Which arm of the PII + anti-abuse gate is the primary escalation route for an
+    action (ADR-049 §D3 compliance_gate). Both overlays gate every action; this
+    selects the role a non-PASS verdict escalates to: PII → DPO, anti-abuse → AML."""
+
+    PII = "PII"
+    ANTI_ABUSE = "ANTI_ABUSE"
+
+
+# ---------------------------------------------------------------------------
+# Value types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProcessRef:
+    """ADR-048 intent→process handle. Both fields required for a resolved intent."""
+
+    process_id: str
+    version: str
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.process_id) and bool(self.version)
+
+
+@dataclass(frozen=True)
+class RequestCost:
+    """Estimated cost of a single agent invocation (ADR-047 per-request dimensions)."""
+
+    tokens: int
+    cost: Decimal
+
+
+@dataclass(frozen=True)
+class CostCap:
+    """Hard caps in both token and monetary (Decimal) dimensions (ADR-047 §D2)."""
+
+    max_request_tokens: int
+    max_request_cost: Decimal
+    max_window_tokens: int
+    max_window_cost: Decimal
+
+
+@dataclass
+class CostWindow:
+    """Rolling per-window usage accumulator (ADR-047 §D2 per-window budget)."""
+
+    used_tokens: int = 0
+    used_cost: Decimal = Decimal("0")
+    window_ref: str = "crm_agent:default"
+
+    def add(self, cost: RequestCost) -> None:
+        self.used_tokens += cost.tokens
+        self.used_cost += cost.cost
+
+
+@dataclass(frozen=True)
+class CRMMask:
+    """Config-as-data Referral / CRM mask (ADR-049 §D3 row "Referral / CRM"). Values
+    are governed config, not hardcoded flow logic; the AUTO/REVIEW/BLOCK *scale* is
+    ADR-047 canon. The mask is the allow-list and the gate posture for the capability."""
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    autonomy_level: AutonomyLevel = AutonomyLevel.AUTO_BIASED
+    lineage_obligation: bool = True
+    # Escalation roles (config-as-data, never hardcoded in flow logic): a PII-overlay
+    # failure escalates to the DPO (ADR-016); an anti-abuse failure (self-referral /
+    # duplicate pair) escalates to AML (R-COMP-FCA-03 referral fraud analysis).
+    dpo_role: str = "DPO"
+    abuse_role: str = "AML"
+    agent_id: str = "crm_agent"
+
+    # The mask scope (ADR-049 §D3 allow-list): the only port ops this mask may reach.
+    scope: tuple[str, ...] = (
+        "CRMProviderPort.register_referral",
+        "CRMProviderPort.resolve_referral_code",
+        "CRMProviderPort.get_user",
+        "CRMProviderPort.update_user_tier",
+    )
+
+    # L3 compliance contour required before any port call: PII + anti-abuse overlay.
+    compliance_gate: tuple[str, ...] = ("PII", "ANTI_ABUSE")
+
+
+@dataclass
+class RegisterReferralIntent:
+    """A resolved client intent to register a referral (``register_referral``).
+
+    AUTO-biased (ADR-049 §D3): a routine referral registration proceeds AUTO within
+    cap. **Override:** when :attr:`payout_linked` is True the registration is tied to
+    an incentive/payout, so the action is forced to the REVIEW band and held for a
+    human reviewer regardless of confidence (ADR-049 §D3). The payout classification
+    is an upstream, structured signal — the agent honors it and never regex-parses
+    free text (see module docstring). Self-referral / duplicate-pair anti-abuse is
+    carried in via the ``compliance_result`` verdict (CONTRACT-defined conditions).
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    referrer: CRMUserId
+    referee: CRMUserId
+    code: ReferralCode
+    occurred_at: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    payout_linked: bool = False
+    metadata: dict[str, object] | None = None
+
+
+@dataclass
+class ResolveCodeIntent:
+    """A resolved low-consequence read intent (``resolve_referral_code``) — the
+    mask's "reads are AUTO-eligible within cap" path (ADR-049 §D3). A read below the
+    AUTO band halts for a re-check, not a HITL hold; never carries a payout signal."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    code: ReferralCode
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class GetUserIntent:
+    """A resolved profile-read intent (``get_user``) — AUTO-eligible within cap. The
+    PII overlay (ADR-016) MUST pass before the profile is returned; a non-PASS PII
+    verdict blocks the read and escalates to the DPO (ADR-049 §D3 compliance_gate)."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    user_id: CRMUserId
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class UpdateTierIntent:
+    """A resolved client intent to change a user's tier (``update_user_tier``).
+
+    AUTO-biased (ADR-049 §D3): a routine tier update proceeds AUTO within cap.
+    **Override:** when :attr:`payout_linked` is True the tier change is tied to an
+    incentive/payout, so the action is forced to the REVIEW band and held for a human
+    reviewer regardless of confidence (ADR-049 §D3). The payout classification is an
+    upstream, structured signal — the agent honors it and never regex-parses text.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    user_id: CRMUserId
+    tier: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    payout_linked: bool = False
+
+
+@dataclass
+class AgentDecisionRecord:
+    """Decision-lineage record emitted per action (ADR-046 schema + ADR-047 cost)."""
+
+    record_id: str
+    timestamp: datetime
+    agent_id: str
+    triggering_event: str
+    intent: str
+    policies_evaluated: list[str]
+    compliance_result: ComplianceResult
+    reasoning_summary: str
+    confidence_score: float
+    action_taken: str
+    human_reviewed_by: str | None
+    correlation_id: str
+    # ADR-047 cost lineage (cost is a first-class lineage dimension).
+    cost_tokens: int = 0
+    cost_amount: Decimal = Decimal("0")
+    budget_window_ref: str = ""
+    budget_breach_flag: BudgetBreach = BudgetBreach.NONE
+    # Escalation marker; set on a PII-gate fail (DPO) or anti-abuse fail (AML).
+    escalated_to: str | None = None
+
+
+@dataclass
+class AgentOutcome:
+    """Result of a masked action: the decision, whether a port was called, and the
+    lineage record that was emitted (always non-None — lineage is non-optional).
+
+    ``requires_step_up`` is carried for shape-parity with the sibling agents'
+    outcome; the Referral / CRM mask never sets it (biometric step-up is N/A, a
+    referral/CRM update never moves client funds — ADR-049 §D4)."""
+
+    decision: ConfirmationDecision
+    executed: bool
+    record: AgentDecisionRecord
+    result: object | None = None
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+class DecisionRecorder(ABC):
+    """Sink for :class:`AgentDecisionRecord` (ADR-046 producer→sink seam).
+
+    Injected, not implemented here: the ClickHouse/lineage wiring is out of scope
+    (ADR-049 §D7). The agent depends only on this interface.
+    """
+
+    @abstractmethod
+    async def record(self, record: AgentDecisionRecord) -> None:
+        """Persist one decision-lineage record. Must be durable before the action
+        is considered complete (ADR-046 §D4 producer obligation)."""
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    """All inputs a single masked action evaluates against."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+    # Which arm of the PII + anti-abuse gate is the primary escalation route on a
+    # non-PASS verdict (PII → DPO, anti-abuse → AML).
+    compliance_overlay: ComplianceOverlay
+    human_reviewed_by: str | None
+    # A register/tier update supports a REVIEW-band HITL hold; a read is AUTO-only and
+    # instead halts below the AUTO band. Defaults False so the read path is unchanged.
+    supports_review_hitl: bool = False
+    # Payout/incentive override: a payout-linked action is forced to the REVIEW band
+    # and held for a reviewer regardless of confidence (ADR-049 §D3).
+    force_review: bool = False
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class CRMAgent:
+    """L2 referral/CRM agent enforcing the ADR-049 Referral / CRM mask.
+
+    The provider port and the lineage recorder are injected as interfaces
+    (constructor injection); the agent contains pure governance logic and is
+    unit-testable without any live infra.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider_port: CRMProviderPort,
+        recorder: DecisionRecorder,
+        mask: CRMMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._provider = provider_port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def register_referral(
+        self,
+        intent: RegisterReferralIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        """Register a referral via ``CRMProviderPort.register_referral`` under the mask.
+
+        AUTO-biased (ADR-049 §D3): a routine registration within cap proceeds AUTO.
+        If ``intent.payout_linked`` is set the registration is incentive/payout-linked,
+        so the action is forced to the REVIEW band and held for a human reviewer
+        regardless of confidence; supply ``human_reviewed_by`` to proceed. The PII +
+        anti-abuse overlay (``compliance_result``) must PASS before the port is called;
+        a non-PASS verdict blocks and escalates (anti-abuse → AML). The provider's
+        CONTRACT result (``accepted`` / ``reason`` for self-referral or duplicate
+        pair) is surfaced verbatim on the outcome.
+        """
+        event = ReferralEvent(
+            referrer=intent.referrer,
+            referee=intent.referee,
+            code=intent.code,
+            occurred_at=intent.occurred_at,
+            correlation_id=intent.correlation_id,
+            metadata=intent.metadata,
+        )
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"register_referral:{intent.referrer}->{intent.referee}",
+            success_action="REGISTER_REFERRAL",
+            op="CRMProviderPort.register_referral",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            compliance_overlay=ComplianceOverlay.ANTI_ABUSE,
+            human_reviewed_by=human_reviewed_by,
+            supports_review_hitl=True,
+            force_review=intent.payout_linked,
+        )
+        return await self._run_action(ctx, lambda: self._provider.register_referral(event))
+
+    async def resolve_referral_code(
+        self,
+        intent: ResolveCodeIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Low-consequence read via ``CRMProviderPort.resolve_referral_code`` —
+        AUTO-eligible, no HITL hold (the mask's within-cap read path, ADR-049 §D3).
+        A read below the AUTO band halts for a re-check, not a HITL hold."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"resolve_referral_code:{intent.code}",
+            success_action="RESOLVE_REFERRAL_CODE",
+            op="CRMProviderPort.resolve_referral_code",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            compliance_overlay=ComplianceOverlay.ANTI_ABUSE,
+            human_reviewed_by=None,
+        )
+        return await self._run_action(
+            ctx, lambda: self._provider.resolve_referral_code(intent.code)
+        )
+
+    async def get_user(
+        self,
+        intent: GetUserIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Profile read via ``CRMProviderPort.get_user`` — AUTO-eligible within cap.
+
+        The PII overlay (ADR-016) gate (``compliance_result``) must PASS before the
+        profile is returned; a non-PASS PII verdict blocks the read and escalates to
+        the DPO (ADR-049 §D3 compliance_gate). A read below the AUTO band halts for a
+        re-check, not a HITL hold."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_user:{intent.user_id}",
+            success_action="GET_USER",
+            op="CRMProviderPort.get_user",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            compliance_overlay=ComplianceOverlay.PII,
+            human_reviewed_by=None,
+        )
+        return await self._run_action(ctx, lambda: self._provider.get_user(intent.user_id))
+
+    async def update_user_tier(
+        self,
+        intent: UpdateTierIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        """Apply a tier change via ``CRMProviderPort.update_user_tier`` under the mask.
+
+        AUTO-biased (ADR-049 §D3): a routine tier change within cap proceeds AUTO.
+        If ``intent.payout_linked`` is set the tier change is incentive/payout-linked,
+        so the action is forced to the REVIEW band and held for a human reviewer
+        regardless of confidence; supply ``human_reviewed_by`` to proceed. The PII +
+        anti-abuse overlay (``compliance_result``) must PASS before the port is called.
+        """
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"update_user_tier:{intent.user_id}:{intent.tier}",
+            success_action="UPDATE_USER_TIER",
+            op="CRMProviderPort.update_user_tier",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            compliance_overlay=ComplianceOverlay.ANTI_ABUSE,
+            human_reviewed_by=human_reviewed_by,
+            supports_review_hitl=True,
+            force_review=intent.payout_linked,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._provider.update_user_tier(
+                intent.user_id, intent.tier, intent.correlation_id
+            ),
+        )
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _compliance_role(self, overlay: ComplianceOverlay) -> str:
+        # PII failures route to the DPO (ADR-016); anti-abuse failures route to AML
+        # (R-COMP-FCA-03 referral fraud analysis). Roles are config-as-data.
+        return self._mask.dpo_role if overlay is ComplianceOverlay.PII else self._mask.abuse_role
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be in [0.0, 1.0]")
+        policies = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no port call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. ADR-049 §D3 — mask scope allow-list; an off-list op is refused outright.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op} is not on the Referral / CRM mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band (AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70)
+        #    + ADR-049 §D3 payout-linked override (force REVIEW regardless of confidence).
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+        if ctx.force_review and band is ConfirmationDecision.AUTO:
+            # Payout/incentive-linked: an otherwise-AUTO action is pulled down to
+            # REVIEW so a human confirms anything tied to a payout (ADR-049 §D3).
+            policies.append("ADR-049-D3-payout-linked-REVIEW")
+            band = ConfirmationDecision.REVIEW
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+        if band is ConfirmationDecision.REVIEW:
+            # Read path: reads are AUTO-only, so a below-AUTO read halts for a
+            # re-check at higher confidence, not a HITL hold (ADR-049 §D3).
+            if not ctx.supports_review_hitl:
+                return _Evaluation(
+                    band,
+                    False,
+                    "HALT_REVIEW_DEFERRED",
+                    "Read intent below AUTO band; reads are AUTO-only, no HITL hold (ADR-049 §D3).",
+                    policies,
+                    ctx.compliance_result,
+                    BudgetBreach.NONE,
+                    halt_reason="review_deferred",
+                    requires_hitl=True,
+                )
+            # Register/tier in the REVIEW band (low confidence OR payout-linked) holds.
+            if ctx.human_reviewed_by is None:
+                reason = (
+                    "Payout-linked action pulled to REVIEW; paused for HITL regardless "
+                    "of confidence (ADR-049 §D3)."
+                    if ctx.force_review
+                    else "Action in REVIEW band; paused for HITL confirmation (ADR-049 §D4)."
+                )
+                return _Evaluation(
+                    band,
+                    False,
+                    "HOLD_FOR_REVIEW",
+                    reason,
+                    policies,
+                    ctx.compliance_result,
+                    BudgetBreach.NONE,
+                    halt_reason="hitl_review_required",
+                    requires_hitl=True,
+                )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window); action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. L3 compliance gate — PII + anti-abuse overlay. A non-PASS verdict halts
+        #    AND escalates (PII → DPO, anti-abuse → AML).
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            escalated = self._compliance_role(ctx.compliance_overlay)
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"{ctx.compliance_overlay.value} overlay returned {ctx.compliance_result}; "
+                f"action blocked and escalated to {escalated}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=escalated,
+            )
+
+        # Biometric step-up: N/A for referral/CRM (no money movement, ADR-049 §D4).
+        # All gates satisfied — clear to commit the action.
+        reviewer = (
+            "" if ctx.human_reviewed_by is None else f" (reviewed by {ctx.human_reviewed_by})"
+        )
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All mask gates satisfied at {band.value} confidence{reviewer}; committing within scope.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except CRMProviderError as exc:
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=ev.compliance_result,
+                        reasoning=f"Provider rejected the action: {exc}",
+                        escalated_to=ev.escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        return await self._record(
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies=ev.policies,
+            compliance_result=compliance_result,
+            reasoning=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=ctx.human_reviewed_by,
+            correlation_id=ctx.correlation_id,
+            request_cost=ctx.request_cost,
+            budget_breach=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+
+    async def _record(
+        self,
+        *,
+        triggering_event: str,
+        intent: str,
+        policies: list[str],
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        confidence_score: float,
+        action_taken: str,
+        human_reviewed_by: str | None,
+        correlation_id: str,
+        request_cost: RequestCost,
+        budget_breach: BudgetBreach,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        """Build, persist, and return exactly one ADR-046 lineage record (the single
+        producer→sink seam used by every exit path)."""
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=triggering_event,
+            intent=intent,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=human_reviewed_by,
+            correlation_id=correlation_id,
+            cost_tokens=request_cost.tokens,
+            cost_amount=request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "AutonomyLevel",
+    "BudgetBreach",
+    "CRMAgent",
+    "CRMMask",
+    "ComplianceOverlay",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "GetUserIntent",
+    "ProcessRef",
+    "RegisterReferralIntent",
+    "RequestCost",
+    "ResolveCodeIntent",
+    "UpdateTierIntent",
+]

--- a/tests/agents/test_crm_agent.py
+++ b/tests/agents/test_crm_agent.py
@@ -1,0 +1,630 @@
+"""Tests for the ADR-049 Referral / CRM mask agent (services/agents/crm_agent.py).
+
+Covers every mask path in the §D2 gate-chain order:
+AUTO routine referral registration, the payout-linked override → forced REVIEW
+HITL hold then proceed-with-reviewer (regardless of confidence), anti-abuse
+(self-referral / duplicate pair) → BLOCK + AML escalation, PII-gate fail on
+get_user → BLOCK + DPO escalation, the AUTO resolve_referral_code read and its
+below-AUTO re-check halt, get_user AUTO read, update_user_tier AUTO and its
+payout-linked REVIEW, cost-cap breach (per-request and per-window), BLOCK on low
+confidence, out-of-scope refusal, unresolved process_ref, provider-error lineage,
+and the lineage-per-action obligation (ADR-046). The port and the recorder are
+fakes — the agent is exercised as pure governance logic with no live infra.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents.crm_agent import (
+    AgentDecisionRecord,
+    AutonomyLevel,
+    BudgetBreach,
+    ComplianceOverlay,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    CRMAgent,
+    CRMMask,
+    DecisionRecorder,
+    GetUserIntent,
+    ProcessRef,
+    RegisterReferralIntent,
+    RequestCost,
+    ResolveCodeIntent,
+    UpdateTierIntent,
+)
+from services.crm.crm_provider_port import (
+    CRMProviderPort,
+    CRMUser,
+    CRMUserId,
+    ReferralEvent,
+    RegisterReferralResult,
+    SelfReferral,
+    ValidationError,
+)
+
+# ── Fakes (the port & sink are injected interfaces; never implemented in services) ──
+
+
+class FakeRecorder(DecisionRecorder):
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+class FakeCRMProviderPort(CRMProviderPort):
+    """In-test CRMProviderPort double. Records calls; returns canned results or
+    raises a configured error so the agent's governance logic is exercised without
+    any live provider."""
+
+    def __init__(
+        self,
+        *,
+        register_result: RegisterReferralResult | None = None,
+        resolve_result: CRMUserId | None = "owner-1",
+        user_result: CRMUser | None = None,
+        register_raises: Exception | None = None,
+    ) -> None:
+        self._register_result = register_result or RegisterReferralResult(accepted=True)
+        self._resolve_result = resolve_result
+        self._user_result = user_result if user_result is not None else CRMUser(user_id="u1")
+        self._register_raises = register_raises
+        self.register_calls: list[ReferralEvent] = []
+        self.resolve_calls: list[str] = []
+        self.get_user_calls: list[str] = []
+        self.update_tier_calls: list[tuple[str, str, str]] = []
+
+    async def register_referral(self, event: ReferralEvent) -> RegisterReferralResult:
+        self.register_calls.append(event)
+        if self._register_raises is not None:
+            raise self._register_raises
+        return self._register_result
+
+    async def resolve_referral_code(self, code: str) -> CRMUserId | None:
+        self.resolve_calls.append(code)
+        return self._resolve_result
+
+    async def get_user(self, user_id: str) -> CRMUser | None:
+        self.get_user_calls.append(user_id)
+        return self._user_result
+
+    async def update_user_tier(self, user_id: str, tier: str, correlation_id: str) -> None:
+        self.update_tier_calls.append((user_id, tier, correlation_id))
+
+
+# ── Builders ──────────────────────────────────────────────────────────────────
+
+
+def make_mask(**overrides) -> CRMMask:
+    base = {
+        "cost_cap": CostCap(
+            max_request_tokens=10_000,
+            max_request_cost=Decimal("1.00"),
+            max_window_tokens=100_000,
+            max_window_cost=Decimal("10.00"),
+        ),
+    }
+    base.update(overrides)
+    return CRMMask(**base)
+
+
+def make_agent(
+    *,
+    mask: CRMMask | None = None,
+    port: FakeCRMProviderPort | None = None,
+    recorder: FakeRecorder | None = None,
+    cost_window: CostWindow | None = None,
+) -> tuple[CRMAgent, FakeCRMProviderPort, FakeRecorder]:
+    port = port or FakeCRMProviderPort()
+    recorder = recorder or FakeRecorder()
+    agent = CRMAgent(
+        provider_port=port,
+        recorder=recorder,
+        mask=mask or make_mask(),
+        cost_window=cost_window,
+    )
+    return agent, port, recorder
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    return (
+        ProcessRef(process_id="PROC-CRM", version="1")
+        if resolved
+        else ProcessRef(process_id="", version="")
+    )
+
+
+def make_register_intent(
+    *,
+    confidence: float = 0.95,
+    cost: RequestCost | None = None,
+    resolved: bool = True,
+    payout_linked: bool = False,
+    referrer: str = "ref-1",
+    referee: str = "ref-2",
+) -> RegisterReferralIntent:
+    return RegisterReferralIntent(
+        intent_text="Register my friend's referral",
+        process_ref=_ref(resolved),
+        referrer=referrer,
+        referee=referee,
+        code="CODE-123",
+        occurred_at="2026-06-07T00:00:00Z",
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=cost or RequestCost(tokens=200, cost=Decimal("0.02")),
+        payout_linked=payout_linked,
+    )
+
+
+def make_resolve_intent(
+    *, confidence: float = 0.99, cost: RequestCost | None = None
+) -> ResolveCodeIntent:
+    return ResolveCodeIntent(
+        intent_text="Who owns this referral code?",
+        process_ref=_ref(),
+        code="CODE-123",
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=cost or RequestCost(tokens=20, cost=Decimal("0.005")),
+    )
+
+
+def make_get_user_intent(
+    *, confidence: float = 0.99, cost: RequestCost | None = None
+) -> GetUserIntent:
+    return GetUserIntent(
+        intent_text="Fetch the user profile",
+        process_ref=_ref(),
+        user_id="u1",
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=cost or RequestCost(tokens=30, cost=Decimal("0.006")),
+    )
+
+
+def make_tier_intent(
+    *,
+    confidence: float = 0.95,
+    cost: RequestCost | None = None,
+    payout_linked: bool = False,
+) -> UpdateTierIntent:
+    return UpdateTierIntent(
+        intent_text="Promote this user to premium",
+        process_ref=_ref(),
+        user_id="u1",
+        tier="premium",
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=cost or RequestCost(tokens=200, cost=Decimal("0.02")),
+        payout_linked=payout_linked,
+    )
+
+
+# ── AUTO routine referral registration ───────────────────────────────────────────
+
+
+async def test_auto_routine_referral_executes_no_hitl():
+    agent, port, recorder = make_agent()
+    outcome = await agent.register_referral(make_register_intent(confidence=0.95))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert outcome.requires_hitl is False
+    assert outcome.requires_step_up is False
+    assert len(port.register_calls) == 1
+    assert recorder.records[0].action_taken == "REGISTER_REFERRAL"
+    assert len(recorder.records) == 1
+
+
+async def test_register_result_surfaced_on_outcome():
+    port = FakeCRMProviderPort(register_result=RegisterReferralResult(accepted=True))
+    agent, port, _ = make_agent(port=port)
+    outcome = await agent.register_referral(make_register_intent())
+    assert isinstance(outcome.result, RegisterReferralResult)
+    assert outcome.result.accepted is True
+
+
+async def test_contract_rejection_reason_surfaced_when_compliance_passes():
+    # Defense-in-depth: even when the agent's anti-abuse gate PASSes, the port may
+    # still reject a self-referral; the CONTRACT reason is surfaced verbatim.
+    port = FakeCRMProviderPort(
+        register_result=RegisterReferralResult(accepted=False, reason="self_referral")
+    )
+    agent, port, recorder = make_agent(port=port)
+    outcome = await agent.register_referral(make_register_intent())
+    assert outcome.executed is True
+    assert outcome.result.accepted is False
+    assert outcome.result.reason == "self_referral"
+    assert recorder.records[0].action_taken == "REGISTER_REFERRAL"
+
+
+# ── Payout-linked override: forced REVIEW regardless of confidence ────────────────
+
+
+async def test_payout_linked_referral_forces_review_hold_even_at_auto_confidence():
+    agent, port, recorder = make_agent()
+    outcome = await agent.register_referral(
+        make_register_intent(confidence=0.99, payout_linked=True)
+    )
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.requires_hitl is True
+    assert outcome.halt_reason == "hitl_review_required"
+    assert port.register_calls == []
+    assert recorder.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert recorder.records[0].human_reviewed_by is None
+    assert "ADR-049-D3-payout-linked-REVIEW" in recorder.records[0].policies_evaluated
+
+
+async def test_payout_linked_referral_proceeds_with_reviewer():
+    agent, port, recorder = make_agent()
+    outcome = await agent.register_referral(
+        make_register_intent(confidence=0.99, payout_linked=True),
+        human_reviewed_by="ops@banxe",
+    )
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is True
+    assert len(port.register_calls) == 1
+    assert recorder.records[0].action_taken == "REGISTER_REFERRAL"
+    assert recorder.records[0].human_reviewed_by == "ops@banxe"
+
+
+async def test_non_payout_review_band_holds_for_hitl():
+    # A routine referral in the REVIEW band still holds for HITL (not payout-tagged).
+    agent, port, recorder = make_agent()
+    outcome = await agent.register_referral(make_register_intent(confidence=0.80))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.requires_hitl is True
+    assert port.register_calls == []
+    assert recorder.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert "ADR-049-D3-payout-linked-REVIEW" not in recorder.records[0].policies_evaluated
+
+
+# ── Anti-abuse overlay (self-referral / duplicate pair) → BLOCK + AML ─────────────
+
+
+async def test_anti_abuse_self_referral_verdict_blocks_and_escalates_aml():
+    # The L3 anti-abuse overlay classifies the self-referral upstream; the agent
+    # BLOCKs before the port is ever called and escalates to AML.
+    agent, port, recorder = make_agent()
+    outcome = await agent.register_referral(
+        make_register_intent(referrer="same", referee="same"),
+        compliance_result=ComplianceResult.FAIL,
+    )
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert outcome.escalated_to == "AML"
+    assert port.register_calls == []
+    assert recorder.records[0].action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert recorder.records[0].compliance_result is ComplianceResult.FAIL
+    assert recorder.records[0].escalated_to == "AML"
+
+
+async def test_anti_abuse_duplicate_pair_verdict_blocks_and_escalates_aml():
+    agent, port, recorder = make_agent()
+    outcome = await agent.register_referral(
+        make_register_intent(),
+        compliance_result=ComplianceResult.ESCALATE,
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert port.register_calls == []
+    assert recorder.records[0].escalated_to == "AML"
+
+
+async def test_provider_self_referral_error_records_then_raises():
+    # If the port itself raises (defense-in-depth), lineage is emitted then re-raised.
+    port = FakeCRMProviderPort(
+        register_raises=SelfReferral("referrer == referee", correlation_id="corr-1")
+    )
+    agent, port, recorder = make_agent(port=port)
+    with pytest.raises(SelfReferral):
+        await agent.register_referral(make_register_intent(confidence=0.95))
+
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_PROVIDER_ERROR:SelfReferral"
+
+
+# ── PII overlay (ADR-016) on get_user ────────────────────────────────────────────
+
+
+async def test_get_user_auto_read_executes():
+    port = FakeCRMProviderPort(user_result=CRMUser(user_id="u1", tier="premium"))
+    agent, port, recorder = make_agent(port=port)
+    outcome = await agent.get_user(make_get_user_intent(confidence=0.99))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert outcome.requires_hitl is False
+    assert port.get_user_calls == ["u1"]
+    assert outcome.result.tier == "premium"
+    assert recorder.records[0].action_taken == "GET_USER"
+    assert len(recorder.records) == 1
+
+
+async def test_get_user_pii_fail_blocks_and_escalates_dpo():
+    agent, port, recorder = make_agent()
+    outcome = await agent.get_user(make_get_user_intent(), compliance_result=ComplianceResult.FAIL)
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert outcome.escalated_to == "DPO"
+    assert port.get_user_calls == []
+    assert recorder.records[0].action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert recorder.records[0].compliance_result is ComplianceResult.FAIL
+    assert recorder.records[0].escalated_to == "DPO"
+
+
+async def test_get_user_below_auto_halts_for_recheck():
+    agent, port, recorder = make_agent()
+    outcome = await agent.get_user(make_get_user_intent(confidence=0.80))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert port.get_user_calls == []
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+# ── resolve_referral_code: AUTO read + below-AUTO re-check ────────────────────────
+
+
+async def test_resolve_referral_code_auto_read_executes():
+    agent, port, recorder = make_agent()
+    outcome = await agent.resolve_referral_code(make_resolve_intent(confidence=0.99))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert outcome.requires_hitl is False
+    assert port.resolve_calls == ["CODE-123"]
+    assert outcome.result == "owner-1"
+    assert recorder.records[0].action_taken == "RESOLVE_REFERRAL_CODE"
+    assert len(recorder.records) == 1
+
+
+async def test_resolve_referral_code_unknown_returns_none():
+    port = FakeCRMProviderPort(resolve_result=None)
+    agent, port, _ = make_agent(port=port)
+    outcome = await agent.resolve_referral_code(make_resolve_intent(confidence=0.99))
+    assert outcome.executed is True
+    assert outcome.result is None
+
+
+async def test_resolve_referral_code_below_auto_halts_for_recheck():
+    agent, port, recorder = make_agent()
+    outcome = await agent.resolve_referral_code(make_resolve_intent(confidence=0.80))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert port.resolve_calls == []
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+# ── update_user_tier: AUTO + payout-linked REVIEW ────────────────────────────────
+
+
+async def test_update_tier_auto_executes():
+    agent, port, recorder = make_agent()
+    outcome = await agent.update_user_tier(make_tier_intent(confidence=0.95))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert port.update_tier_calls == [("u1", "premium", "corr-1")]
+    assert recorder.records[0].action_taken == "UPDATE_USER_TIER"
+
+
+async def test_update_tier_payout_linked_forces_review_hold():
+    agent, port, recorder = make_agent()
+    outcome = await agent.update_user_tier(make_tier_intent(confidence=0.99, payout_linked=True))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.requires_hitl is True
+    assert port.update_tier_calls == []
+    assert recorder.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert "ADR-049-D3-payout-linked-REVIEW" in recorder.records[0].policies_evaluated
+
+
+async def test_update_tier_payout_linked_proceeds_with_reviewer():
+    agent, port, recorder = make_agent()
+    outcome = await agent.update_user_tier(
+        make_tier_intent(confidence=0.99, payout_linked=True),
+        human_reviewed_by="ops@banxe",
+    )
+    assert outcome.executed is True
+    assert port.update_tier_calls == [("u1", "premium", "corr-1")]
+    assert recorder.records[0].human_reviewed_by == "ops@banxe"
+
+
+async def test_update_tier_pii_abuse_fail_blocks():
+    agent, port, recorder = make_agent()
+    outcome = await agent.update_user_tier(
+        make_tier_intent(), compliance_result=ComplianceResult.FAIL
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert port.update_tier_calls == []
+    assert outcome.escalated_to == "AML"
+
+
+# ── BLOCK / scope / process resolution ───────────────────────────────────────────
+
+
+async def test_block_low_confidence_register():
+    agent, port, recorder = make_agent()
+    outcome = await agent.register_referral(make_register_intent(confidence=0.40))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert port.register_calls == []
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+async def test_block_low_confidence_read():
+    agent, port, recorder = make_agent()
+    outcome = await agent.resolve_referral_code(make_resolve_intent(confidence=0.40))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert port.resolve_calls == []
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+async def test_unresolved_process_ref_blocks():
+    agent, port, recorder = make_agent()
+    outcome = await agent.register_referral(make_register_intent(resolved=False))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert port.register_calls == []
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+async def test_out_of_scope_op_refused():
+    # An op not on the mask allow-list is refused outright (ADR-049 §D3).
+    agent, port, recorder = make_agent(
+        mask=make_mask(scope=("CRMProviderPort.resolve_referral_code",))
+    )
+    outcome = await agent.register_referral(make_register_intent(confidence=0.95))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "out_of_scope"
+    assert port.register_calls == []
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+@pytest.mark.parametrize(
+    ("confidence", "expected"),
+    [
+        (0.91, ConfirmationDecision.AUTO),
+        (0.90, ConfirmationDecision.REVIEW),
+        (0.70, ConfirmationDecision.REVIEW),
+        (0.6999, ConfirmationDecision.BLOCK),
+    ],
+)
+async def test_confidence_band_boundaries(confidence, expected):
+    agent, _, _ = make_agent()
+    outcome = await agent.register_referral(
+        make_register_intent(confidence=confidence), human_reviewed_by="ops@banxe"
+    )
+    assert outcome.decision is expected
+
+
+# ── Cost-cap breach ──────────────────────────────────────────────────────────────
+
+
+async def test_per_request_cost_cap_breach_blocks():
+    agent, port, recorder = make_agent()
+    intent = make_register_intent(cost=RequestCost(tokens=999_999, cost=Decimal("0.01")))
+    outcome = await agent.register_referral(intent)
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert port.register_calls == []
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+    assert recorder.records[0].action_taken == "HALT_COST_CAP_BREACH"
+
+
+async def test_per_window_cost_cap_breach_blocks():
+    window = CostWindow(used_tokens=99_900, used_cost=Decimal("0.00"))
+    agent, port, _ = make_agent(cost_window=window)
+    outcome = await agent.register_referral(
+        make_register_intent(cost=RequestCost(tokens=200, cost=Decimal("0.01")))
+    )
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert port.register_calls == []
+
+
+async def test_window_accumulates_on_successful_action():
+    window = CostWindow()
+    agent, _, _ = make_agent(cost_window=window)
+    await agent.register_referral(
+        make_register_intent(cost=RequestCost(tokens=300, cost=Decimal("0.02")))
+    )
+    assert window.used_tokens == 300
+    assert window.used_cost == Decimal("0.02")
+
+
+# ── Provider error → lineage then re-raise ───────────────────────────────────────
+
+
+async def test_provider_validation_error_records_then_raises():
+    port = FakeCRMProviderPort(
+        register_raises=ValidationError("empty user_id", correlation_id="corr-1")
+    )
+    agent, port, recorder = make_agent(port=port)
+    with pytest.raises(ValidationError):
+        await agent.register_referral(make_register_intent(confidence=0.95))
+
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_PROVIDER_ERROR:ValidationError"
+
+
+# ── Lineage obligation (ADR-046) ─────────────────────────────────────────────────
+
+
+async def test_lineage_record_emitted_per_action_with_adr046_fields():
+    agent, _, recorder = make_agent()
+    await agent.register_referral(make_register_intent())
+    await agent.register_referral(make_register_intent(confidence=0.40))  # a halt also records
+    assert len(recorder.records) == 2
+
+    rec = recorder.records[0]
+    assert rec.record_id
+    assert rec.timestamp.tzinfo is not None
+    assert rec.agent_id == "crm_agent"
+    assert rec.intent == "Register my friend's referral"
+    assert rec.correlation_id == "corr-1"
+    assert rec.policies_evaluated  # non-empty ordered policy list
+    assert 0.0 <= rec.confidence_score <= 1.0
+    assert rec.cost_tokens == 200
+    assert rec.cost_amount == Decimal("0.02")
+    assert rec.budget_window_ref == "crm_agent:default"
+
+
+async def test_invalid_confidence_raises():
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError):
+        await agent.register_referral(make_register_intent(confidence=1.5))
+
+
+# ── Mask config-as-data ──────────────────────────────────────────────────────────
+
+
+async def test_mask_is_auto_biased_with_pii_and_anti_abuse_gate():
+    mask = make_mask()
+    assert mask.autonomy_level is AutonomyLevel.AUTO_BIASED
+    assert mask.compliance_gate == ("PII", "ANTI_ABUSE")
+    assert mask.dpo_role == "DPO"
+    assert mask.abuse_role == "AML"
+    assert "CRMProviderPort.register_referral" in mask.scope
+    assert "CRMProviderPort.update_user_tier" in mask.scope
+
+
+async def test_custom_escalation_roles_used():
+    agent, _, recorder = make_agent(mask=make_mask(dpo_role="DataOfficer", abuse_role="FraudOps"))
+    pii = await agent.get_user(make_get_user_intent(), compliance_result=ComplianceResult.FAIL)
+    abuse = await agent.register_referral(
+        make_register_intent(), compliance_result=ComplianceResult.FAIL
+    )
+    assert pii.escalated_to == "DataOfficer"
+    assert abuse.escalated_to == "FraudOps"
+
+
+async def test_compliance_overlay_routing_values():
+    # PII overlay → DPO; anti-abuse overlay → AML (escalation routing is overlay-keyed).
+    assert ComplianceOverlay.PII.value == "PII"
+    assert ComplianceOverlay.ANTI_ABUSE.value == "ANTI_ABUSE"


### PR DESCRIPTION
## What

Fifth L2 client-facing agent (ADR-049 **§D3 row "Referral / CRM"**), the emi-stack sibling of the merged KYC (#151) and Notification (#152) agents. Binds the `CRMProviderPort` capability behind the governed ADR-049 §D2 gate chain.

ADR-049 §D3 row as read:
| Referral / CRM | `CRMProviderPort` | AUTO-biased | AUTO for routine CRM/referral updates; REVIEW for incentive/payout-linked actions | PII + anti-abuse overlay |

## Gate chain (ADR-049 §D2, fixed order)
`process_ref → scope → band → cost_cap → compliance(PII + anti-abuse) → [biometric step-up N/A] → port call` — exactly one `AgentDecisionRecord` (ADR-046) per action on every exit path; cost-cap per-request **and** per-window, token **and** Decimal (ADR-047); `process_ref` resolution (ADR-048).

## CRMAgent methods
- **register_referral** — AUTO-biased routine update; **payout/incentive-linked → forced REVIEW** (HITL hold) regardless of band; anti-abuse (self-referral / duplicate pair) → BLOCK via the compliance verdict, escalates to AML.
- **resolve_referral_code** — low-consequence read, AUTO-eligible.
- **get_user** — read; **PII overlay must PASS** else BLOCK + DPO escalation.
- **update_user_tier** — AUTO within cap; **payout/incentive-linked → REVIEW**.

Payout/incentive detection is a **structured upstream signal** (`payout_linked` bool), never free-text regex (documented assumption). PII + anti-abuse arrive as the injected `compliance_result` verdict. No biometric step-up (not money movement) — but payout-linked REVIEW is mandatory.

## Boundaries
- `CRMProviderPort` + `DecisionRecorder` injected as interfaces, **never implemented** here.
- `services/crm/crm_provider_port.py` and `services/referral/*` **untouched** (existing real logic).
- Scope = `services/agents/**` + tests only.

## Tests
`tests/agents/test_crm_agent.py` — 36 cases, **100% coverage** of `services/agents/crm_agent.py`: AUTO routine referral, payout-linked forced-REVIEW hold + proceed-with-reviewer, anti-abuse self-referral/duplicate → BLOCK, PII-fail on get_user → BLOCK, resolve_referral_code AUTO read + below-AUTO re-check, get_user AUTO read, update_user_tier AUTO + payout REVIEW, cost-cap breach (per-request + window), BLOCK low band, unresolved process_ref, out-of-scope, provider-error lineage, lineage-per-action, band boundaries.

ruff format + ruff check clean; bandit clean (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)