### PR TITLE
feat(intent-layer): ADR-049 L1 Intent classifier/router (S5.1) [IL-126]

### DIFF
--- a/services/intent_layer/__init__.py
+++ b/services/intent_layer/__init__.py
@@ -1,0 +1,77 @@
+"""
+services/intent_layer — ADR-049 L1 Intent Layer (client intent → L2 agent dispatch)
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+
+The CLIENT-facing L1 Intent Layer specified by ADR-049: capture a free-form client
+intent, classify it DETERMINISTICALLY against the S3 intent→process map, resolve it to a
+canonical process_ref = {process_id, version} (ADR-048), select the client-facing mask,
+and dispatch to the L2 agent through an injected port.
+
+NOT the same layer as services/agent_routing (ADR-021), which is the INTERNAL
+compliance/AML/KYC task-router to tier workers. This layer:
+  - is gated by INTENT_LAYER_ENABLED  (DISTINCT from ADR-021's AGENT_ROUTING_ENABLED);
+  - is cross-repo (dispatches to agents in payment-core AND emi-stack) via injected
+    ports, with NO hard dependency on either agent repo's internals;
+  - treats an intent that resolves to no process as a governance event, never improvised.
+
+Composition example (wiring is composition-root work, not done in this package)::
+
+    catalog = IntentCatalog.from_files(MAP_PATH, REGISTRY_PATH)
+    enabled = intent_layer_enabled()
+    classifier = IntentClassifier(catalog, enabled=enabled, llm=my_s1_llm_port)
+    router = IntentRouter(my_agent_dispatch_port, enabled=enabled)
+
+    resolved = classifier.classify("send money to Alice")
+    disposition = router.route(resolved)
+"""
+
+from __future__ import annotations
+
+from services.intent_layer.catalog import IntentCatalog, UnresolvableProcessError
+from services.intent_layer.classifier import IntentClassifier
+from services.intent_layer.config import (
+    INTENT_LAYER_ENABLED_ENV,
+    intent_layer_enabled,
+)
+from services.intent_layer.models import (
+    ConfidenceBand,
+    Disposition,
+    DispositionKind,
+    IntentDefinition,
+    IntentStatus,
+    MatchSource,
+    ProcessRef,
+    ResolvedIntent,
+)
+from services.intent_layer.ports import (
+    AgentDispatchPort,
+    DispatchReceipt,
+    DispatchRequest,
+    LLMClassification,
+    LLMClassifierPort,
+    NullLLMClassifier,
+)
+from services.intent_layer.router import IntentRouter
+
+__all__ = [
+    "INTENT_LAYER_ENABLED_ENV",
+    "AgentDispatchPort",
+    "ConfidenceBand",
+    "Disposition",
+    "DispositionKind",
+    "DispatchReceipt",
+    "DispatchRequest",
+    "IntentCatalog",
+    "IntentClassifier",
+    "IntentDefinition",
+    "IntentRouter",
+    "IntentStatus",
+    "LLMClassification",
+    "LLMClassifierPort",
+    "MatchSource",
+    "NullLLMClassifier",
+    "ProcessRef",
+    "ResolvedIntent",
+    "UnresolvableProcessError",
+    "intent_layer_enabled",
+]

