### PR TITLE
refactor(agents): shared lineage/cost primitives (_lineage) + ADR-046 §D5 fields

### DIFF
--- a/services/agents/__init__.py
+++ b/services/agents/__init__.py
@@ -16,6 +16,18 @@ recorder are injected as interfaces; agents never implement them.
 
 from __future__ import annotations
 
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
 from services.agents.crm_agent import (
     ComplianceOverlay,
     CRMAgent,
@@ -26,30 +38,20 @@ from services.agents.crm_agent import (
     UpdateTierIntent,
 )
 from services.agents.notification_agent import (
-    AgentDecisionRecord,
-    AgentOutcome,
     AutonomyLevel,
-    BudgetBreach,
     ChannelCheckIntent,
-    ComplianceResult,
-    ConfirmationDecision,
-    CostCap,
-    CostWindow,
-    DecisionRecorder,
     NotificationAgent,
     NotificationMask,
     NotificationSendIntent,
-    ProcessRef,
-    RequestCost,
 )
 
-# NOTE: the agents share structurally-identical governance primitives
-# (ProcessRef, RequestCost, CostCap, CostWindow, DecisionRecorder, ComplianceResult,
-# ConfirmationDecision, BudgetBreach, AutonomyLevel, AgentDecisionRecord,
-# AgentOutcome). The package re-exports one canonical set (from notification_agent);
-# the CRM-specific public types are re-exported alongside. Import the per-agent
-# module directly (e.g. ``services.agents.crm_agent``) when the module-local
-# identity of a shared primitive matters.
+# NOTE: the agents share structurally-identical governance primitives (ProcessRef,
+# RequestCost, CostCap, CostWindow, DecisionRecorder, ComplianceResult,
+# ConfirmationDecision, BudgetBreach, AgentDecisionRecord, AgentOutcome). These now
+# live in the canonical ``services/agents/_lineage.py`` module and are re-exported
+# from here; each agent module imports the same single set (DRY — no per-module
+# duplicates). The mask-specific public types (AutonomyLevel, ComplianceOverlay, the
+# per-mask masks/intents) are re-exported from their owning agent module alongside.
 __all__ = [
     "AgentDecisionRecord",
     "AgentOutcome",

--- a/services/agents/_lineage.py
+++ b/services/agents/_lineage.py
@@ -1,0 +1,202 @@
+"""Shared lineage & cost primitives for the L2 client-facing agents (canonical).
+
+WHY: the KYC-onboarding, Notifications, and Referral/CRM masks
+(``services/agents/kyc_onboarding_agent.py``, ``notification_agent.py``,
+``crm_agent.py``) each enforce the *same* governance vocabulary — the ADR-048
+process handle, the ADR-047 cost dimensions, and the ADR-046 decision-lineage
+record. Those definitions were byte-for-byte identical across the three modules
+(DRY debt). This module is the single canonical home for them; each mask module
+imports from here and keeps only its mask-specific types (its mask config, its
+intent vocabulary, its private evaluation context). Moving — not re-inventing —
+these primitives preserves behaviour exactly: same gate inputs, same record
+schema. It is the emi-stack analogue of banxe-payment-core's
+``src/agents/_lineage.py``.
+
+Scope boundary (unchanged): this is pure governance data + the recorder seam.
+The ClickHouse/lineage sink and the LLM-orchestration/routing layer
+(``AGENT_ROUTING_ENABLED``) remain out of scope (Terminal A infra, ADR-049
+§D6/§D7); the agents depend only on the :class:`DecisionRecorder` interface.
+
+R-SEC (R-SEC-NEW-01, ADR-021): :class:`AgentDecisionRecord` carries opaque
+metadata ONLY — never seed/entropy/key/password/plaintext/ciphertext. Secret
+material lives solely on the per-mask intent fields, is routed straight to the
+injected port, and (for results) is returned on ``AgentOutcome.result`` to the
+caller, never recorded.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+
+# ---------------------------------------------------------------------------
+# Shared mask vocabulary (ADR-046 / ADR-047 / ADR-049 §D4)
+# ---------------------------------------------------------------------------
+
+
+class ConfirmationDecision(StrEnum):
+    """HITL band selected by the confirmation_policy (ADR-047 / ADR-049 §D4)."""
+
+    AUTO = "auto"
+    REVIEW = "review"
+    BLOCK = "block"
+
+
+class ComplianceResult(StrEnum):
+    """Net L3 compliance-gate outcome carried on the lineage record (ADR-046)."""
+
+    PASS = "PASS"  # nosec B105 # noqa: S105 — compliance verdict, not a credential
+    FAIL = "FAIL"
+    ESCALATE = "ESCALATE"
+    NA = "N/A"
+
+
+class BudgetBreach(StrEnum):
+    """Cost-cap breach flag for the lineage record (ADR-047 §D2/§D4)."""
+
+    NONE = "NONE"
+    WARN = "WARN"
+    BREACH = "BREACH"
+
+
+# ---------------------------------------------------------------------------
+# Value types — ADR-048 process handle + ADR-047 cost dimensions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProcessRef:
+    """ADR-048 intent→process handle. Both fields required for a resolved intent."""
+
+    process_id: str
+    version: str
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.process_id) and bool(self.version)
+
+
+@dataclass(frozen=True)
+class RequestCost:
+    """Estimated cost of a single agent invocation (ADR-047 per-request dimensions)."""
+
+    tokens: int
+    cost: Decimal
+
+
+@dataclass(frozen=True)
+class CostCap:
+    """Hard caps in both token and monetary (Decimal) dimensions (ADR-047 §D2)."""
+
+    max_request_tokens: int
+    max_request_cost: Decimal
+    max_window_tokens: int
+    max_window_cost: Decimal
+
+
+@dataclass
+class CostWindow:
+    """Rolling per-window usage accumulator (ADR-047 §D2 per-window budget).
+
+    ``window_ref`` defaults to a generic label; each agent overrides it with its
+    own ``f"{mask.agent_id}:default"`` at construction (behaviour unchanged)."""
+
+    used_tokens: int = 0
+    used_cost: Decimal = Decimal("0")
+    window_ref: str = "agent:default"
+
+    def add(self, cost: RequestCost) -> None:
+        self.used_tokens += cost.tokens
+        self.used_cost += cost.cost
+
+
+# ---------------------------------------------------------------------------
+# Lineage record (ADR-046) + outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgentDecisionRecord:
+    """Decision-lineage record emitted per action (ADR-046 schema + ADR-047 cost).
+
+    R-SEC: carries opaque metadata ONLY — never seed/entropy/key/password/plaintext.
+    """
+
+    record_id: str
+    timestamp: datetime
+    agent_id: str
+    triggering_event: str
+    intent: str
+    policies_evaluated: list[str]
+    compliance_result: ComplianceResult
+    reasoning_summary: str
+    confidence_score: float
+    action_taken: str
+    human_reviewed_by: str | None
+    correlation_id: str
+    # ADR-047 cost lineage (cost is a first-class lineage dimension).
+    cost_tokens: int = 0
+    cost_amount: Decimal = Decimal("0")
+    budget_window_ref: str = ""
+    budget_breach_flag: BudgetBreach = BudgetBreach.NONE
+    # Escalation marker: set on a compliance fail/escalate (and, for KYC, on
+    # low-confidence identity decisions and blocked downgrades). The role is
+    # mask-defined config-as-data — MLRO (KYC) / DPO (PII) / AML (anti-abuse).
+    escalated_to: str | None = None
+    # ADR-046 §D5 additive fields (non-breaking; all default None when not supplied).
+    # ``immutable_storage_ref`` is the WORM/immutable storage handle for the record.
+    # ``input_tokens`` + ``output_tokens`` REFINE the existing ``cost_tokens`` total
+    # into the prompt/completion split; the ``cost_tokens`` total stays authoritative.
+    immutable_storage_ref: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+
+@dataclass
+class AgentOutcome:
+    """Result of a masked action: the decision, whether a port was called, and the
+    lineage record that was emitted (always non-None — lineage is non-optional).
+
+    ``result`` carries the port's return value to the caller; it is the functional
+    return only and is NEVER part of the recorded lineage (R-SEC). ``requires_step_up``
+    is carried for shape-parity across masks; only the KYC identity path sets it (a
+    notification / referral-CRM update never moves client funds — ADR-049 §D4)."""
+
+    decision: ConfirmationDecision
+    executed: bool
+    record: AgentDecisionRecord
+    result: object | None = None
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+class DecisionRecorder(ABC):
+    """Sink for :class:`AgentDecisionRecord` (ADR-046 producer→sink seam).
+
+    Injected, not implemented here: the ClickHouse/lineage wiring is out of scope
+    (ADR-049 §D7). The agent depends only on this interface.
+    """
+
+    @abstractmethod
+    async def record(self, record: AgentDecisionRecord) -> None:
+        """Persist one decision-lineage record. Must be durable before the action
+        is considered complete (ADR-046 §D4 producer obligation)."""
+
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "BudgetBreach",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "ProcessRef",
+    "RequestCost",
+]

--- a/services/agents/crm_agent.py
+++ b/services/agents/crm_agent.py
@@ -73,14 +73,24 @@ the same conditions as defense-in-depth (a CONTRACT ``RegisterReferralResult`` w
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from decimal import Decimal
 from enum import StrEnum
 import uuid
 
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
 from services.crm.crm_provider_port import (
     CRMProviderError,
     CRMProviderPort,
@@ -92,31 +102,6 @@ from services.crm.crm_provider_port import (
 # ---------------------------------------------------------------------------
 # Mask vocabulary
 # ---------------------------------------------------------------------------
-
-
-class ConfirmationDecision(StrEnum):
-    """HITL band selected by the confirmation_policy (ADR-047 / ADR-049 §D4)."""
-
-    AUTO = "auto"
-    REVIEW = "review"
-    BLOCK = "block"
-
-
-class ComplianceResult(StrEnum):
-    """Net L3 compliance-gate (PII + anti-abuse overlay) outcome on the lineage record."""
-
-    PASS = "PASS"  # nosec B105 # noqa: S105 — compliance verdict, not a credential
-    FAIL = "FAIL"
-    ESCALATE = "ESCALATE"
-    NA = "N/A"
-
-
-class BudgetBreach(StrEnum):
-    """Cost-cap breach flag for the lineage record (ADR-047 §D2/§D4)."""
-
-    NONE = "NONE"
-    WARN = "WARN"
-    BREACH = "BREACH"
 
 
 class AutonomyLevel(StrEnum):
@@ -138,51 +123,8 @@ class ComplianceOverlay(StrEnum):
 
 
 # ---------------------------------------------------------------------------
-# Value types
+# Value types — mask config (the shared cost/lineage primitives live in ``_lineage``)
 # ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class ProcessRef:
-    """ADR-048 intent→process handle. Both fields required for a resolved intent."""
-
-    process_id: str
-    version: str
-
-    @property
-    def resolved(self) -> bool:
-        return bool(self.process_id) and bool(self.version)
-
-
-@dataclass(frozen=True)
-class RequestCost:
-    """Estimated cost of a single agent invocation (ADR-047 per-request dimensions)."""
-
-    tokens: int
-    cost: Decimal
-
-
-@dataclass(frozen=True)
-class CostCap:
-    """Hard caps in both token and monetary (Decimal) dimensions (ADR-047 §D2)."""
-
-    max_request_tokens: int
-    max_request_cost: Decimal
-    max_window_tokens: int
-    max_window_cost: Decimal
-
-
-@dataclass
-class CostWindow:
-    """Rolling per-window usage accumulator (ADR-047 §D2 per-window budget)."""
-
-    used_tokens: int = 0
-    used_cost: Decimal = Decimal("0")
-    window_ref: str = "crm_agent:default"
-
-    def add(self, cost: RequestCost) -> None:
-        self.used_tokens += cost.tokens
-        self.used_cost += cost.cost
 
 
 @dataclass(frozen=True)
@@ -288,63 +230,6 @@ class UpdateTierIntent:
     confidence_score: float
     request_cost: RequestCost
     payout_linked: bool = False
-
-
-@dataclass
-class AgentDecisionRecord:
-    """Decision-lineage record emitted per action (ADR-046 schema + ADR-047 cost)."""
-
-    record_id: str
-    timestamp: datetime
-    agent_id: str
-    triggering_event: str
-    intent: str
-    policies_evaluated: list[str]
-    compliance_result: ComplianceResult
-    reasoning_summary: str
-    confidence_score: float
-    action_taken: str
-    human_reviewed_by: str | None
-    correlation_id: str
-    # ADR-047 cost lineage (cost is a first-class lineage dimension).
-    cost_tokens: int = 0
-    cost_amount: Decimal = Decimal("0")
-    budget_window_ref: str = ""
-    budget_breach_flag: BudgetBreach = BudgetBreach.NONE
-    # Escalation marker; set on a PII-gate fail (DPO) or anti-abuse fail (AML).
-    escalated_to: str | None = None
-
-
-@dataclass
-class AgentOutcome:
-    """Result of a masked action: the decision, whether a port was called, and the
-    lineage record that was emitted (always non-None — lineage is non-optional).
-
-    ``requires_step_up`` is carried for shape-parity with the sibling agents'
-    outcome; the Referral / CRM mask never sets it (biometric step-up is N/A, a
-    referral/CRM update never moves client funds — ADR-049 §D4)."""
-
-    decision: ConfirmationDecision
-    executed: bool
-    record: AgentDecisionRecord
-    result: object | None = None
-    halt_reason: str | None = None
-    requires_step_up: bool = False
-    requires_hitl: bool = False
-    escalated_to: str | None = None
-
-
-class DecisionRecorder(ABC):
-    """Sink for :class:`AgentDecisionRecord` (ADR-046 producer→sink seam).
-
-    Injected, not implemented here: the ClickHouse/lineage wiring is out of scope
-    (ADR-049 §D7). The agent depends only on this interface.
-    """
-
-    @abstractmethod
-    async def record(self, record: AgentDecisionRecord) -> None:
-        """Persist one decision-lineage record. Must be durable before the action
-        is considered complete (ADR-046 §D4 producer obligation)."""
 
 
 # ---------------------------------------------------------------------------

--- a/services/agents/kyc_onboarding_agent.py
+++ b/services/agents/kyc_onboarding_agent.py
@@ -42,7 +42,6 @@ logic.
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -50,6 +49,18 @@ from decimal import Decimal
 from enum import StrEnum
 import uuid
 
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
 from services.kyc.kyc_provider_port import (
     KYCProviderError,
     KYCProviderPort,
@@ -60,31 +71,6 @@ from services.kyc.kyc_provider_port import (
 # ---------------------------------------------------------------------------
 # Mask vocabulary
 # ---------------------------------------------------------------------------
-
-
-class ConfirmationDecision(StrEnum):
-    """HITL band selected by the confirmation_policy (ADR-047 / ADR-049 §D4)."""
-
-    AUTO = "auto"
-    REVIEW = "review"
-    BLOCK = "block"
-
-
-class ComplianceResult(StrEnum):
-    """Net L3 compliance-gate outcome carried on the lineage record (ADR-046)."""
-
-    PASS = "PASS"  # nosec B105 # noqa: S105 — compliance verdict, not a credential
-    FAIL = "FAIL"
-    ESCALATE = "ESCALATE"
-    NA = "N/A"
-
-
-class BudgetBreach(StrEnum):
-    """Cost-cap breach flag for the lineage record (ADR-047 §D2/§D4)."""
-
-    NONE = "NONE"
-    WARN = "WARN"
-    BREACH = "BREACH"
 
 
 class AutonomyLevel(StrEnum):
@@ -103,51 +89,8 @@ class IdentityDecision(StrEnum):
 
 
 # ---------------------------------------------------------------------------
-# Value types
+# Value types — mask config (the shared cost/lineage primitives live in ``_lineage``)
 # ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class ProcessRef:
-    """ADR-048 intent→process handle. Both fields required for a resolved intent."""
-
-    process_id: str
-    version: str
-
-    @property
-    def resolved(self) -> bool:
-        return bool(self.process_id) and bool(self.version)
-
-
-@dataclass(frozen=True)
-class RequestCost:
-    """Estimated cost of a single agent invocation (ADR-047 per-request dimensions)."""
-
-    tokens: int
-    cost: Decimal
-
-
-@dataclass(frozen=True)
-class CostCap:
-    """Hard caps in both token and monetary (Decimal) dimensions (ADR-047 §D2)."""
-
-    max_request_tokens: int
-    max_request_cost: Decimal
-    max_window_tokens: int
-    max_window_cost: Decimal
-
-
-@dataclass
-class CostWindow:
-    """Rolling per-window usage accumulator (ADR-047 §D2 per-window budget)."""
-
-    used_tokens: int = 0
-    used_cost: Decimal = Decimal("0")
-    window_ref: str = "kyc_onboarding_agent:default"
-
-    def add(self, cost: RequestCost) -> None:
-        self.used_tokens += cost.tokens
-        self.used_cost += cost.cost
 
 
 @dataclass(frozen=True)
@@ -232,60 +175,6 @@ class IdentityDecisionIntent:
     request_cost: RequestCost
     biometric_required: bool = False
     biometric_verified: bool = False
-
-
-@dataclass
-class AgentDecisionRecord:
-    """Decision-lineage record emitted per action (ADR-046 schema + ADR-047 cost)."""
-
-    record_id: str
-    timestamp: datetime
-    agent_id: str
-    triggering_event: str
-    intent: str
-    policies_evaluated: list[str]
-    compliance_result: ComplianceResult
-    reasoning_summary: str
-    confidence_score: float
-    action_taken: str
-    human_reviewed_by: str | None
-    correlation_id: str
-    # ADR-047 cost lineage (cost is a first-class lineage dimension).
-    cost_tokens: int = 0
-    cost_amount: Decimal = Decimal("0")
-    budget_window_ref: str = ""
-    budget_breach_flag: BudgetBreach = BudgetBreach.NONE
-    # MLRO escalation marker (`.claude/rules/agents.md`); set on compliance
-    # fail/escalate, low-confidence identity decisions, and blocked downgrades.
-    escalated_to: str | None = None
-
-
-@dataclass
-class AgentOutcome:
-    """Result of a masked action: the decision, whether a port was called, and the
-    lineage record that was emitted (always non-None — lineage is non-optional)."""
-
-    decision: ConfirmationDecision
-    executed: bool
-    record: AgentDecisionRecord
-    result: object | None = None
-    halt_reason: str | None = None
-    requires_step_up: bool = False
-    requires_hitl: bool = False
-    escalated_to: str | None = None
-
-
-class DecisionRecorder(ABC):
-    """Sink for :class:`AgentDecisionRecord` (ADR-046 producer→sink seam).
-
-    Injected, not implemented here: the ClickHouse/lineage wiring is out of scope
-    (ADR-049 §D7). The agent depends only on this interface.
-    """
-
-    @abstractmethod
-    async def record(self, record: AgentDecisionRecord) -> None:
-        """Persist one decision-lineage record. Must be durable before the action
-        is considered complete (ADR-046 §D4 producer obligation)."""
 
 
 # ---------------------------------------------------------------------------

--- a/services/agents/notification_agent.py
+++ b/services/agents/notification_agent.py
@@ -55,14 +55,24 @@ The agent HONORS that signal and never parses free text for amounts/balances
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from decimal import Decimal
 from enum import StrEnum
 import uuid
 
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
 from services.notifications.notification_provider_port import (
     NotificationChannel,
     NotificationError,
@@ -76,31 +86,6 @@ from services.notifications.notification_provider_port import (
 # ---------------------------------------------------------------------------
 
 
-class ConfirmationDecision(StrEnum):
-    """HITL band selected by the confirmation_policy (ADR-047 / ADR-049 §D4)."""
-
-    AUTO = "auto"
-    REVIEW = "review"
-    BLOCK = "block"
-
-
-class ComplianceResult(StrEnum):
-    """Net L3 compliance-gate (PII overlay, ADR-016) outcome on the lineage record."""
-
-    PASS = "PASS"  # nosec B105 # noqa: S105 — compliance verdict, not a credential
-    FAIL = "FAIL"
-    ESCALATE = "ESCALATE"
-    NA = "N/A"
-
-
-class BudgetBreach(StrEnum):
-    """Cost-cap breach flag for the lineage record (ADR-047 §D2/§D4)."""
-
-    NONE = "NONE"
-    WARN = "WARN"
-    BREACH = "BREACH"
-
-
 class AutonomyLevel(StrEnum):
     """Mask autonomy posture (ADR-049 §D3). Notifications are AUTO-biased:
     informational sends and channel reads are AUTO-eligible within cap; only a
@@ -111,51 +96,8 @@ class AutonomyLevel(StrEnum):
 
 
 # ---------------------------------------------------------------------------
-# Value types
+# Value types — mask config (the shared cost/lineage primitives live in ``_lineage``)
 # ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class ProcessRef:
-    """ADR-048 intent→process handle. Both fields required for a resolved intent."""
-
-    process_id: str
-    version: str
-
-    @property
-    def resolved(self) -> bool:
-        return bool(self.process_id) and bool(self.version)
-
-
-@dataclass(frozen=True)
-class RequestCost:
-    """Estimated cost of a single agent invocation (ADR-047 per-request dimensions)."""
-
-    tokens: int
-    cost: Decimal
-
-
-@dataclass(frozen=True)
-class CostCap:
-    """Hard caps in both token and monetary (Decimal) dimensions (ADR-047 §D2)."""
-
-    max_request_tokens: int
-    max_request_cost: Decimal
-    max_window_tokens: int
-    max_window_cost: Decimal
-
-
-@dataclass
-class CostWindow:
-    """Rolling per-window usage accumulator (ADR-047 §D2 per-window budget)."""
-
-    used_tokens: int = 0
-    used_cost: Decimal = Decimal("0")
-    window_ref: str = "notification_agent:default"
-
-    def add(self, cost: RequestCost) -> None:
-        self.used_tokens += cost.tokens
-        self.used_cost += cost.cost
 
 
 @dataclass(frozen=True)
@@ -218,63 +160,6 @@ class ChannelCheckIntent:
     correlation_id: str
     confidence_score: float
     request_cost: RequestCost
-
-
-@dataclass
-class AgentDecisionRecord:
-    """Decision-lineage record emitted per action (ADR-046 schema + ADR-047 cost)."""
-
-    record_id: str
-    timestamp: datetime
-    agent_id: str
-    triggering_event: str
-    intent: str
-    policies_evaluated: list[str]
-    compliance_result: ComplianceResult
-    reasoning_summary: str
-    confidence_score: float
-    action_taken: str
-    human_reviewed_by: str | None
-    correlation_id: str
-    # ADR-047 cost lineage (cost is a first-class lineage dimension).
-    cost_tokens: int = 0
-    cost_amount: Decimal = Decimal("0")
-    budget_window_ref: str = ""
-    budget_breach_flag: BudgetBreach = BudgetBreach.NONE
-    # DPO escalation marker (ADR-016); set on a PII-gate fail/escalate.
-    escalated_to: str | None = None
-
-
-@dataclass
-class AgentOutcome:
-    """Result of a masked action: the decision, whether a port was called, and the
-    lineage record that was emitted (always non-None — lineage is non-optional).
-
-    ``requires_step_up`` is carried for shape-parity with the sibling agents'
-    outcome; the Notifications mask never sets it (biometric step-up is N/A, a
-    notification never moves client funds — ADR-049 §D4)."""
-
-    decision: ConfirmationDecision
-    executed: bool
-    record: AgentDecisionRecord
-    result: object | None = None
-    halt_reason: str | None = None
-    requires_step_up: bool = False
-    requires_hitl: bool = False
-    escalated_to: str | None = None
-
-
-class DecisionRecorder(ABC):
-    """Sink for :class:`AgentDecisionRecord` (ADR-046 producer→sink seam).
-
-    Injected, not implemented here: the ClickHouse/lineage wiring is out of scope
-    (ADR-049 §D7). The agent depends only on this interface.
-    """
-
-    @abstractmethod
-    async def record(self, record: AgentDecisionRecord) -> None:
-        """Persist one decision-lineage record. Must be durable before the action
-        is considered complete (ADR-046 §D4 producer obligation)."""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/test_lineage.py
+++ b/tests/agents/test_lineage.py
@@ -1,0 +1,210 @@
+"""Unit tests for the canonical shared lineage/cost primitives (``_lineage``).
+
+These cover the primitives in isolation (the per-agent behaviour is covered by
+``test_kyc_onboarding_agent``/``test_notification_agent``/``test_crm_agent``,
+which exercise the same imported classes after the DRY extraction):
+
+* ``CostCap`` breach reasoning per-request AND per-window (ADR-047 §D2).
+* ``CostWindow`` accumulation and the generic default ``window_ref``.
+* ``ProcessRef.resolved`` truth table (ADR-048).
+* ``AgentDecisionRecord`` cost defaults, the emi ``escalated_to`` marker, and the
+  ADR-046 §D5 additive fields (default ``None``; the optional input/output token
+  split refines the existing ``cost_tokens`` total).
+* ``AgentOutcome`` defaults + the emi ``escalated_to`` field.
+* ``DecisionRecorder`` is the injectable ABC seam.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+
+# ── ProcessRef (ADR-048) ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("process_id", "version", "resolved"),
+    [
+        ("P-1", "v1", True),
+        ("", "v1", False),
+        ("P-1", "", False),
+        ("", "", False),
+    ],
+)
+def test_process_ref_resolved(process_id: str, version: str, resolved: bool) -> None:
+    assert ProcessRef(process_id=process_id, version=version).resolved is resolved
+
+
+# ── CostWindow (ADR-047 §D2) ──────────────────────────────────────────────────
+
+
+def test_cost_window_default_window_ref_is_generic() -> None:
+    # The generic default; each agent overrides it with f"{agent_id}:default".
+    assert CostWindow().window_ref == "agent:default"
+    assert CostWindow().used_tokens == 0
+    assert CostWindow().used_cost == Decimal("0")
+
+
+def test_cost_window_add_accumulates_both_dimensions() -> None:
+    window = CostWindow()
+    window.add(RequestCost(tokens=100, cost=Decimal("0.50")))
+    window.add(RequestCost(tokens=25, cost=Decimal("0.25")))
+    assert window.used_tokens == 125
+    assert window.used_cost == Decimal("0.75")
+
+
+# ── CostCap breach reasoning (per-request AND per-window) ──────────────────────
+
+
+def _cap() -> CostCap:
+    return CostCap(
+        max_request_tokens=1_000,
+        max_request_cost=Decimal("1.00"),
+        max_window_tokens=10_000,
+        max_window_cost=Decimal("10.00"),
+    )
+
+
+def _breaches(cap: CostCap, window: CostWindow, cost: RequestCost) -> bool:
+    """Mirror of each agent's ``_cost_breaches`` predicate (ADR-047 §D2)."""
+    return (
+        cost.tokens > cap.max_request_tokens
+        or cost.cost > cap.max_request_cost
+        or window.used_tokens + cost.tokens > cap.max_window_tokens
+        or window.used_cost + cost.cost > cap.max_window_cost
+    )
+
+
+def test_cost_cap_within_all_dimensions_does_not_breach() -> None:
+    assert _breaches(_cap(), CostWindow(), RequestCost(tokens=500, cost=Decimal("0.50"))) is False
+
+
+def test_cost_cap_per_request_token_breach() -> None:
+    assert _breaches(_cap(), CostWindow(), RequestCost(tokens=1_001, cost=Decimal("0.01"))) is True
+
+
+def test_cost_cap_per_request_cost_breach() -> None:
+    assert _breaches(_cap(), CostWindow(), RequestCost(tokens=1, cost=Decimal("1.01"))) is True
+
+
+def test_cost_cap_per_window_token_breach() -> None:
+    window = CostWindow(used_tokens=9_900, used_cost=Decimal("0.00"))
+    assert _breaches(_cap(), window, RequestCost(tokens=200, cost=Decimal("0.01"))) is True
+
+
+def test_cost_cap_per_window_cost_breach() -> None:
+    window = CostWindow(used_tokens=0, used_cost=Decimal("9.99"))
+    assert _breaches(_cap(), window, RequestCost(tokens=1, cost=Decimal("0.50"))) is True
+
+
+# ── AgentDecisionRecord (ADR-046 + escalation marker + §D5 additive fields) ───
+
+
+def _record(**overrides: object) -> AgentDecisionRecord:
+    base: dict[str, object] = dict(
+        record_id="r-1",
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        agent_id="test_agent",
+        triggering_event="evt",
+        intent="do a thing",
+        policies_evaluated=["ADR-048-process-resolution"],
+        compliance_result=ComplianceResult.PASS,
+        reasoning_summary="ok",
+        confidence_score=0.95,
+        action_taken="DONE",
+        human_reviewed_by=None,
+        correlation_id="c-1",
+    )
+    base.update(overrides)
+    return AgentDecisionRecord(**base)  # type: ignore[arg-type]
+
+
+def test_decision_record_cost_defaults() -> None:
+    rec = _record()
+    assert rec.cost_tokens == 0
+    assert rec.cost_amount == Decimal("0")
+    assert rec.budget_window_ref == ""
+    assert rec.budget_breach_flag is BudgetBreach.NONE
+
+
+def test_decision_record_escalated_to_defaults_none_and_settable() -> None:
+    # The emi escalation marker (MLRO/DPO/AML) is set on a compliance fail/escalate.
+    assert _record().escalated_to is None
+    assert _record(escalated_to="MLRO").escalated_to == "MLRO"
+
+
+def test_decision_record_d5_fields_default_none() -> None:
+    # ADR-046 §D5 additive fields are non-breaking and default to None.
+    rec = _record()
+    assert rec.immutable_storage_ref is None
+    assert rec.input_tokens is None
+    assert rec.output_tokens is None
+
+
+def test_decision_record_d5_token_split_is_optional_and_refines_total() -> None:
+    # The input/output split is optional; when supplied it refines the existing
+    # cost_tokens TOTAL (which stays authoritative), not replaces it.
+    rec = _record(cost_tokens=300, input_tokens=200, output_tokens=100)
+    assert rec.cost_tokens == 300
+    assert rec.input_tokens + rec.output_tokens == rec.cost_tokens
+
+
+def test_decision_record_d5_immutable_storage_ref_settable() -> None:
+    rec = _record(immutable_storage_ref="worm://lineage/r-1")
+    assert rec.immutable_storage_ref == "worm://lineage/r-1"
+
+
+# ── AgentOutcome + DecisionRecorder seam ──────────────────────────────────────
+
+
+def test_agent_outcome_defaults() -> None:
+    rec = _record()
+    outcome = AgentOutcome(decision=ConfirmationDecision.AUTO, executed=True, record=rec)
+    assert outcome.result is None
+    assert outcome.halt_reason is None
+    assert outcome.requires_step_up is False
+    assert outcome.requires_hitl is False
+    assert outcome.escalated_to is None
+
+
+def test_agent_outcome_escalated_to_settable() -> None:
+    rec = _record()
+    outcome = AgentOutcome(
+        decision=ConfirmationDecision.BLOCK,
+        executed=False,
+        record=rec,
+        escalated_to="DPO",
+    )
+    assert outcome.escalated_to == "DPO"
+
+
+async def test_decision_recorder_is_injectable_abc() -> None:
+    captured: list[AgentDecisionRecord] = []
+
+    class _Recorder(DecisionRecorder):
+        async def record(self, record: AgentDecisionRecord) -> None:
+            captured.append(record)
+
+    rec = _record()
+    await _Recorder().record(rec)
+    assert captured == [rec]
+
+
+def test_decision_recorder_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError):
+        DecisionRecorder()  # type: ignore[abstract]


### PR DESCRIPTION
## What

Behaviour-preserving DRY refactor mirroring **banxe-payment-core PR #14** in emi-stack.

The three L2 client-facing agents — `kyc_onboarding_agent.py`, `notification_agent.py`, `crm_agent.py` — each duplicated the *same* governance vocabulary (ADR-048 process handle, ADR-047 cost dimensions, ADR-046 decision-lineage record, the recorder seam, and the `ConfirmationDecision`/`ComplianceResult`/`BudgetBreach` enums). This extracts one canonical home.

## Changes (scope: `services/agents/**` + `tests/agents/**` only)

- **New** `services/agents/_lineage.py` — canonical `ProcessRef`, `RequestCost`, `CostCap`, `CostWindow`, `AgentDecisionRecord`, `AgentOutcome`, `DecisionRecorder`, enums. Mirrors payment-core's `src/agents/_lineage.py`. emi-specific `escalated_to: str | None = None` retained on `AgentDecisionRecord` + `AgentOutcome`.
- **ADR-046 §D5 additive fields** on `AgentDecisionRecord`: `immutable_storage_ref`, `input_tokens`, `output_tokens` — all default `None`, strictly non-breaking. The input/output split *refines* the authoritative `cost_tokens` total. Appended after `escalated_to`; original field order untouched.
- **Migrated all 3 agents** to import from `_lineage`; deleted the duplicated local definitions (~125 lines removed each). Each agent keeps its mask-specifics (KYC: `IdentityDecision` + MLRO escalation; Notifications: funds-data REVIEW; Referral/CRM: `ComplianceOverlay` + anti-abuse/payout REVIEW). Gate chain, records, and `escalated_to` semantics identical.
- **`__init__.py`** re-exports the shared set from `_lineage`; public `__all__` surface unchanged.
- **New** `tests/agents/test_lineage.py` mirroring payment-core's.

## Verification

- All existing agent tests pass **unchanged** (behaviour-preserving); full repo suite **10090 passed, 5 skipped**.
- **100%** coverage on `services/agents/**` including `_lineage.py`.
- `ruff format` + `ruff check` clean; `bandit` exit 0.
- R-SEC intact (record carries opaque metadata only). §D5 additive-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)