--- a/services/intent_layer/catalog.py
+++ b/services/intent_layer/catalog.py
@@ -1,0 +1,97 @@
+"""
+services/intent_layer/catalog.py — intent→process_ref catalog (S3 inputs)
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+
+Loads the two S3 artefacts and joins them into a resolved, query-ready catalog:
+  - banxe-business-processes/ai-agent-context/intent-process-map.yaml
+      (intent + aliases + capability + process_ids)
+  - banxe-business-processes/ai-agent-context/processes-registry.json
+      ({process_id, version}) — the version source for each process_ref.
+
+Every process_id in the map MUST exist in the registry (mirrors the repo's own
+validate_resolvable.py). A bare process_id with no registry entry is a construction
+error, surfaced loudly at load time — never silently dispatched.
+
+The catalog is pure data: it can be built from parsed dicts (unit tests / DI) or from
+files (composition root). It hard-depends on neither agent repo.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from services.intent_layer.models import IntentDefinition, ProcessRef
+
+
+def _normalise(text: str) -> str:
+    """Canonical lookup key: lowercased, collapsed internal whitespace, trimmed."""
+    return " ".join(text.lower().split())
+
+
+class UnresolvableProcessError(ValueError):
+    """Raised when an intent maps to a process_id absent from the registry."""
+
+
+class IntentCatalog:
+    """Resolved intent→process_ref lookup over the S3 map + registry."""
+
+    def __init__(self, definitions: list[IntentDefinition]) -> None:
+        self._definitions: list[IntentDefinition] = list(definitions)
+        self._index: dict[str, IntentDefinition] = {}
+        for d in self._definitions:
+            self._index[_normalise(d.intent)] = d
+            for alias in d.aliases:
+                self._index[_normalise(alias)] = d
+
+    @property
+    def definitions(self) -> list[IntentDefinition]:
+        """All intent definitions — passed to the LLM port as fuzzy-match candidates."""
+        return list(self._definitions)
+
+    def lookup(self, key: str) -> IntentDefinition | None:
+        """Exact/alias lookup on the normalised key; None when nothing matches."""
+        return self._index.get(_normalise(key))
+
+    def by_intent(self, intent: str) -> IntentDefinition | None:
+        """Resolve a canonical intent token (used to re-validate an LLM proposal)."""
+        d = self._index.get(_normalise(intent))
+        return d if d is not None and _normalise(d.intent) == _normalise(intent) else None
+
+    # ── Construction ────────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_data(cls, intent_map: dict[str, Any], registry: dict[str, Any]) -> IntentCatalog:
+        """Build from already-parsed YAML/JSON structures (the DI / test entry point)."""
+        versions = {
+            entry["process_id"]: entry["version"] for entry in registry.get("processes", [])
+        }
+        definitions: list[IntentDefinition] = []
+        for row in intent_map.get("intents", []):
+            refs: list[ProcessRef] = []
+            for pid in row.get("process_ids", []):
+                if pid not in versions:
+                    raise UnresolvableProcessError(
+                        f"intent {row['intent']!r} → process_id {pid!r} "
+                        "not present in processes-registry.json"
+                    )
+                refs.append(ProcessRef(process_id=pid, version=versions[pid]))
+            definitions.append(
+                IntentDefinition(
+                    intent=row["intent"],
+                    aliases=tuple(row.get("aliases", [])),
+                    capability=row["capability"],
+                    process_refs=tuple(refs),
+                )
+            )
+        return cls(definitions)
+
+    @classmethod
+    def from_files(cls, map_path: str | Path, registry_path: str | Path) -> IntentCatalog:
+        """Build from the two S3 files on disk (the composition-root entry point)."""
+        import yaml  # local import — keeps PyYAML optional for pure-data test paths
+
+        intent_map = yaml.safe_load(Path(map_path).read_text(encoding="utf-8"))
+        registry = json.loads(Path(registry_path).read_text(encoding="utf-8"))
+        return cls.from_data(intent_map, registry)

--- a/services/intent_layer/classifier.py
+++ b/services/intent_layer/classifier.py
@@ -1,0 +1,105 @@
+"""
+services/intent_layer/classifier.py — L1 IntentClassifier
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+
+ADR-049 D1 capture+resolve. classify(intent_text) → ResolvedIntent.
+
+Classification is DETERMINISTIC FIRST: exact/alias match against the S3 intent→process
+map (already version-resolved by IntentCatalog), confidence 1.0 (AUTO band). Only when
+deterministic matching fails AND INTENT_LAYER_ENABLED is true is the injected
+LLMClassifierPort consulted — and it must name an EXISTING catalog intent, which the
+classifier re-validates (the LLM never invents a process_ref). An intent that resolves
+to no canonical process is UNRESOLVED → a governance event (ADR-048 D3.3 / ADR-049 D2),
+never improvised.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from services.intent_layer.catalog import IntentCatalog
+from services.intent_layer.models import (
+    IntentDefinition,
+    IntentStatus,
+    MatchSource,
+    ResolvedIntent,
+)
+from services.intent_layer.ports import LLMClassifierPort, NullLLMClassifier
+
+_EXACT_CONFIDENCE = 1.0
+
+
+class IntentClassifier:
+    """Resolves free-form client intent text to a ResolvedIntent."""
+
+    def __init__(
+        self,
+        catalog: IntentCatalog,
+        *,
+        enabled: bool = False,
+        llm: LLMClassifierPort | None = None,
+    ) -> None:
+        self._catalog = catalog
+        self._enabled = enabled
+        self._llm: LLMClassifierPort = llm if llm is not None else NullLLMClassifier()
+
+    def classify(self, intent_text: str, *, correlation_id: str | None = None) -> ResolvedIntent:
+        """Capture+resolve one client intent. Always returns a ResolvedIntent; an
+        unmatched intent yields status=UNRESOLVED (governance event), never an exception."""
+        cid = correlation_id or uuid.uuid4().hex
+
+        match = self._catalog.lookup(intent_text)
+        if match is not None:
+            source = MatchSource.EXACT if _is_exact(match, intent_text) else MatchSource.ALIAS
+            return self._resolved(intent_text, cid, match, _EXACT_CONFIDENCE, source)
+
+        llm_match = self._fuzzy(intent_text)
+        if llm_match is not None:
+            definition, confidence = llm_match
+            return self._resolved(intent_text, cid, definition, confidence, MatchSource.LLM)
+
+        return ResolvedIntent(
+            raw_text=intent_text,
+            correlation_id=cid,
+            status=IntentStatus.UNRESOLVED,
+            confidence=0.0,
+            match_source=MatchSource.NONE,
+        )
+
+    # ── internals ────────────────────────────────────────────────────────────────
+
+    def _fuzzy(self, intent_text: str) -> tuple[IntentDefinition, float] | None:
+        """Gated LLM fallback: only when enabled. Re-validates the proposed intent
+        against the catalog so a hallucinated token cannot resolve to a process_ref."""
+        if not self._enabled:
+            return None
+        proposal = self._llm.classify(intent_text, self._catalog.definitions)
+        if proposal is None:
+            return None
+        definition = self._catalog.by_intent(proposal.matched_intent)
+        if definition is None:
+            return None
+        return definition, proposal.confidence
+
+    @staticmethod
+    def _resolved(
+        text: str,
+        cid: str,
+        definition: IntentDefinition,
+        confidence: float,
+        source: MatchSource,
+    ) -> ResolvedIntent:
+        return ResolvedIntent(
+            raw_text=text,
+            correlation_id=cid,
+            status=IntentStatus.RESOLVED,
+            confidence=confidence,
+            match_source=source,
+            matched_intent=definition.intent,
+            capability=definition.capability,
+            process_refs=definition.process_refs,
+        )
+
+
+def _is_exact(definition: IntentDefinition, text: str) -> bool:
+    return " ".join(text.lower().split()) == " ".join(definition.intent.lower().split())

--- a/services/intent_layer/config.py
+++ b/services/intent_layer/config.py
@@ -1,0 +1,27 @@
+"""
+services/intent_layer/config.py — L1 Intent Layer feature flag
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+
+INTENT_LAYER_ENABLED governs the ADR-049 client L1 Intent Layer. It is DISTINCT from
+ADR-021's AGENT_ROUTING_ENABLED (the internal compliance/AML/KYC tier-worker router) —
+the two layers are separate concerns and MUST NOT share a flag. Default false: the
+layer is inert until explicitly activated, so it is safe to ship pre-activation.
+
+Gating semantics:
+  - false → IntentRouter.route() returns NOT_ENABLED (no dispatch); the LLM fuzzy
+            fallback in IntentClassifier is also suppressed.
+  - true  → deterministic classification dispatches; LLM fallback is consulted when a
+            non-Null LLMClassifierPort is injected (S1 gateway).
+"""
+
+from __future__ import annotations
+
+import os
+
+INTENT_LAYER_ENABLED_ENV = "INTENT_LAYER_ENABLED"
+
+
+def intent_layer_enabled(env: dict[str, str] | None = None) -> bool:
+    """Read the INTENT_LAYER_ENABLED flag. Injectable env for deterministic tests."""
+    source = env if env is not None else os.environ
+    return source.get(INTENT_LAYER_ENABLED_ENV, "false").strip().lower() == "true"

--- a/services/intent_layer/models.py
+++ b/services/intent_layer/models.py
@@ -1,0 +1,141 @@
+"""
+services/intent_layer/models.py — L1 Intent Layer domain types
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+
+ADR-049 L1 Intent Layer (the CLIENT intent surface). NOT ADR-021 agent_routing —
+that is the internal compliance/AML/KYC task-router to tier workers. This module is
+the client-facing L1→L2 seam: classify a free-form client intent, resolve it to a
+canonical ``process_ref = {process_id, version}`` (ADR-048 intent→process contract),
+select the client-facing mask, and hand off to the L2 agent.
+
+These are pure data types — no I/O, no LLM, no port wiring. They are the envelope the
+classifier produces and the router consumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+# ── Enumerations ────────────────────────────────────────────────────────────────
+
+
+class IntentStatus(str, Enum):
+    """Outcome of classifying a client intent against the intent→process map."""
+
+    RESOLVED = "RESOLVED"  # matched an intent that resolves to ≥1 process_ref
+    UNRESOLVED = "UNRESOLVED"  # no canonical process — ADR-048 D3.3 governance event
+
+
+class ConfidenceBand(str, Enum):
+    """ADR-049 D4 HITL bands — reused verbatim, NO new threshold scale introduced."""
+
+    AUTO = "AUTO"  # confidence > 0.90
+    REVIEW = "REVIEW"  # 0.70 ≤ confidence ≤ 0.90
+    BLOCK = "BLOCK"  # confidence < 0.70
+
+    @classmethod
+    def of(cls, confidence: float) -> ConfidenceBand:
+        """Map a confidence score onto the ADR-049 D4 band."""
+        if confidence > 0.90:
+            return cls.AUTO
+        if confidence >= 0.70:
+            return cls.REVIEW
+        return cls.BLOCK
+
+
+class MatchSource(str, Enum):
+    """How the classifier arrived at a match — determinism is auditable per decision."""
+
+    EXACT = "EXACT"  # canonical intent token matched
+    ALIAS = "ALIAS"  # one of the intent's aliases matched
+    LLM = "LLM"  # fuzzy LLM fallback (gated behind INTENT_LAYER_ENABLED + S1 gateway)
+    NONE = "NONE"  # no match — UNRESOLVED
+
+
+class DispositionKind(str, Enum):
+    """What the router did with a ResolvedIntent."""
+
+    DISPATCHED = "DISPATCHED"  # handed off to the L2 client-facing agent
+    NOT_ENABLED = "NOT_ENABLED"  # INTENT_LAYER_ENABLED is false — safe pre-activation no-op
+    GOVERNANCE_EVENT = "GOVERNANCE_EVENT"  # UNRESOLVED intent → HITL / process-gap backlog
+
+
+# ── Value objects ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ProcessRef:
+    """ADR-048 resolvable handle: the {process_id, version} an intent resolves to.
+
+    Conforms to banxe-architecture/schemas/process_ref.schema.json — a non-sensitive
+    identifier pair that MUST NOT embed secrets or PII.
+    """
+
+    process_id: str
+    version: str
+
+    def __post_init__(self) -> None:
+        if not self.process_id:
+            raise ValueError("process_id must not be empty")
+        if not self.version:
+            raise ValueError("version must not be empty")
+
+    def as_dict(self) -> dict[str, str]:
+        return {"process_id": self.process_id, "version": self.version}
+
+
+@dataclass(frozen=True)
+class IntentDefinition:
+    """One row of the S3 intent→process map (intent-process-map.yaml).
+
+    process_refs are pre-resolved against processes-registry.json at catalog-load time,
+    so an IntentDefinition always carries fully-versioned refs (never bare process_ids).
+    """
+
+    intent: str
+    aliases: tuple[str, ...]
+    capability: str
+    process_refs: tuple[ProcessRef, ...]
+
+
+# ── Classifier / router outputs ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ResolvedIntent:
+    """Structured, auditable request emitted by L1 capture+resolve (ADR-049 D1.4).
+
+    This is the object that crosses the L1→L2 boundary. For an UNRESOLVED intent the
+    process_refs tuple is empty and status is UNRESOLVED (governance event).
+    """
+
+    raw_text: str
+    correlation_id: str
+    status: IntentStatus
+    confidence: float
+    match_source: MatchSource
+    matched_intent: str | None = None
+    capability: str | None = None
+    process_refs: tuple[ProcessRef, ...] = field(default_factory=tuple)
+
+    @property
+    def band(self) -> ConfidenceBand:
+        """ADR-049 D4 confidence band for this resolution."""
+        return ConfidenceBand.of(self.confidence)
+
+    @property
+    def is_resolved(self) -> bool:
+        return self.status is IntentStatus.RESOLVED
+
+
+@dataclass(frozen=True)
+class Disposition:
+    """Result of routing a ResolvedIntent — what L1 did and why."""
+
+    kind: DispositionKind
+    correlation_id: str
+    capability: str | None = None
+    process_refs: tuple[ProcessRef, ...] = field(default_factory=tuple)
+    receipt: object | None = None  # AgentDispatchPort receipt, when DISPATCHED
+    reason: str | None = None

--- a/services/intent_layer/ports.py
+++ b/services/intent_layer/ports.py
@@ -1,0 +1,91 @@
+"""
+services/intent_layer/ports.py — L1 Intent Layer injected ports (interfaces only)
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+
+L1 is CROSS-REPO: it dispatches to client-facing agents that live in BOTH
+banxe-payment-core and banxe-emi-stack. To avoid a hard dependency on either agent
+repo's internals, L1 talks to the outside world only through these Protocol ports.
+Concrete wiring (the 9 masks, the S1 LLM gateway) is composition-root work, injected
+at the seam — NOT imported here. This keeps the layer unit-testable without live infra.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from services.intent_layer.models import IntentDefinition, ProcessRef, ResolvedIntent
+
+# ── LLM fallback port (S1 gateway seam) ──────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LLMClassification:
+    """A fuzzy match proposed by the LLM fallback. Always names an existing intent
+    token from the catalog — the classifier re-validates it, the LLM never invents a
+    process_ref (ADR-048 D3.3: no improvisation)."""
+
+    matched_intent: str
+    confidence: float
+
+
+@runtime_checkable
+class LLMClassifierPort(Protocol):
+    """S1-gateway-backed fuzzy classifier. Only consulted when deterministic matching
+    fails AND INTENT_LAYER_ENABLED is true. Returns None when it cannot confidently
+    map the text to one of ``candidates`` (the catalog's intent definitions)."""
+
+    def classify(
+        self, intent_text: str, candidates: list[IntentDefinition]
+    ) -> LLMClassification | None: ...
+
+
+class NullLLMClassifier:
+    """Default LLM port: always abstains. Lets the whole layer be exercised with zero
+    live-LLM dependency — deterministic classification is fully testable without it."""
+
+    def classify(
+        self, intent_text: str, candidates: list[IntentDefinition]
+    ) -> LLMClassification | None:
+        return None
+
+
+# ── Agent dispatch port (L1 → L2 seam) ───────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class DispatchRequest:
+    """The structured hand-off L1 passes across the L1→L2 boundary (ADR-049 D2).
+
+    Carries the resolved process_ref(s) so the L2 agent's §D2 chain has its process_ref
+    gate already satisfied — the agent never re-resolves, it executes within its mask.
+    """
+
+    capability: str
+    process_refs: tuple[ProcessRef, ...]
+    resolved_intent: ResolvedIntent
+    correlation_id: str
+
+    @property
+    def process_ref(self) -> ProcessRef:
+        """Primary process_ref (first declared) — convenience for single-process masks."""
+        return self.process_refs[0]
+
+
+@dataclass(frozen=True)
+class DispatchReceipt:
+    """Acknowledgement returned by a client-facing agent on accepting the hand-off."""
+
+    accepted: bool
+    agent: str
+    detail: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@runtime_checkable
+class AgentDispatchPort(Protocol):
+    """The injected handle to the 9 client-facing agents (in payment-core + emi-stack).
+    Concrete implementations are wired at the composition root, keyed by capability —
+    NOT imported into this layer."""
+
+    def dispatch(self, request: DispatchRequest) -> DispatchReceipt: ...

--- a/services/intent_layer/router.py
+++ b/services/intent_layer/router.py
@@ -1,0 +1,61 @@
+"""
+services/intent_layer/router.py — L1 IntentRouter
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+
+ADR-049 D1.4 hand-off + D2 chain. route(ResolvedIntent) → Disposition.
+
+Ordered guards (ADR-049 D2 invariants):
+  1. INTENT_LAYER_ENABLED false  → NOT_ENABLED, NO dispatch (safe pre-activation).
+  2. UNRESOLVED intent           → GOVERNANCE_EVENT (HITL / process-gap), NO dispatch,
+                                    never improvised (ADR-048 D3.3).
+  3. otherwise                   → select the client-facing mask by capability and
+                                    dispatch via the injected AgentDispatchPort, passing
+                                    the resolved process_ref(s) so the L2 agent's §D2
+                                    chain has its process_ref gate already satisfied.
+
+The router holds NO concrete agent imports — the 9 masks are reached only through the
+injected AgentDispatchPort (cross-repo: payment-core + emi-stack).
+"""
+
+from __future__ import annotations
+
+from services.intent_layer.models import Disposition, DispositionKind, ResolvedIntent
+from services.intent_layer.ports import AgentDispatchPort, DispatchRequest
+
+
+class IntentRouter:
+    """Dispatches a ResolvedIntent to its client-facing agent under the feature flag."""
+
+    def __init__(self, dispatcher: AgentDispatchPort, *, enabled: bool = False) -> None:
+        self._dispatcher = dispatcher
+        self._enabled = enabled
+
+    def route(self, resolved: ResolvedIntent) -> Disposition:
+        if not self._enabled:
+            return Disposition(
+                kind=DispositionKind.NOT_ENABLED,
+                correlation_id=resolved.correlation_id,
+                reason="INTENT_LAYER_ENABLED is false — no dispatch (safe pre-activation)",
+            )
+
+        if not resolved.is_resolved:
+            return Disposition(
+                kind=DispositionKind.GOVERNANCE_EVENT,
+                correlation_id=resolved.correlation_id,
+                reason="intent resolved to no canonical process — HITL / process-gap (ADR-048 D3.3)",
+            )
+
+        request = DispatchRequest(
+            capability=resolved.capability,  # type: ignore[arg-type]  # resolved ⇒ non-None
+            process_refs=resolved.process_refs,
+            resolved_intent=resolved,
+            correlation_id=resolved.correlation_id,
+        )
+        receipt = self._dispatcher.dispatch(request)
+        return Disposition(
+            kind=DispositionKind.DISPATCHED,
+            correlation_id=resolved.correlation_id,
+            capability=resolved.capability,
+            process_refs=resolved.process_refs,
+            receipt=receipt,
+        )

--- a/tests/test_intent_layer/conftest.py
+++ b/tests/test_intent_layer/conftest.py
@@ -1,0 +1,190 @@
+"""
+tests/test_intent_layer/conftest.py — shared fixtures for the L1 Intent Layer tests
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+
+All fixtures are in-memory / file-fixture based: the whole layer is exercised with NO
+live LLM and NO network, every external dependency injected. INTENT_MAP / REGISTRY
+mirror the shape (and the 9 client-facing capabilities) of the real S3 artefacts in
+banxe-business-processes/ai-agent-context/.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from services.intent_layer.catalog import IntentCatalog
+from services.intent_layer.ports import (
+    DispatchReceipt,
+    DispatchRequest,
+    LLMClassification,
+)
+
+# ── The 9 client-facing capabilities (ADR-049 D3), mirroring intent-process-map.yaml ──
+
+INTENT_MAP: dict = {
+    "version": "1.0.0",
+    "intents": [
+        {
+            "intent": "pay",
+            "aliases": ["transfer", "send money", "make a payment", "move funds"],
+            "capability": "Payments",
+            "process_ids": ["payment-processing-process"],
+        },
+        {
+            "intent": "exchange",
+            "aliases": ["fx", "convert currency", "currency exchange", "swap currency"],
+            "capability": "FX / Exchange",
+            "process_ids": ["fx-exchange"],
+        },
+        {
+            "intent": "view-balance",
+            "aliases": ["check balance", "view balance", "what's my balance", "manage wallet"],
+            "capability": "Wallet",
+            "process_ids": ["wallet-balance-inquiry"],
+        },
+        {
+            "intent": "freeze-card",
+            "aliases": ["block card", "freeze my card", "lock card", "report card lost/stolen"],
+            "capability": "Card (Wallet/Payments-adjacent)",
+            "process_ids": ["card-blocking"],
+        },
+        {
+            "intent": "onboard-kyc",
+            "aliases": [
+                "sign up",
+                "open an account",
+                "register",
+                "complete KYC",
+                "verify identity",
+            ],
+            "capability": "KYC onboarding",
+            "process_ids": ["onboarding-process"],
+        },
+        {
+            "intent": "get-statement",
+            "aliases": ["statement", "download statement", "account statement", "get my statement"],
+            "capability": "Statements (ADR-055)",
+            "process_ids": ["statement-generation"],
+        },
+        {
+            "intent": "see-spending",
+            "aliases": ["spending", "spending breakdown", "where did my money go", "insights"],
+            "capability": "Analytics / Reporting (ADR-054)",
+            "process_ids": ["spending-analytics"],
+        },
+        {
+            "intent": "refer-a-friend",
+            "aliases": ["referral", "invite a friend", "refer", "share invite"],
+            "capability": "Referral / CRM",
+            "process_ids": ["referral-management"],
+        },
+        {
+            "intent": "get-notified",
+            "aliases": ["notifications", "alerts", "notify me", "manage notifications"],
+            "capability": "Notifications",
+            "process_ids": ["notification-dispatch"],
+        },
+        # adjacent card intents resolving to existing card processes
+        {
+            "intent": "activate-card",
+            "aliases": ["activate my card", "turn on card", "enable card"],
+            "capability": "Card",
+            "process_ids": ["card-activation"],
+        },
+        {
+            "intent": "order-card",
+            "aliases": ["get a card", "new card", "request card", "issue card"],
+            "capability": "Card",
+            "process_ids": ["card-issuance"],
+        },
+        {
+            "intent": "replace-card",
+            "aliases": ["replace card", "lost card replacement", "new card same account"],
+            "capability": "Card",
+            "process_ids": ["card-replacement"],
+        },
+    ],
+}
+
+REGISTRY: dict = {
+    "schema": "ai-agent-context/process_ref.schema.json",
+    "processes": [
+        {"process_id": "payment-processing-process", "version": "1.0.0"},
+        {"process_id": "fx-exchange", "version": "1.0.0"},
+        {"process_id": "wallet-balance-inquiry", "version": "1.0.0"},
+        {"process_id": "card-blocking", "version": "1.0.0"},
+        {"process_id": "onboarding-process", "version": "1.0.0"},
+        {"process_id": "statement-generation", "version": "1.0.0"},
+        {"process_id": "spending-analytics", "version": "1.0.0"},
+        {"process_id": "referral-management", "version": "1.0.0"},
+        {"process_id": "notification-dispatch", "version": "1.0.0"},
+        {"process_id": "card-activation", "version": "1.0.0"},
+        {"process_id": "card-issuance", "version": "1.0.0"},
+        {"process_id": "card-replacement", "version": "1.0.0"},
+    ],
+}
+
+# Expected (intent, capability, process_id) for the 9 primary client-facing capabilities.
+NINE_CAPABILITIES = [
+    ("pay", "Payments", "payment-processing-process"),
+    ("exchange", "FX / Exchange", "fx-exchange"),
+    ("view-balance", "Wallet", "wallet-balance-inquiry"),
+    ("freeze-card", "Card (Wallet/Payments-adjacent)", "card-blocking"),
+    ("onboard-kyc", "KYC onboarding", "onboarding-process"),
+    ("get-statement", "Statements (ADR-055)", "statement-generation"),
+    ("see-spending", "Analytics / Reporting (ADR-054)", "spending-analytics"),
+    ("refer-a-friend", "Referral / CRM", "referral-management"),
+    ("get-notified", "Notifications", "notification-dispatch"),
+]
+
+
+@pytest.fixture()
+def catalog() -> IntentCatalog:
+    return IntentCatalog.from_data(INTENT_MAP, REGISTRY)
+
+
+class SpyDispatcher:
+    """AgentDispatchPort double — records every dispatch and returns a canned receipt."""
+
+    def __init__(self, *, accepted: bool = True) -> None:
+        self.calls: list[DispatchRequest] = []
+        self._accepted = accepted
+
+    def dispatch(self, request: DispatchRequest) -> DispatchReceipt:
+        self.calls.append(request)
+        return DispatchReceipt(accepted=self._accepted, agent=f"agent:{request.capability}")
+
+
+@pytest.fixture()
+def spy_dispatcher() -> SpyDispatcher:
+    return SpyDispatcher()
+
+
+class StubLLM:
+    """LLMClassifierPort double — maps a fixed text to a fixed intent token."""
+
+    def __init__(self, *, text: str, intent: str, confidence: float) -> None:
+        self._text = text
+        self._intent = intent
+        self._confidence = confidence
+        self.calls: list[str] = []
+
+    def classify(self, intent_text: str, candidates: list) -> LLMClassification | None:
+        self.calls.append(intent_text)
+        if intent_text == self._text:
+            return LLMClassification(matched_intent=self._intent, confidence=self._confidence)
+        return None
+
+
+@pytest.fixture()
+def map_files(tmp_path) -> tuple[str, str]:
+    """Write the S3 artefacts to disk for the from_files() path (needs PyYAML)."""
+    import yaml
+
+    map_path = tmp_path / "intent-process-map.yaml"
+    reg_path = tmp_path / "processes-registry.json"
+    map_path.write_text(yaml.safe_dump(INTENT_MAP), encoding="utf-8")
+    reg_path.write_text(json.dumps(REGISTRY), encoding="utf-8")
+    return str(map_path), str(reg_path)

--- a/tests/test_intent_layer/test_catalog.py
+++ b/tests/test_intent_layer/test_catalog.py
@@ -1,0 +1,81 @@
+"""
+tests/test_intent_layer/test_catalog.py — IntentCatalog: load, resolve, validate
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.intent_layer.catalog import IntentCatalog, UnresolvableProcessError
+from services.intent_layer.models import ProcessRef
+
+from .conftest import INTENT_MAP, NINE_CAPABILITIES, REGISTRY
+
+
+def test_every_process_id_resolves_to_a_versioned_ref(catalog):
+    for intent, _capability, process_id in NINE_CAPABILITIES:
+        definition = catalog.lookup(intent)
+        assert definition is not None
+        assert definition.process_refs == (ProcessRef(process_id, "1.0.0"),)
+
+
+def test_exact_and_alias_keys_index_to_same_definition(catalog):
+    by_intent = catalog.lookup("pay")
+    by_alias = catalog.lookup("send money")
+    assert by_intent is by_alias
+    assert by_intent.capability == "Payments"
+
+
+def test_lookup_is_case_and_whitespace_insensitive(catalog):
+    assert catalog.lookup("  SEND   MONEY ") is catalog.lookup("send money")
+
+
+def test_lookup_unknown_text_returns_none(catalog):
+    assert catalog.lookup("teleport me to mars") is None
+
+
+def test_by_intent_resolves_canonical_token_only(catalog):
+    assert catalog.by_intent("pay") is not None
+    # an alias is not a canonical intent token
+    assert catalog.by_intent("send money") is None
+    assert catalog.by_intent("nope") is None
+
+
+def test_definitions_exposes_all_rows(catalog):
+    assert len(catalog.definitions) == len(INTENT_MAP["intents"])
+
+
+def test_missing_registry_entry_raises_at_load():
+    bad_map = {
+        "intents": [
+            {
+                "intent": "ghost",
+                "aliases": [],
+                "capability": "X",
+                "process_ids": ["no-such-process"],
+            }
+        ]
+    }
+    with pytest.raises(UnresolvableProcessError, match="no-such-process"):
+        IntentCatalog.from_data(bad_map, REGISTRY)
+
+
+def test_from_files_round_trips(map_files):
+    map_path, reg_path = map_files
+    catalog = IntentCatalog.from_files(map_path, reg_path)
+    assert catalog.lookup("exchange").process_refs == (ProcessRef("fx-exchange", "1.0.0"),)
+
+
+def test_process_ref_rejects_empty_fields():
+    with pytest.raises(ValueError, match="process_id"):
+        ProcessRef("", "1.0.0")
+    with pytest.raises(ValueError, match="version"):
+        ProcessRef("x", "")
+
+
+def test_process_ref_as_dict_matches_schema_shape():
+    assert ProcessRef("fx-exchange", "1.0.0").as_dict() == {
+        "process_id": "fx-exchange",
+        "version": "1.0.0",
+    }

--- a/tests/test_intent_layer/test_classifier.py
+++ b/tests/test_intent_layer/test_classifier.py
@@ -1,0 +1,105 @@
+"""
+tests/test_intent_layer/test_classifier.py — IntentClassifier: deterministic + LLM + UNRESOLVED
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.intent_layer.classifier import IntentClassifier
+from services.intent_layer.models import (
+    ConfidenceBand,
+    IntentStatus,
+    MatchSource,
+    ProcessRef,
+)
+from services.intent_layer.ports import NullLLMClassifier
+
+from .conftest import NINE_CAPABILITIES, StubLLM
+
+
+@pytest.mark.parametrize(("intent", "capability", "process_id"), NINE_CAPABILITIES)
+def test_deterministic_exact_match_all_nine_capabilities(catalog, intent, capability, process_id):
+    resolved = IntentClassifier(catalog).classify(intent)
+    assert resolved.status is IntentStatus.RESOLVED
+    assert resolved.match_source is MatchSource.EXACT
+    assert resolved.capability == capability
+    assert resolved.process_refs == (ProcessRef(process_id, "1.0.0"),)
+    assert resolved.confidence == 1.0
+    assert resolved.band is ConfidenceBand.AUTO
+
+
+def test_alias_match_resolves_same_process(catalog):
+    resolved = IntentClassifier(catalog).classify("send money")
+    assert resolved.status is IntentStatus.RESOLVED
+    assert resolved.match_source is MatchSource.ALIAS
+    assert resolved.matched_intent == "pay"
+    assert resolved.process_refs == (ProcessRef("payment-processing-process", "1.0.0"),)
+
+
+def test_unresolved_intent_is_governance_event(catalog):
+    resolved = IntentClassifier(catalog).classify("buy me a coffee on the moon")
+    assert resolved.status is IntentStatus.UNRESOLVED
+    assert resolved.match_source is MatchSource.NONE
+    assert resolved.process_refs == ()
+    assert resolved.capability is None
+    assert resolved.confidence == 0.0
+    assert resolved.band is ConfidenceBand.BLOCK
+
+
+def test_null_llm_default_means_no_fuzzy_match_even_when_enabled(catalog):
+    # NullLLMClassifier is the default port → fuzzy abstains → UNRESOLVED, no live LLM.
+    classifier = IntentClassifier(catalog, enabled=True)
+    assert isinstance(classifier._llm, NullLLMClassifier)
+    assert (
+        classifier.classify("i would like to move some funds around").status
+        is IntentStatus.UNRESOLVED
+    )
+
+
+def test_llm_fallback_consulted_only_when_enabled(catalog):
+    stub = StubLLM(text="zap my money over", intent="pay", confidence=0.82)
+
+    disabled = IntentClassifier(catalog, enabled=False, llm=stub)
+    assert disabled.classify("zap my money over").status is IntentStatus.UNRESOLVED
+    assert stub.calls == []  # gated: not even consulted when disabled
+
+    enabled = IntentClassifier(catalog, enabled=True, llm=stub)
+    resolved = enabled.classify("zap my money over")
+    assert stub.calls == ["zap my money over"]
+    assert resolved.status is IntentStatus.RESOLVED
+    assert resolved.match_source is MatchSource.LLM
+    assert resolved.matched_intent == "pay"
+    assert resolved.confidence == 0.82
+    assert resolved.band is ConfidenceBand.REVIEW
+
+
+def test_llm_proposing_unknown_intent_is_rejected_no_improvisation(catalog):
+    # LLM hallucinates a non-catalog token → must NOT resolve to any process_ref.
+    stub = StubLLM(text="do the thing", intent="hallucinated-intent", confidence=0.99)
+    resolved = IntentClassifier(catalog, enabled=True, llm=stub).classify("do the thing")
+    assert resolved.status is IntentStatus.UNRESOLVED
+
+
+def test_deterministic_wins_before_llm_is_consulted(catalog):
+    stub = StubLLM(text="pay", intent="exchange", confidence=0.99)
+    resolved = IntentClassifier(catalog, enabled=True, llm=stub).classify("pay")
+    assert resolved.match_source is MatchSource.EXACT
+    assert resolved.matched_intent == "pay"
+    assert stub.calls == []  # deterministic short-circuits the fallback
+
+
+def test_correlation_id_is_stable_when_supplied_else_generated(catalog):
+    classifier = IntentClassifier(catalog)
+    assert classifier.classify("pay", correlation_id="corr-123").correlation_id == "corr-123"
+    a = classifier.classify("pay").correlation_id
+    b = classifier.classify("pay").correlation_id
+    assert a and b and a != b  # auto-generated ids are unique per call
+
+
+def test_confidence_band_boundaries():
+    assert ConfidenceBand.of(0.91) is ConfidenceBand.AUTO
+    assert ConfidenceBand.of(0.90) is ConfidenceBand.REVIEW
+    assert ConfidenceBand.of(0.70) is ConfidenceBand.REVIEW
+    assert ConfidenceBand.of(0.69) is ConfidenceBand.BLOCK

--- a/tests/test_intent_layer/test_config.py
+++ b/tests/test_intent_layer/test_config.py
@@ -1,0 +1,41 @@
+"""
+tests/test_intent_layer/test_config.py — INTENT_LAYER_ENABLED flag (distinct from ADR-021)
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.intent_layer.config import (
+    INTENT_LAYER_ENABLED_ENV,
+    intent_layer_enabled,
+)
+
+
+def test_flag_name_is_distinct_from_adr021():
+    # MUST NOT collide with ADR-021's AGENT_ROUTING_ENABLED.
+    assert INTENT_LAYER_ENABLED_ENV == "INTENT_LAYER_ENABLED"
+    assert INTENT_LAYER_ENABLED_ENV != "AGENT_ROUTING_ENABLED"
+
+
+def test_default_is_false_when_unset():
+    assert intent_layer_enabled(env={}) is False
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "  True  ", "tRuE"])
+def test_truthy_values(value):
+    assert intent_layer_enabled(env={INTENT_LAYER_ENABLED_ENV: value}) is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "", "yes", "1"])
+def test_only_literal_true_enables(value):
+    # Conservative: anything that is not "true" leaves the layer inert.
+    assert intent_layer_enabled(env={INTENT_LAYER_ENABLED_ENV: value}) is False
+
+
+def test_reads_process_environ_by_default(monkeypatch):
+    monkeypatch.setenv(INTENT_LAYER_ENABLED_ENV, "true")
+    assert intent_layer_enabled() is True
+    monkeypatch.delenv(INTENT_LAYER_ENABLED_ENV, raising=False)
+    assert intent_layer_enabled() is False

--- a/tests/test_intent_layer/test_router.py
+++ b/tests/test_intent_layer/test_router.py
@@ -1,0 +1,85 @@
+"""
+tests/test_intent_layer/test_router.py — IntentRouter: gating, governance, dispatch
+IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
+"""
+
+from __future__ import annotations
+
+from services.intent_layer.classifier import IntentClassifier
+from services.intent_layer.models import (
+    DispositionKind,
+    IntentStatus,
+    MatchSource,
+    ProcessRef,
+    ResolvedIntent,
+)
+from services.intent_layer.router import IntentRouter
+
+
+def _resolve(catalog, text, *, enabled=True):
+    return IntentClassifier(catalog, enabled=enabled).classify(text)
+
+
+def test_disabled_router_does_not_dispatch(catalog, spy_dispatcher):
+    router = IntentRouter(spy_dispatcher, enabled=False)
+    disposition = router.route(_resolve(catalog, "pay"))
+    assert disposition.kind is DispositionKind.NOT_ENABLED
+    assert spy_dispatcher.calls == []  # no dispatch pre-activation
+
+
+def test_unresolved_intent_routes_to_governance_event(catalog, spy_dispatcher):
+    router = IntentRouter(spy_dispatcher, enabled=True)
+    unresolved = _resolve(catalog, "teleport my cat")
+    assert unresolved.status is IntentStatus.UNRESOLVED
+    disposition = router.route(unresolved)
+    assert disposition.kind is DispositionKind.GOVERNANCE_EVENT
+    assert spy_dispatcher.calls == []  # never improvised into a dispatch
+
+
+def test_resolved_intent_dispatches_with_process_ref(catalog, spy_dispatcher):
+    router = IntentRouter(spy_dispatcher, enabled=True)
+    resolved = _resolve(catalog, "exchange")
+    disposition = router.route(resolved)
+
+    assert disposition.kind is DispositionKind.DISPATCHED
+    assert disposition.capability == "FX / Exchange"
+    assert len(spy_dispatcher.calls) == 1
+    request = spy_dispatcher.calls[0]
+    # the L2 agent's §D2 process_ref gate is satisfied by the hand-off payload
+    assert request.process_refs == (ProcessRef("fx-exchange", "1.0.0"),)
+    assert request.process_ref == ProcessRef("fx-exchange", "1.0.0")
+    assert request.capability == "FX / Exchange"
+    assert request.correlation_id == resolved.correlation_id
+    assert disposition.receipt.accepted is True
+    assert disposition.receipt.agent == "agent:FX / Exchange"
+
+
+def test_correlation_id_threads_through_disposition(catalog, spy_dispatcher):
+    router = IntentRouter(spy_dispatcher, enabled=True)
+    resolved = _resolve(catalog, "pay")
+    disposition = router.route(resolved)
+    assert disposition.correlation_id == resolved.correlation_id
+    assert spy_dispatcher.calls[0].resolved_intent is resolved
+
+
+def test_disabled_router_short_circuits_before_governance_check(catalog, spy_dispatcher):
+    # Even an UNRESOLVED intent yields NOT_ENABLED (flag is the outermost guard).
+    router = IntentRouter(spy_dispatcher, enabled=False)
+    unresolved = ResolvedIntent(
+        raw_text="x",
+        correlation_id="c1",
+        status=IntentStatus.UNRESOLVED,
+        confidence=0.0,
+        match_source=MatchSource.NONE,
+    )
+    assert router.route(unresolved).kind is DispositionKind.NOT_ENABLED
+
+
+def test_dispatch_receipt_can_signal_rejection(catalog):
+    from .conftest import SpyDispatcher
+
+    rejecting = SpyDispatcher(accepted=False)
+    router = IntentRouter(rejecting, enabled=True)
+    disposition = router.route(_resolve(catalog, "pay"))
+    assert disposition.kind is DispositionKind.DISPATCHED
+    assert disposition.receipt.accepted is False


### PR DESCRIPTION
## S5.1 — ADR-049 L1 Intent Layer (classifier + router)

First of S5. Builds the **client-facing L1 Intent Layer** (ADR-049) as a new, self-contained module. **Layer distinction is respected:** this is NOT `services/agent_routing` (ADR-021 internal compliance/AML/KYC tier-worker router) — that package and the 9 client agents are **untouched**.

### Placement
`services/intent_layer/` in **banxe-emi-stack** (hosts most client-facing agents). The layer is cross-repo (dispatches to agents in payment-core **and** emi-stack) and depends on **neither** agent repo's internals — all external deps are injected via Protocol ports.

### API
- `IntentClassifier.classify(intent_text) -> ResolvedIntent{raw_text, matched_intent, capability, process_refs:[{process_id,version}], confidence, status, correlation_id}`
- `IntentRouter.route(ResolvedIntent) -> Disposition{DISPATCHED | NOT_ENABLED | GOVERNANCE_EVENT}`

### Behaviour
- **Deterministic first:** exact/alias match against `intent-process-map.yaml`, versions resolved from `processes-registry.json` (confidence 1.0 / AUTO band). Every `process_id` validated against the registry at load (loud failure, never silent dispatch).
- **LLM fuzzy fallback is gated** behind `INTENT_LAYER_ENABLED` + an injected `LLMClassifierPort` (default `NullLLMClassifier`, so the whole layer is unit-testable with **no live LLM**). LLM proposals are re-validated against the catalog — no hallucinated `process_ref` (ADR-048 D3.3).
- **Unresolved intent → governance event** (HITL / process-gap), never improvised.
- **`INTENT_LAYER_ENABLED` is DISTINCT from ADR-021's `AGENT_ROUTING_ENABLED`.** Off ⇒ `route()` returns `NOT_ENABLED` (no dispatch) — safe pre-activation.
- Dispatch hands the resolved `process_ref` to the L2 agent via `AgentDispatchPort`, satisfying the agent's §D2 `process_ref` gate; one `correlation_id` threads the chain.

### Tests / quality
- 46 unit tests, **100% module coverage**; all deps injected (no network, no live LLM).
- `ruff check` + `ruff format --check` clean; `bandit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intent classification system that deterministically resolves user intents to processes and capabilities.
  * Supports exact intent matching, alias resolution, and optional fuzzy/LLM-based fallback.
  * Feature-gated via environment variable with routing to agent dispatch.
  * Includes confidence scoring and governance event handling for unresolved intents.

* **Tests**
  * Added comprehensive test coverage for intent catalog, classifier, router, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->