### PR TITLE
feat(producers): compliance/confidence/cost PRODUCERS — close audit gap #6 [S5.2]

### DIFF
--- a/services/producers/WIRING.md
+++ b/services/producers/WIRING.md
@@ -1,0 +1,90 @@
+# Producers wiring (S5.2) — closing audit gap #6
+
+The 9 L2 client-facing agents accept three governance values as **injected,
+keyword-only inputs**:
+
+| agent input         | type               | how the agent receives it                |
+|---------------------|--------------------|------------------------------------------|
+| `compliance_result` | `ComplianceResult` | keyword param, **defaults to `PASS`**    |
+| `confidence_score`  | `float`            | carried on the action `intent`           |
+| `request_cost`      | `RequestCost`      | carried on the action `intent`           |
+
+**Audit gap #6:** nothing *produced* `compliance_result` — the default-`PASS`
+meant every action passed compliance silently. This package is the **producer
+side of that seam**. The agents are **not edited**; the composition root computes
+the three values and feeds them into the params/intent that already exist.
+
+## What produces what
+
+- **`ComplianceProducer`** → a real `ComplianceResult` (`PASS`/`FAIL`/`ESCALATE`/`N/A`),
+  by orchestrating the existing L3 through three **injected Protocol ports**
+  (`AMLCheckPort`, `SanctionsCheckPort`, `FraudCheckPort`). Aggregation: any
+  `FAIL` → `FAIL`; else any `ESCALATE` → `ESCALATE`; else all-`N/A` → `N/A`; else
+  `PASS`. This **replaces** the default-`PASS`.
+- **`ConfidenceScorer`** → a deterministic `confidence_score ∈ [0,1]` from
+  `match_source` / ambiguity / risk class (maps onto the ADR-049 §D4 bands).
+- **`CostEstimator`** → a `RequestCost` (tokens + **Decimal** amount, no float)
+  with an ADR-047 cost-cap awareness flag (`NONE`/`WARN`/`BREACH`).
+
+## The L3 is wrapped, never edited
+
+`services/producers/adapters.py` holds the **wired composition**: each adapter
+delegates to an existing L3 service via a minimal *structural* Protocol (no
+concrete L3 import, no L3 edits) and translates the L3 result into an opaque
+`CheckOutcome`:
+
+| adapter                 | wraps (L3)                                   | maps                                      |
+|-------------------------|----------------------------------------------|-------------------------------------------|
+| `AMLCheckAdapter`       | `services/aml` `TxMonitorService`            | `sanctions_block`→FAIL; any HITL flag→ESCALATE |
+| `SanctionsCheckAdapter` | `services/sanctions_screening` `ScreeningEngine` | `CONFIRMED_MATCH`→FAIL; `POSSIBLE`/`ERROR`→ESCALATE |
+| `FraudCheckAdapter`     | `services/fraud` `FraudScoringPort`          | `block`→FAIL; hold/APP-scam/HIGH-risk→ESCALATE |
+
+**R-SEC:** the producer core carries only an opaque `subject_ref`; the sanctions
+identity (name/nationality — PII) is resolved L3-side inside the adapter via
+`SanctionsIdentityPort`, owned by the composition root. Outputs carry the L3
+report/decision id + non-PII policy codes only — never a name, account, or raw
+L3 reason string.
+
+## Composition-root wiring (no agent edits)
+
+```python
+from decimal import Decimal
+
+from services.producers import (
+    ComplianceProducer, ConfidenceScorer, CostEstimator, ProducerBundle,
+    AMLCheckAdapter, SanctionsCheckAdapter, FraudCheckAdapter, ComplianceCheckRequest,
+)
+from services.producers.confidence_scorer import ScoringSignals
+from services.producers.ports import DEFAULT_COST_CAP
+
+# Build the bundle once, from the live L3 services + the PII identity resolver.
+bundle = ProducerBundle(
+    compliance=ComplianceProducer(
+        aml=AMLCheckAdapter(tx_monitor),                       # live services/aml
+        sanctions=SanctionsCheckAdapter(screening_engine,      # live services/sanctions_screening
+                                        identity=identity_resolver),
+        fraud=FraudCheckAdapter(fraud_scorer),                 # live services/fraud
+    ),
+    confidence=ConfidenceScorer(),
+    cost=CostEstimator(cost_cap=DEFAULT_COST_CAP, source=gateway_accounting),
+)
+
+# Per dispatch (after L1 router resolves the intent, before invoking the L2 agent):
+outputs = bundle.produce(
+    check_request=ComplianceCheckRequest(
+        action=resolved.matched_intent, correlation_id=resolved.correlation_id,
+        subject_ref=subject_ref, amount=amount,
+    ),
+    signals=ScoringSignals.from_resolved_intent(resolved, risk_class="STANDARD"),
+    est_tokens=est_tokens,
+)
+
+# outputs map 1:1 onto the EXISTING agent seam — no agent code changes:
+await agent.do_action(
+    intent,  # carries outputs.confidence_score + outputs.request_cost
+    compliance_result=outputs.compliance_result,  # ← REPLACES the default-PASS
+)
+```
+
+`ProducerBundle.null()` is the safe pre-activation default (Null ports → `PASS`,
+static cost source) for environments where the live L3 is not yet wired.

--- a/services/producers/__init__.py
+++ b/services/producers/__init__.py
@@ -1,0 +1,58 @@
+"""
+services/producers — compliance / confidence / cost PRODUCERS (S5.2).
+
+Closes audit gap #6: the L2 client-facing agents accept ``compliance_result``
+(default :data:`ComplianceResult.PASS`), ``confidence_score`` and
+``request_cost`` as INJECTED inputs, but nothing PRODUCED them — a silent
+default-PASS is an audit risk. This package is the producer side of that seam:
+
+  • :class:`ComplianceProducer` — real PASS/FAIL/ESCALATE/N-A verdict, by
+    orchestrating the existing L3 (AML / sanctions / fraud) via INJECTED ports.
+  • :class:`ConfidenceScorer`   — deterministic confidence_score ∈ [0,1].
+  • :class:`CostEstimator`      — RequestCost (tokens + Decimal) with cap-awareness.
+  • :class:`ProducerBundle`     — the composition-root entry point; its outputs
+    populate the agents' existing keyword params (no agent edits — see WIRING.md).
+
+The L3 services are wrapped via ``services/producers/adapters.py`` (the WIRED
+composition); the producer core depends only on Protocol ports and is unit-
+testable with Null defaults (no live L3, no network).
+"""
+
+from __future__ import annotations
+
+from services.producers.adapters import (
+    AMLCheckAdapter,
+    FraudCheckAdapter,
+    SanctionsCheckAdapter,
+)
+from services.producers.bundle import ProducerBundle, ProducerOutputs
+from services.producers.compliance_producer import (
+    ComplianceProducer,
+    ComplianceVerdict,
+    aggregate,
+)
+from services.producers.confidence_scorer import ConfidenceScorer, ScoringSignals
+from services.producers.cost_estimator import CostEstimate, CostEstimator
+from services.producers.ports import (
+    CheckOutcome,
+    ComplianceCheckRequest,
+    SanctionsIdentity,
+)
+
+__all__ = [
+    "AMLCheckAdapter",
+    "CheckOutcome",
+    "ComplianceCheckRequest",
+    "ComplianceProducer",
+    "ComplianceVerdict",
+    "ConfidenceScorer",
+    "CostEstimate",
+    "CostEstimator",
+    "FraudCheckAdapter",
+    "ProducerBundle",
+    "ProducerOutputs",
+    "SanctionsCheckAdapter",
+    "SanctionsIdentity",
+    "ScoringSignals",
+    "aggregate",
+]

--- a/services/producers/adapters.py
+++ b/services/producers/adapters.py
@@ -1,0 +1,204 @@
+"""
+services/producers/adapters.py — WIRED L3 adapters for the compliance producer.
+
+These adapters are the *only* place the producers touch the real L3. Each
+implements one of the ports from ``services/producers/ports.py`` by delegating to
+an existing L3 service through a minimal structural Protocol (``*_Like``) — so no
+concrete L3 class is imported and NO L3 file is edited. They translate an L3
+result into an opaque :class:`CheckOutcome` (verdict + ref + non-PII codes).
+
+Mapping rules (ADR-046):
+  • AML       — sanctions_block → FAIL; any HITL flag (SAR/EDD/velocity/
+                structuring) → ESCALATE; else PASS.
+  • Sanctions — CONFIRMED_MATCH → FAIL; POSSIBLE_MATCH → ESCALATE;
+                ERROR → ESCALATE; CLEAR → PASS; no resolvable identity → N/A.
+  • Fraud     — block → FAIL; hold_for_review / APP-scam / HIGH|CRITICAL risk →
+                ESCALATE; else PASS.
+
+R-SEC: outputs carry the L3 report/decision id + policy codes only — never the
+matched name, account, or any raw L3 reason string.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Protocol
+
+from services.agents._lineage import ComplianceResult
+from services.aml.tx_monitor import MonitorResult, TxMonitorRequest
+from services.fraud.fraud_port import FraudScoringRequest, FraudScoringResult
+from services.producers.ports import (
+    CheckOutcome,
+    ComplianceCheckRequest,
+    NullSanctionsIdentity,
+    SanctionsIdentityPort,
+)
+from services.sanctions_screening.models import ScreeningReport, ScreeningResult
+
+# ── Minimal structural views of the L3 services (no concrete import) ──────────
+
+
+class _TxMonitorLike(Protocol):
+    def evaluate(self, req: TxMonitorRequest) -> MonitorResult: ...
+
+
+class _ScreeningEngineLike(Protocol):
+    def screen_entity(
+        self,
+        entity_name: str,
+        entity_type: object,
+        nationality: str,
+        date_of_birth: str | None = ...,
+        requested_by: str = ...,
+    ) -> ScreeningReport: ...
+
+
+class _FraudScorerLike(Protocol):
+    def score(self, request: FraudScoringRequest) -> FraudScoringResult: ...
+
+
+# ── AML adapter (wraps services/aml tx_monitor + thresholds) ─────────────────
+
+
+class AMLCheckAdapter:
+    """Wrap an L3 ``TxMonitorService`` as an :class:`AMLCheckPort`."""
+
+    def __init__(self, tx_monitor: _TxMonitorLike) -> None:
+        self._monitor = tx_monitor
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome:
+        result = self._monitor.evaluate(
+            TxMonitorRequest(
+                transaction_id=request.correlation_id,
+                customer_id=request.subject_ref,
+                entity_type=request.entity_type,
+                amount=request.amount,
+                currency=request.currency,
+                is_pep=request.is_pep,
+                is_sanctions_hit=request.is_sanctions_hit,
+                is_fx=request.is_fx,
+            )
+        )
+        return CheckOutcome(
+            result=_map_aml(result),
+            ref=result.transaction_id,
+            reason_codes=_aml_codes(result),
+        )
+
+
+def _map_aml(result: MonitorResult) -> ComplianceResult:
+    if result.sanctions_block:
+        return ComplianceResult.FAIL
+    if result.requires_hitl:
+        return ComplianceResult.ESCALATE
+    return ComplianceResult.PASS
+
+
+def _aml_codes(result: MonitorResult) -> tuple[str, ...]:
+    flags = (
+        ("SANCTIONS_BLOCK", result.sanctions_block),
+        ("SAR_REQUIRED", result.sar_required),
+        ("EDD_REQUIRED", result.edd_required),
+        ("VELOCITY_DAILY", result.velocity_daily_breach),
+        ("VELOCITY_MONTHLY", result.velocity_monthly_breach),
+        ("STRUCTURING", result.structuring_signal),
+    )
+    return tuple(code for code, on in flags if on)
+
+
+# ── Sanctions adapter (wraps services/sanctions_screening) ───────────────────
+
+
+class SanctionsCheckAdapter:
+    """Wrap an L3 ``ScreeningEngine`` as a :class:`SanctionsCheckPort`.
+
+    The screening identity (name/nationality — PII) is resolved L3-side via the
+    injected :class:`SanctionsIdentityPort`, so no PII flows through the producer
+    core. Without a resolvable identity the check returns N/A (cannot screen)."""
+
+    def __init__(
+        self,
+        engine: _ScreeningEngineLike,
+        *,
+        identity: SanctionsIdentityPort | None = None,
+    ) -> None:
+        self._engine = engine
+        self._identity: SanctionsIdentityPort = identity or NullSanctionsIdentity()
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome:
+        identity = self._identity.resolve(request.subject_ref)
+        if identity is None:
+            return CheckOutcome(result=ComplianceResult.NA, ref="sanctions:no-identity")
+        report = self._engine.screen_entity(
+            entity_name=identity.entity_name,
+            entity_type=identity.entity_type,
+            nationality=identity.nationality,
+        )
+        return CheckOutcome(
+            result=_map_sanctions(report.result),
+            ref=report.report_id,
+            reason_codes=tuple(sorted({hit.list_source for hit in report.hits})),
+        )
+
+
+def _map_sanctions(result: ScreeningResult) -> ComplianceResult:
+    if result is ScreeningResult.CONFIRMED_MATCH:
+        return ComplianceResult.FAIL
+    if result in (ScreeningResult.POSSIBLE_MATCH, ScreeningResult.ERROR):
+        return ComplianceResult.ESCALATE
+    return ComplianceResult.PASS
+
+
+# ── Fraud adapter (wraps services/fraud fraud_port) ──────────────────────────
+
+
+class FraudCheckAdapter:
+    """Wrap an L3 ``FraudScoringPort`` as a :class:`FraudCheckPort`."""
+
+    def __init__(
+        self,
+        scorer: _FraudScorerLike,
+        *,
+        destination_country: str = "GB",
+        payment_rail: str = "FPS",
+    ) -> None:
+        self._scorer = scorer
+        self._country = destination_country
+        self._rail = payment_rail
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome:
+        result = self._scorer.score(
+            FraudScoringRequest(
+                transaction_id=request.correlation_id,
+                customer_id=request.subject_ref,
+                amount=request.amount or Decimal("0"),
+                currency=request.currency,
+                destination_account="",
+                destination_sort_code="",
+                destination_country=self._country,
+                payment_rail=self._rail,
+                entity_type=request.entity_type,
+            )
+        )
+        return CheckOutcome(
+            result=_map_fraud(result),
+            ref=result.transaction_id,
+            reason_codes=(f"RISK_{result.risk.value}",),
+        )
+
+
+def _map_fraud(result: FraudScoringResult) -> ComplianceResult:
+    if result.block:
+        return ComplianceResult.FAIL
+    if result.hold_for_review or result.app_scam_indicator.value != "NONE":
+        return ComplianceResult.ESCALATE
+    if result.risk.value in ("HIGH", "CRITICAL"):
+        return ComplianceResult.ESCALATE
+    return ComplianceResult.PASS
+
+
+__all__ = [
+    "AMLCheckAdapter",
+    "FraudCheckAdapter",
+    "SanctionsCheckAdapter",
+]

--- a/services/producers/bundle.py
+++ b/services/producers/bundle.py
@@ -1,0 +1,89 @@
+"""
+services/producers/bundle.py — ProducerBundle (S5.2).
+
+The single object the composition root uses to populate the three INJECTED agent
+inputs before invoking an L2 agent. It runs the compliance / confidence / cost
+producers and returns :class:`ProducerOutputs`, whose fields map 1:1 onto the
+agents' existing keyword params:
+
+    outputs = bundle.produce(...)
+    await agent.do_action(
+        intent,                                   # carries confidence_score + request_cost
+        compliance_result=outputs.compliance_result,   # ← REPLACES default-PASS
+    )
+
+NO agent is edited — the bundle only PRODUCES values that flow into the seam that
+already exists. ``ProducerBundle.null()`` is the safe pre-wiring default (all
+PASS); the WIRED composition builds it with real adapters (see ``adapters.py``
+and ``WIRING.md``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from services.agents._lineage import BudgetBreach, ComplianceResult, RequestCost
+from services.producers.compliance_producer import ComplianceProducer, ComplianceVerdict
+from services.producers.confidence_scorer import ConfidenceScorer, ScoringSignals
+from services.producers.cost_estimator import CostEstimator
+from services.producers.ports import DEFAULT_COST_CAP, ComplianceCheckRequest
+
+
+@dataclass(frozen=True)
+class ProducerOutputs:
+    """The three produced agent inputs + diagnostics (no PII)."""
+
+    compliance_result: ComplianceResult
+    confidence_score: float
+    request_cost: RequestCost
+    budget_breach: BudgetBreach
+    verdict: ComplianceVerdict
+
+
+class ProducerBundle:
+    """Bundles the three producers behind one ``produce(...)`` call."""
+
+    def __init__(
+        self,
+        *,
+        compliance: ComplianceProducer,
+        confidence: ConfidenceScorer,
+        cost: CostEstimator,
+    ) -> None:
+        self._compliance = compliance
+        self._confidence = confidence
+        self._cost = cost
+
+    def produce(
+        self,
+        *,
+        check_request: ComplianceCheckRequest,
+        signals: ScoringSignals,
+        est_tokens: int,
+        accounting_key: str | None = None,
+    ) -> ProducerOutputs:
+        """Run all three producers for one agent invocation."""
+        verdict = self._compliance.evaluate(check_request)
+        confidence = self._confidence.score(signals)
+        estimate = self._cost.estimate(
+            check_request.action, est_tokens=est_tokens, accounting_key=accounting_key
+        )
+        return ProducerOutputs(
+            compliance_result=verdict.result,
+            confidence_score=confidence,
+            request_cost=estimate.cost,
+            budget_breach=estimate.breach,
+            verdict=verdict,
+        )
+
+    @classmethod
+    def null(cls) -> ProducerBundle:
+        """Pre-wiring default: Null compliance ports (PASS) + static cost source."""
+        return cls(
+            compliance=ComplianceProducer(),
+            confidence=ConfidenceScorer(),
+            cost=CostEstimator(cost_cap=DEFAULT_COST_CAP),
+        )
+
+
+__all__ = ["ProducerBundle", "ProducerOutputs"]

--- a/services/producers/compliance_producer.py
+++ b/services/producers/compliance_producer.py
@@ -1,0 +1,99 @@
+"""
+services/producers/compliance_producer.py — ComplianceProducer (S5.2, ADR-046).
+
+Closes audit gap #6: the L2 agents accept ``compliance_result`` defaulting to
+:data:`ComplianceResult.PASS`; nothing produced a real verdict (silent
+default-PASS = audit risk). :class:`ComplianceProducer` PRODUCES the verdict by
+orchestrating the existing L3 through three INJECTED ports — an AML check
+(wraps services/aml), a sanctions check (wraps services/sanctions_screening) and
+a fraud check (wraps services/fraud). It NEVER imports or edits L3; the ports
+default to Null producers (PASS) so it is unit-testable without live L3.
+
+Aggregation (net verdict, ADR-046):
+  • any FAIL                       → FAIL    (hard block, e.g. sanctions confirmed)
+  • else any ESCALATE              → ESCALATE (e.g. AML SAR/EDD needing MLRO)
+  • else all checks N/A            → N/A     (nothing applicable)
+  • else                           → PASS
+
+R-SEC: the returned :class:`ComplianceVerdict` carries the net result + per-check
+opaque refs/codes only — never raw PII.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from services.agents._lineage import ComplianceResult
+from services.producers.ports import (
+    AMLCheckPort,
+    CheckOutcome,
+    ComplianceCheckRequest,
+    FraudCheckPort,
+    NullAMLCheck,
+    NullFraudCheck,
+    NullSanctionsCheck,
+    SanctionsCheckPort,
+)
+
+
+@dataclass(frozen=True)
+class ComplianceVerdict:
+    """Net compliance verdict + the per-check opaque outcomes (no PII).
+
+    ``result`` is the value the composition root passes into an agent's
+    ``compliance_result`` keyword param, REPLACING the default-PASS.
+    """
+
+    result: ComplianceResult
+    correlation_id: str
+    checks: tuple[CheckOutcome, ...]
+
+
+def aggregate(outcomes: tuple[CheckOutcome, ...]) -> ComplianceResult:
+    """Combine per-check outcomes into one net :class:`ComplianceResult`.
+
+    FAIL dominates ESCALATE dominates PASS; an all-N/A set stays N/A.
+    """
+    results = [o.result for o in outcomes]
+    if ComplianceResult.FAIL in results:
+        return ComplianceResult.FAIL
+    if ComplianceResult.ESCALATE in results:
+        return ComplianceResult.ESCALATE
+    if results and all(r is ComplianceResult.NA for r in results):
+        return ComplianceResult.NA
+    return ComplianceResult.PASS
+
+
+class ComplianceProducer:
+    """Produce a real :class:`ComplianceResult` by orchestrating injected L3 ports.
+
+    Defaults to Null ports (all PASS) so the core is testable without live L3;
+    the WIRED composition injects real adapters (``services/producers/adapters.py``).
+    """
+
+    def __init__(
+        self,
+        *,
+        aml: AMLCheckPort | None = None,
+        sanctions: SanctionsCheckPort | None = None,
+        fraud: FraudCheckPort | None = None,
+    ) -> None:
+        self._aml: AMLCheckPort = aml or NullAMLCheck()
+        self._sanctions: SanctionsCheckPort = sanctions or NullSanctionsCheck()
+        self._fraud: FraudCheckPort = fraud or NullFraudCheck()
+
+    def evaluate(self, request: ComplianceCheckRequest) -> ComplianceVerdict:
+        """Run all three checks and return the aggregated verdict."""
+        outcomes: tuple[CheckOutcome, ...] = (
+            self._sanctions.check(request),
+            self._aml.check(request),
+            self._fraud.check(request),
+        )
+        return ComplianceVerdict(
+            result=aggregate(outcomes),
+            correlation_id=request.correlation_id,
+            checks=outcomes,
+        )
+
+
+__all__ = ["ComplianceProducer", "ComplianceVerdict", "aggregate"]

--- a/services/producers/confidence_scorer.py
+++ b/services/producers/confidence_scorer.py
@@ -1,0 +1,81 @@
+"""
+services/producers/confidence_scorer.py — ConfidenceScorer (S5.2, ADR-049 §D4).
+
+Produces the ``confidence_score`` [0,1] the L2 agents accept, from DETERMINISTIC
+signals — no LLM, no I/O, no clock — so the same signals always yield the same
+score (auditable). Signals:
+  • match_source  — how L1 resolved the intent (EXACT/ALIAS high, LLM lower, NONE 0)
+  • resolved      — an UNRESOLVED intent scores 0 (governance event, never AUTO)
+  • ambiguity     — [0,1] competing-candidate pressure, subtracts confidence
+  • risk_class    — STANDARD/ELEVATED/HIGH, higher risk shaves confidence
+
+The score maps onto the existing ADR-049 §D4 :class:`ConfidenceBand` thresholds
+(>0.90 AUTO, 0.70–0.90 REVIEW, <0.70 BLOCK) — NO new scale is introduced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from services.intent_layer.models import ConfidenceBand, MatchSource
+
+# Deterministic base confidence per match source (auditable constants).
+_BASE: dict[MatchSource, float] = {
+    MatchSource.EXACT: 1.0,
+    MatchSource.ALIAS: 0.95,
+    MatchSource.LLM: 0.75,
+    MatchSource.NONE: 0.0,
+}
+
+# Risk-class confidence penalties (higher risk → lower autonomy).
+_RISK_PENALTY: dict[str, float] = {
+    "STANDARD": 0.0,
+    "ELEVATED": 0.05,
+    "HIGH": 0.15,
+}
+
+_AMBIGUITY_WEIGHT = 0.20
+
+
+@dataclass(frozen=True)
+class ScoringSignals:
+    """Deterministic inputs to the confidence score (no PII, no clock)."""
+
+    match_source: MatchSource
+    resolved: bool = True
+    ambiguity: float = 0.0  # [0,1]
+    risk_class: str = "STANDARD"  # STANDARD | ELEVATED | HIGH
+
+    @classmethod
+    def from_resolved_intent(
+        cls, resolved_intent: object, *, ambiguity: float = 0.0, risk_class: str = "STANDARD"
+    ) -> ScoringSignals:
+        """Build signals from an L1 ``ResolvedIntent`` (duck-typed: reads
+        ``match_source`` + ``is_resolved``) plus caller-supplied risk context."""
+        return cls(
+            match_source=resolved_intent.match_source,  # type: ignore[attr-defined]
+            resolved=bool(resolved_intent.is_resolved),  # type: ignore[attr-defined]
+            ambiguity=ambiguity,
+            risk_class=risk_class,
+        )
+
+
+class ConfidenceScorer:
+    """Deterministic producer of ``confidence_score`` ∈ [0,1]."""
+
+    def score(self, signals: ScoringSignals) -> float:
+        """Return the confidence score for the given signals (clamped to [0,1])."""
+        if not signals.resolved or signals.match_source is MatchSource.NONE:
+            return 0.0
+        base = _BASE[signals.match_source]
+        ambiguity = min(max(signals.ambiguity, 0.0), 1.0)
+        penalty = _RISK_PENALTY.get(signals.risk_class.upper(), 0.0)
+        raw = base - (ambiguity * _AMBIGUITY_WEIGHT) - penalty
+        return round(min(max(raw, 0.0), 1.0), 4)
+
+    def band(self, signals: ScoringSignals) -> ConfidenceBand:
+        """ADR-049 §D4 band for the produced score."""
+        return ConfidenceBand.of(self.score(signals))
+
+
+__all__ = ["ConfidenceScorer", "ScoringSignals"]

--- a/services/producers/cost_estimator.py
+++ b/services/producers/cost_estimator.py
@@ -1,0 +1,85 @@
+"""
+services/producers/cost_estimator.py — CostEstimator (S5.2, ADR-047 §D2).
+
+Produces the ``request_cost`` (:class:`RequestCost` = tokens + Decimal amount)
+the L2 agents accept, and a cap-awareness :class:`BudgetBreach` flag. Money is
+ALWAYS :class:`~decimal.Decimal` — never float (ADR-047 §D2 / house rule).
+
+Source of truth, in order:
+  1. live S1-gateway per-key accounting via the injected :class:`CostSourcePort`
+     (when ``accounting_key`` is given and the gateway has a figure);
+  2. otherwise a deterministic static estimate ``tokens × price_per_1k / 1000``.
+
+Cap-awareness compares the cost against an ADR-047 :class:`CostCap` in BOTH the
+token and monetary dimensions → NONE / WARN / BREACH.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from services.agents._lineage import BudgetBreach, CostCap, RequestCost
+from services.producers.ports import (
+    DEFAULT_PRICE_PER_1K_TOKENS,
+    CostSourcePort,
+    StaticCostSource,
+)
+
+_ONE_K = Decimal("1000")
+_CENTI_MICRO = Decimal("0.000001")  # 6dp monetary quantum
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    """Produced cost for one agent invocation + its cap-awareness flag."""
+
+    cost: RequestCost
+    breach: BudgetBreach
+
+
+class CostEstimator:
+    """Deterministic producer of :class:`RequestCost` with cost-cap awareness."""
+
+    def __init__(
+        self,
+        *,
+        cost_cap: CostCap,
+        price_per_1k_tokens: Decimal = DEFAULT_PRICE_PER_1K_TOKENS,
+        source: CostSourcePort | None = None,
+        warn_ratio: Decimal = Decimal("0.8"),
+    ) -> None:
+        self._cap = cost_cap
+        self._price = price_per_1k_tokens
+        self._source: CostSourcePort = source or StaticCostSource()
+        self._warn_ratio = warn_ratio
+
+    def estimate(
+        self, action: str, *, est_tokens: int, accounting_key: str | None = None
+    ) -> CostEstimate:
+        """Estimate cost for ``action``; prefer live S1 accounting when available."""
+        if est_tokens < 0:
+            raise ValueError("est_tokens must be non-negative")
+        cost = self._live_cost(accounting_key) or self._static_cost(est_tokens)
+        return CostEstimate(cost=cost, breach=self._breach(cost))
+
+    def _live_cost(self, accounting_key: str | None) -> RequestCost | None:
+        if accounting_key is None:
+            return None
+        return self._source.usage_for(accounting_key)
+
+    def _static_cost(self, est_tokens: int) -> RequestCost:
+        amount = (Decimal(est_tokens) / _ONE_K * self._price).quantize(_CENTI_MICRO)
+        return RequestCost(tokens=est_tokens, cost=amount)
+
+    def _breach(self, cost: RequestCost) -> BudgetBreach:
+        if cost.tokens > self._cap.max_request_tokens or cost.cost > self._cap.max_request_cost:
+            return BudgetBreach.BREACH
+        token_warn = Decimal(self._cap.max_request_tokens) * self._warn_ratio
+        cost_warn = self._cap.max_request_cost * self._warn_ratio
+        if Decimal(cost.tokens) >= token_warn or cost.cost >= cost_warn:
+            return BudgetBreach.WARN
+        return BudgetBreach.NONE
+
+
+__all__ = ["CostEstimate", "CostEstimator"]

--- a/services/producers/ports.py
+++ b/services/producers/ports.py
@@ -1,0 +1,200 @@
+"""
+services/producers/ports.py — injected seams + non-PII value objects for the
+compliance / confidence / cost PRODUCERS (S5.2, ADR-046 / ADR-047 / ADR-049).
+
+WHY THIS FILE EXISTS
+--------------------
+The 9 L2 client-facing agents accept ``compliance_result``, ``confidence_score``
+and ``request_cost`` as INJECTED keyword-only inputs, with
+``compliance_result`` defaulting to :data:`ComplianceResult.PASS` (audit gap #6:
+nothing PRODUCES the verdict — a silent default-PASS is an audit risk). This
+package is the producer side of that seam: the composition root computes the
+three values and passes them in, so the agents need NO edits.
+
+These producers WRAP the real L3 (services/aml, services/sanctions_screening,
+services/fraud) through the Protocol ports defined here — they never import the
+concrete L3 classes, so the core is unit-testable with the Null defaults below
+(no live L3, no network). The WIRED composition supplies real adapters
+(``services/producers/adapters.py``).
+
+R-SEC (R-SEC-NEW-01, ADR-021): every type that crosses this seam carries only
+opaque identifiers + risk-relevant scalars and verdict codes — NEVER a name, an
+account number, or any raw PII. PII stays L3-side; it is resolved into a check
+only inside an adapter, behind :class:`SanctionsIdentityPort`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Protocol, runtime_checkable
+
+from services.agents._lineage import (
+    BudgetBreach,
+    ComplianceResult,
+    CostCap,
+    RequestCost,
+)
+
+# ── Non-PII value objects crossing the producer seam ─────────────────────────
+
+
+@dataclass(frozen=True)
+class ComplianceCheckRequest:
+    """Normalised, NON-PII input for a compliance check.
+
+    Carries only an opaque subject handle plus risk-relevant scalars. The
+    ``subject_ref`` is a tokenised/opaque customer handle — never a name. The
+    sanctions identity (name/nationality) is resolved L3-side inside the adapter
+    via :class:`SanctionsIdentityPort`, never threaded through this object.
+    """
+
+    action: str  # the resolved intent / capability / action id
+    correlation_id: str
+    subject_ref: str  # opaque customer handle — NEVER a name / PII
+    amount: Decimal = Decimal("0")
+    currency: str = "GBP"
+    entity_type: str = "INDIVIDUAL"  # "INDIVIDUAL" | "COMPANY"
+    is_pep: bool = False
+    is_sanctions_hit: bool = False  # pre-resolved upstream flag (opaque)
+    is_fx: bool = False
+    risk_class: str = "STANDARD"  # STANDARD | ELEVATED | HIGH
+
+
+@dataclass(frozen=True)
+class CheckOutcome:
+    """One L3 check's verdict, reduced to a :class:`ComplianceResult` + opaque refs.
+
+    ``ref`` is an opaque L3 handle (report/decision id). ``reason_codes`` are
+    non-PII policy codes (e.g. ``SAR_REQUIRED``, ``SANCTIONS_CONFIRMED``) — never
+    raw L3 reason strings, which may embed amounts/identities (R-SEC).
+    """
+
+    result: ComplianceResult
+    ref: str = ""
+    reason_codes: tuple[str, ...] = ()
+
+
+# ── Compliance L3 check ports (wrapped by adapters, defaulted to Null) ────────
+
+
+@runtime_checkable
+class AMLCheckPort(Protocol):
+    """Wraps services/aml (tx_monitor + thresholds). Returns an opaque verdict."""
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome: ...
+
+
+@runtime_checkable
+class SanctionsCheckPort(Protocol):
+    """Wraps services/sanctions_screening. Returns an opaque verdict."""
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome: ...
+
+
+@runtime_checkable
+class FraudCheckPort(Protocol):
+    """Wraps services/fraud (fraud_port). Returns an opaque verdict."""
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome: ...
+
+
+@runtime_checkable
+class SanctionsIdentityPort(Protocol):
+    """PII boundary owned by the composition root: resolves an opaque
+    ``subject_ref`` to the screening identity needed by the L3 engine. Kept OUT
+    of :class:`ComplianceCheckRequest` so no raw PII ever flows through the
+    producer core (R-SEC)."""
+
+    def resolve(self, subject_ref: str) -> SanctionsIdentity | None: ...
+
+
+@dataclass(frozen=True)
+class SanctionsIdentity:
+    """Screening identity resolved L3-side only (held by the wiring layer)."""
+
+    entity_name: str
+    entity_type: str  # "individual" | "organisation" | "vessel"
+    nationality: str  # ISO-3166-1 alpha-2
+
+
+# ── Cost source port (S1 gateway per-key accounting, defaulted to static) ─────
+
+
+@runtime_checkable
+class CostSourcePort(Protocol):
+    """Live per-key usage from the S1 gateway accounting (ADR-047). Returns
+    ``None`` when no live accounting is available — the estimator then falls back
+    to a deterministic static estimate."""
+
+    def usage_for(self, accounting_key: str) -> RequestCost | None: ...
+
+
+# ── Null / static defaults — make the core testable without live L3 ──────────
+
+
+class NullAMLCheck:
+    """Default AML port: no live L3 → PASS. Replaced by a real adapter when wired."""
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome:
+        return CheckOutcome(result=ComplianceResult.PASS, ref="aml:null")
+
+
+class NullSanctionsCheck:
+    """Default sanctions port: no live L3 → PASS. Replaced when wired."""
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome:
+        return CheckOutcome(result=ComplianceResult.PASS, ref="sanctions:null")
+
+
+class NullFraudCheck:
+    """Default fraud port: no live L3 → PASS. Replaced when wired."""
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome:
+        return CheckOutcome(result=ComplianceResult.PASS, ref="fraud:null")
+
+
+class NullSanctionsIdentity:
+    """Default identity resolver: no PII map wired → cannot screen → ``None``."""
+
+    def resolve(self, subject_ref: str) -> SanctionsIdentity | None:
+        return None
+
+
+class StaticCostSource:
+    """Default cost source: no live S1 accounting → deterministic static estimate."""
+
+    def usage_for(self, accounting_key: str) -> RequestCost | None:
+        return None
+
+
+# Default cost cap used by ``ProducerBundle.null`` and as a safe fallback
+# (ADR-047 §D2 — token + Decimal, no float).
+DEFAULT_COST_CAP = CostCap(
+    max_request_tokens=8_000,
+    max_request_cost=Decimal("0.50"),
+    max_window_tokens=2_000_000,
+    max_window_cost=Decimal("100.00"),
+)
+
+# Default per-1k-token price for the static estimate (Decimal — never float).
+DEFAULT_PRICE_PER_1K_TOKENS = Decimal("0.015")
+
+__all__ = [
+    "DEFAULT_COST_CAP",
+    "DEFAULT_PRICE_PER_1K_TOKENS",
+    "AMLCheckPort",
+    "BudgetBreach",
+    "CheckOutcome",
+    "ComplianceCheckRequest",
+    "CostSourcePort",
+    "FraudCheckPort",
+    "NullAMLCheck",
+    "NullFraudCheck",
+    "NullSanctionsCheck",
+    "NullSanctionsIdentity",
+    "SanctionsCheckPort",
+    "SanctionsIdentity",
+    "SanctionsIdentityPort",
+    "StaticCostSource",
+]

--- a/tests/test_producers/conftest.py
+++ b/tests/test_producers/conftest.py
@@ -1,0 +1,44 @@
+"""Shared stub L3 ports for the producers tests — NO live L3, NO network."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from services.agents._lineage import ComplianceResult
+from services.producers.ports import (
+    CheckOutcome,
+    ComplianceCheckRequest,
+    SanctionsIdentity,
+)
+
+
+class StubCheck:
+    """A compliance check port that always returns a fixed result."""
+
+    def __init__(self, result: ComplianceResult, *, ref: str = "stub") -> None:
+        self._result = result
+        self._ref = ref
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome:
+        return CheckOutcome(result=self._result, ref=self._ref)
+
+
+class StaticIdentity:
+    """SanctionsIdentityPort returning a fixed identity for any subject_ref."""
+
+    def __init__(self, identity: SanctionsIdentity | None) -> None:
+        self._identity = identity
+
+    def resolve(self, subject_ref: str) -> SanctionsIdentity | None:
+        return self._identity
+
+
+def make_request(**overrides: object) -> ComplianceCheckRequest:
+    base: dict[str, object] = {
+        "action": "kyc_onboarding",
+        "correlation_id": "corr-001",
+        "subject_ref": "subj-opaque-001",
+        "amount": Decimal("100"),
+    }
+    base.update(overrides)
+    return ComplianceCheckRequest(**base)  # type: ignore[arg-type]

--- a/tests/test_producers/test_adapters.py
+++ b/tests/test_producers/test_adapters.py
@@ -1,0 +1,214 @@
+"""Adapter tests — the WIRED composition over the REAL L3 (no network).
+
+Drives genuine L3 hits to prove the producer replaces default-PASS with FAIL/
+ESCALATE: a real ScreeningEngine blocked-jurisdiction CONFIRMED_MATCH → FAIL,
+a real TxMonitorService SAR breach → ESCALATE, and a sanctions hard-block → FAIL.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from services.agents._lineage import ComplianceResult
+from services.aml.tx_monitor import TxMonitorService
+from services.fraud.fraud_port import (
+    AppScamIndicator,
+    FraudRisk,
+    FraudScoringRequest,
+    FraudScoringResult,
+)
+from services.producers.adapters import (
+    AMLCheckAdapter,
+    FraudCheckAdapter,
+    SanctionsCheckAdapter,
+)
+from services.producers.ports import SanctionsIdentity
+from services.sanctions_screening.models import (
+    ScreeningHit,
+    ScreeningReport,
+    ScreeningRequest,
+    ScreeningResult,
+)
+from services.sanctions_screening.screening_engine import ScreeningEngine
+from tests.test_producers.conftest import StaticIdentity, make_request
+
+# ── In-memory stores for the real ScreeningEngine ────────────────────────────
+
+
+class _MemScreeningStore:
+    def __init__(self) -> None:
+        self.requests: dict[str, ScreeningRequest] = {}
+        self.reports: dict[str, ScreeningReport] = {}
+
+    def save_request(self, req: ScreeningRequest) -> None:
+        self.requests[req.request_id] = req
+
+    def get_request(self, request_id: str) -> ScreeningRequest | None:
+        return self.requests.get(request_id)
+
+    def save_report(self, report: ScreeningReport) -> None:
+        self.reports[report.request_id] = report
+
+    def get_report(self, request_id: str) -> ScreeningReport | None:
+        return self.reports.get(request_id)
+
+
+class _MemListStore:
+    def __init__(self, entries: dict[object, list[dict]] | None = None) -> None:
+        self._entries = entries or {}
+
+    def get_list(self, source: object) -> None:
+        return None
+
+    def save_list(self, lst: object) -> None:  # pragma: no cover - unused
+        pass
+
+    def get_entries(self, source: object) -> list[dict]:
+        return self._entries.get(source, [])
+
+
+class _MemHitStore:
+    def __init__(self) -> None:
+        self.hits: list[ScreeningHit] = []
+
+    def append(self, hit: ScreeningHit) -> None:
+        self.hits.append(hit)
+
+    def list_by_request(self, request_id: str) -> list[ScreeningHit]:
+        return [h for h in self.hits if h.request_id == request_id]
+
+
+def _engine(entries: dict[object, list[dict]] | None = None) -> ScreeningEngine:
+    return ScreeningEngine(_MemScreeningStore(), _MemListStore(entries), _MemHitStore())
+
+
+class _StubFraudScorer:
+    def __init__(self, result: FraudScoringResult) -> None:
+        self._result = result
+
+    def score(self, request: FraudScoringRequest) -> FraudScoringResult:
+        return self._result
+
+    def health(self) -> bool:  # pragma: no cover - unused
+        return True
+
+
+def _fraud_result(**kw: object) -> FraudScoringResult:
+    base: dict[str, object] = {
+        "transaction_id": "corr-001",
+        "risk": FraudRisk.LOW,
+        "score": 10,
+        "app_scam_indicator": AppScamIndicator.NONE,
+        "block": False,
+        "hold_for_review": False,
+    }
+    base.update(kw)
+    return FraudScoringResult(**base)  # type: ignore[arg-type]
+
+
+# ── AML adapter over the real TxMonitorService ───────────────────────────────
+
+
+def test_aml_adapter_sar_breach_escalates() -> None:
+    # £60k individual ≥ £50k auto-SAR → sar_required → ESCALATE (real L3).
+    adapter = AMLCheckAdapter(TxMonitorService())
+    outcome = adapter.check(make_request(amount=Decimal("60000")))
+    assert outcome.result is ComplianceResult.ESCALATE
+    assert "SAR_REQUIRED" in outcome.reason_codes
+
+
+def test_aml_adapter_sanctions_hard_block_fails() -> None:
+    adapter = AMLCheckAdapter(TxMonitorService())
+    outcome = adapter.check(make_request(amount=Decimal("100"), is_sanctions_hit=True))
+    assert outcome.result is ComplianceResult.FAIL
+    assert "SANCTIONS_BLOCK" in outcome.reason_codes
+
+
+def test_aml_adapter_clean_passes() -> None:
+    adapter = AMLCheckAdapter(TxMonitorService())
+    outcome = adapter.check(make_request(amount=Decimal("100")))
+    assert outcome.result is ComplianceResult.PASS
+    assert outcome.reason_codes == ()
+
+
+# ── Sanctions adapter over the real ScreeningEngine ──────────────────────────
+
+
+def test_sanctions_adapter_blocked_jurisdiction_fails() -> None:
+    # Real engine: nationality RU is a blocked jurisdiction → CONFIRMED_MATCH → FAIL.
+    adapter = SanctionsCheckAdapter(
+        _engine(),
+        identity=StaticIdentity(SanctionsIdentity("Acme Ltd", "organisation", "RU")),
+    )
+    outcome = adapter.check(make_request())
+    assert outcome.result is ComplianceResult.FAIL
+
+
+def test_sanctions_adapter_clear_passes() -> None:
+    adapter = SanctionsCheckAdapter(
+        _engine(),
+        identity=StaticIdentity(SanctionsIdentity("Jane Smith", "individual", "GB")),
+    )
+    outcome = adapter.check(make_request())
+    assert outcome.result is ComplianceResult.PASS
+
+
+def test_sanctions_adapter_possible_match_escalates() -> None:
+    from services.sanctions_screening.models import ListSource
+
+    entries = {ListSource.OFSI: [{"id": "e1", "name": "Ahmad Kahn", "nationality": "GB"}]}
+    adapter = SanctionsCheckAdapter(
+        _engine(entries),
+        identity=StaticIdentity(SanctionsIdentity("Ahmed Khan", "individual", "GB")),
+    )
+    outcome = adapter.check(make_request())
+    # score 80 → 65 ≤ score < 85 → MEDIUM → POSSIBLE_MATCH → ESCALATE.
+    assert outcome.result is ComplianceResult.ESCALATE
+    assert "ofsi" in outcome.reason_codes
+
+
+def test_sanctions_adapter_no_identity_is_na() -> None:
+    # No PII map wired → cannot screen → N/A (never a silent PASS).
+    adapter = SanctionsCheckAdapter(_engine(), identity=StaticIdentity(None))
+    outcome = adapter.check(make_request())
+    assert outcome.result is ComplianceResult.NA
+
+
+def test_sanctions_adapter_error_escalates() -> None:
+    from services.producers.adapters import _map_sanctions
+
+    assert _map_sanctions(ScreeningResult.ERROR) is ComplianceResult.ESCALATE
+
+
+# ── Fraud adapter over a stubbed FraudScoringPort ────────────────────────────
+
+
+def test_fraud_adapter_block_fails() -> None:
+    adapter = FraudCheckAdapter(
+        _StubFraudScorer(_fraud_result(block=True, risk=FraudRisk.CRITICAL))
+    )
+    outcome = adapter.check(make_request())
+    assert outcome.result is ComplianceResult.FAIL
+    assert outcome.reason_codes == ("RISK_CRITICAL",)
+
+
+def test_fraud_adapter_hold_escalates() -> None:
+    adapter = FraudCheckAdapter(_StubFraudScorer(_fraud_result(hold_for_review=True)))
+    assert adapter.check(make_request()).result is ComplianceResult.ESCALATE
+
+
+def test_fraud_adapter_app_scam_escalates() -> None:
+    adapter = FraudCheckAdapter(
+        _StubFraudScorer(_fraud_result(app_scam_indicator=AppScamIndicator.ROMANCE_SCAM))
+    )
+    assert adapter.check(make_request()).result is ComplianceResult.ESCALATE
+
+
+def test_fraud_adapter_high_risk_escalates() -> None:
+    adapter = FraudCheckAdapter(_StubFraudScorer(_fraud_result(risk=FraudRisk.HIGH, score=75)))
+    assert adapter.check(make_request()).result is ComplianceResult.ESCALATE
+
+
+def test_fraud_adapter_low_risk_passes() -> None:
+    adapter = FraudCheckAdapter(_StubFraudScorer(_fraud_result()))
+    assert adapter.check(make_request(amount=Decimal("0"))).result is ComplianceResult.PASS

--- a/tests/test_producers/test_bundle.py
+++ b/tests/test_producers/test_bundle.py
@@ -1,0 +1,56 @@
+"""ProducerBundle — composition-root entry point producing the 3 agent inputs."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from services.agents._lineage import BudgetBreach, ComplianceResult, RequestCost
+from services.intent_layer.models import MatchSource
+from services.producers.bundle import ProducerBundle
+from services.producers.compliance_producer import ComplianceProducer
+from services.producers.confidence_scorer import ConfidenceScorer, ScoringSignals
+from services.producers.cost_estimator import CostEstimator
+from services.producers.ports import DEFAULT_COST_CAP
+from tests.test_producers.conftest import StubCheck, make_request
+
+
+def test_null_bundle_produces_pass_and_cost() -> None:
+    bundle = ProducerBundle.null()
+    out = bundle.produce(
+        check_request=make_request(),
+        signals=ScoringSignals(match_source=MatchSource.EXACT),
+        est_tokens=1000,
+    )
+    assert out.compliance_result is ComplianceResult.PASS
+    assert out.confidence_score == 1.0
+    assert isinstance(out.request_cost, RequestCost)
+    assert out.budget_breach is BudgetBreach.NONE
+    assert out.verdict.result is ComplianceResult.PASS
+
+
+def test_wired_bundle_propagates_fail() -> None:
+    # A wired bundle with a FAIL sanctions port yields FAIL into the agent param.
+    bundle = ProducerBundle(
+        compliance=ComplianceProducer(sanctions=StubCheck(ComplianceResult.FAIL)),
+        confidence=ConfidenceScorer(),
+        cost=CostEstimator(cost_cap=DEFAULT_COST_CAP),
+    )
+    out = bundle.produce(
+        check_request=make_request(amount=Decimal("250000")),
+        signals=ScoringSignals(match_source=MatchSource.LLM, risk_class="HIGH"),
+        est_tokens=500,
+    )
+    assert out.compliance_result is ComplianceResult.FAIL
+    assert out.confidence_score == 0.60
+    assert out.request_cost.tokens == 500
+
+
+def test_bundle_passes_accounting_key_through() -> None:
+    bundle = ProducerBundle.null()
+    out = bundle.produce(
+        check_request=make_request(),
+        signals=ScoringSignals(match_source=MatchSource.EXACT),
+        est_tokens=100,
+        accounting_key="tenant-1",
+    )
+    assert out.request_cost.tokens == 100

--- a/tests/test_producers/test_compliance_producer.py
+++ b/tests/test_producers/test_compliance_producer.py
@@ -1,0 +1,80 @@
+"""ComplianceProducer aggregation — the audit gap #6 closure proof.
+
+Covers FAIL/ESCALATE/PASS/N-A combinations with injected stub L3 ports, and
+proves a real verdict REPLACES the default-PASS.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.agents._lineage import ComplianceResult
+from services.producers.compliance_producer import (
+    ComplianceProducer,
+    aggregate,
+)
+from services.producers.ports import CheckOutcome
+from tests.test_producers.conftest import StubCheck, make_request
+
+R = ComplianceResult
+
+
+@pytest.mark.parametrize(
+    ("sanctions", "aml", "fraud", "expected"),
+    [
+        (R.PASS, R.PASS, R.PASS, R.PASS),
+        (R.FAIL, R.PASS, R.PASS, R.FAIL),  # sanctions confirmed → FAIL
+        (R.PASS, R.ESCALATE, R.PASS, R.ESCALATE),  # AML SAR → ESCALATE
+        (R.PASS, R.PASS, R.ESCALATE, R.ESCALATE),  # fraud hold → ESCALATE
+        (R.FAIL, R.ESCALATE, R.PASS, R.FAIL),  # FAIL dominates ESCALATE
+        (R.ESCALATE, R.ESCALATE, R.ESCALATE, R.ESCALATE),
+        (R.NA, R.NA, R.NA, R.NA),  # nothing applicable
+        (R.NA, R.PASS, R.NA, R.PASS),  # one applicable PASS → PASS
+        (R.NA, R.ESCALATE, R.NA, R.ESCALATE),
+        (R.NA, R.FAIL, R.NA, R.FAIL),
+    ],
+)
+def test_aggregation_combinations(
+    sanctions: ComplianceResult,
+    aml: ComplianceResult,
+    fraud: ComplianceResult,
+    expected: ComplianceResult,
+) -> None:
+    producer = ComplianceProducer(
+        sanctions=StubCheck(sanctions),
+        aml=StubCheck(aml),
+        fraud=StubCheck(fraud),
+    )
+    verdict = producer.evaluate(make_request())
+    assert verdict.result is expected
+    assert verdict.correlation_id == "corr-001"
+    assert len(verdict.checks) == 3
+
+
+def test_aggregate_empty_is_pass() -> None:
+    # Defensive: an empty outcome set is not an all-N/A set → PASS.
+    assert aggregate(()) is ComplianceResult.PASS
+
+
+def test_default_ports_pass_but_are_explicit_producers() -> None:
+    # The Null default still yields PASS, but now via an explicit producer path.
+    verdict = ComplianceProducer().evaluate(make_request())
+    assert verdict.result is ComplianceResult.PASS
+
+
+def test_sanctions_hit_is_not_default_pass() -> None:
+    # AUDIT PROOF: a sanctions hit yields FAIL, NOT the default-PASS.
+    producer = ComplianceProducer(sanctions=StubCheck(ComplianceResult.FAIL))
+    assert producer.evaluate(make_request()).result is ComplianceResult.FAIL
+
+
+def test_aml_hit_escalates_not_pass() -> None:
+    # AUDIT PROOF: an AML hit needing MLRO yields ESCALATE, NOT default-PASS.
+    producer = ComplianceProducer(aml=StubCheck(ComplianceResult.ESCALATE))
+    assert producer.evaluate(make_request()).result is ComplianceResult.ESCALATE
+
+
+def test_outcomes_carry_opaque_refs_only() -> None:
+    outcome = CheckOutcome(result=ComplianceResult.FAIL, ref="rep_abc123", reason_codes=("X",))
+    assert outcome.ref == "rep_abc123"
+    assert outcome.reason_codes == ("X",)

--- a/tests/test_producers/test_confidence_scorer.py
+++ b/tests/test_producers/test_confidence_scorer.py
@@ -1,0 +1,84 @@
+"""ConfidenceScorer — deterministic bands across match_source / risk / ambiguity."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.intent_layer.models import ConfidenceBand, MatchSource
+from services.producers.confidence_scorer import ConfidenceScorer, ScoringSignals
+
+
+@pytest.fixture
+def scorer() -> ConfidenceScorer:
+    return ConfidenceScorer()
+
+
+@pytest.mark.parametrize(
+    ("match_source", "expected"),
+    [
+        (MatchSource.EXACT, 1.0),
+        (MatchSource.ALIAS, 0.95),
+        (MatchSource.LLM, 0.75),
+        (MatchSource.NONE, 0.0),
+    ],
+)
+def test_base_by_match_source(
+    scorer: ConfidenceScorer, match_source: MatchSource, expected: float
+) -> None:
+    assert scorer.score(ScoringSignals(match_source=match_source)) == expected
+
+
+def test_unresolved_scores_zero(scorer: ConfidenceScorer) -> None:
+    signals = ScoringSignals(match_source=MatchSource.EXACT, resolved=False)
+    assert scorer.score(signals) == 0.0
+    assert scorer.band(signals) is ConfidenceBand.BLOCK
+
+
+def test_high_risk_penalty_drops_band(scorer: ConfidenceScorer) -> None:
+    signals = ScoringSignals(match_source=MatchSource.LLM, risk_class="HIGH")
+    assert scorer.score(signals) == 0.60  # 0.75 - 0.15
+    assert scorer.band(signals) is ConfidenceBand.BLOCK
+
+
+def test_elevated_risk_penalty(scorer: ConfidenceScorer) -> None:
+    signals = ScoringSignals(match_source=MatchSource.ALIAS, risk_class="elevated")
+    assert scorer.score(signals) == 0.90  # 0.95 - 0.05 ; case-insensitive
+
+
+def test_ambiguity_penalty_clamped(scorer: ConfidenceScorer) -> None:
+    # ambiguity > 1 is clamped to 1 → max 0.20 penalty.
+    signals = ScoringSignals(match_source=MatchSource.EXACT, ambiguity=5.0)
+    assert scorer.score(signals) == 0.80
+
+
+def test_unknown_risk_class_no_penalty(scorer: ConfidenceScorer) -> None:
+    signals = ScoringSignals(match_source=MatchSource.EXACT, risk_class="WEIRD")
+    assert scorer.score(signals) == 1.0
+
+
+def test_band_thresholds(scorer: ConfidenceScorer) -> None:
+    assert scorer.band(ScoringSignals(MatchSource.EXACT)) is ConfidenceBand.AUTO
+    assert scorer.band(ScoringSignals(MatchSource.LLM)) is ConfidenceBand.REVIEW
+    assert scorer.band(ScoringSignals(MatchSource.NONE)) is ConfidenceBand.BLOCK
+
+
+def test_negative_ambiguity_clamped(scorer: ConfidenceScorer) -> None:
+    signals = ScoringSignals(match_source=MatchSource.EXACT, ambiguity=-3.0)
+    assert scorer.score(signals) == 1.0
+
+
+def test_from_resolved_intent() -> None:
+    from services.intent_layer.models import IntentStatus, ResolvedIntent
+
+    ri = ResolvedIntent(
+        raw_text="show my balance",
+        correlation_id="c1",
+        status=IntentStatus.RESOLVED,
+        confidence=1.0,
+        match_source=MatchSource.EXACT,
+    )
+    signals = ScoringSignals.from_resolved_intent(ri, risk_class="ELEVATED")
+    assert signals.match_source is MatchSource.EXACT
+    assert signals.resolved is True
+    assert signals.risk_class == "ELEVATED"
+    assert ConfidenceScorer().score(signals) == 0.95

--- a/tests/test_producers/test_cost_estimator.py
+++ b/tests/test_producers/test_cost_estimator.py
@@ -1,0 +1,98 @@
+"""CostEstimator — Decimal/token estimate + cap-awareness (no float, ADR-047)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import BudgetBreach, CostCap, RequestCost
+from services.producers.cost_estimator import CostEstimator
+from services.producers.ports import DEFAULT_COST_CAP
+
+
+def _cap() -> CostCap:
+    return CostCap(
+        max_request_tokens=1_000,
+        max_request_cost=Decimal("0.10"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("10.00"),
+    )
+
+
+class _LiveSource:
+    def __init__(self, cost: RequestCost | None) -> None:
+        self._cost = cost
+
+    def usage_for(self, accounting_key: str) -> RequestCost | None:
+        return self._cost
+
+
+def test_static_estimate_is_decimal() -> None:
+    est = CostEstimator(cost_cap=DEFAULT_COST_CAP, price_per_1k_tokens=Decimal("0.015"))
+    out = est.estimate("act", est_tokens=2000)
+    assert out.cost == RequestCost(tokens=2000, cost=Decimal("0.030000"))
+    assert isinstance(out.cost.cost, Decimal)
+    assert out.breach is BudgetBreach.NONE
+
+
+def test_zero_tokens() -> None:
+    est = CostEstimator(cost_cap=DEFAULT_COST_CAP)
+    out = est.estimate("act", est_tokens=0)
+    assert out.cost.cost == Decimal("0.000000")
+
+
+def test_negative_tokens_rejected() -> None:
+    est = CostEstimator(cost_cap=DEFAULT_COST_CAP)
+    with pytest.raises(ValueError, match="non-negative"):
+        est.estimate("act", est_tokens=-1)
+
+
+def test_breach_on_tokens() -> None:
+    est = CostEstimator(cost_cap=_cap(), price_per_1k_tokens=Decimal("0.0001"))
+    assert est.estimate("act", est_tokens=1_001).breach is BudgetBreach.BREACH
+
+
+def test_breach_on_cost() -> None:
+    est = CostEstimator(cost_cap=_cap(), price_per_1k_tokens=Decimal("1.0"))
+    # 500 tokens × £1/1k = £0.50 > £0.10 cap → BREACH (token count under cap).
+    out = est.estimate("act", est_tokens=500)
+    assert out.breach is BudgetBreach.BREACH
+
+
+def test_warn_band_on_tokens() -> None:
+    est = CostEstimator(cost_cap=_cap(), price_per_1k_tokens=Decimal("0.00001"))
+    # 800 tokens = 80% of 1000 cap → WARN.
+    assert est.estimate("act", est_tokens=800).breach is BudgetBreach.WARN
+
+
+def test_none_band_under_warn() -> None:
+    est = CostEstimator(cost_cap=_cap(), price_per_1k_tokens=Decimal("0.00001"))
+    assert est.estimate("act", est_tokens=700).breach is BudgetBreach.NONE
+
+
+def test_live_source_used_when_keyed() -> None:
+    live = RequestCost(tokens=42, cost=Decimal("0.999999"))
+    est = CostEstimator(cost_cap=DEFAULT_COST_CAP, source=_LiveSource(live))
+    out = est.estimate("act", est_tokens=9999, accounting_key="key-1")
+    assert out.cost == live  # live figure wins over the static estimate
+
+
+def test_live_source_none_falls_back_to_static() -> None:
+    est = CostEstimator(
+        cost_cap=DEFAULT_COST_CAP,
+        price_per_1k_tokens=Decimal("0.015"),
+        source=_LiveSource(None),
+    )
+    out = est.estimate("act", est_tokens=1000, accounting_key="key-1")
+    assert out.cost.tokens == 1000  # static fallback
+
+
+def test_no_accounting_key_skips_source() -> None:
+    # A live source is present but no key is given → static path only.
+    est = CostEstimator(
+        cost_cap=DEFAULT_COST_CAP,
+        source=_LiveSource(RequestCost(tokens=1, cost=Decimal("9"))),
+    )
+    out = est.estimate("act", est_tokens=1000)
+    assert out.cost.tokens == 1000

--- a/tests/test_producers/test_ports_defaults.py
+++ b/tests/test_producers/test_ports_defaults.py
@@ -1,0 +1,28 @@
+"""Null / static defaults — the no-live-L3 fallbacks all yield PASS / None."""
+
+from __future__ import annotations
+
+from services.agents._lineage import ComplianceResult
+from services.producers.ports import (
+    NullAMLCheck,
+    NullFraudCheck,
+    NullSanctionsCheck,
+    NullSanctionsIdentity,
+    StaticCostSource,
+)
+from tests.test_producers.conftest import make_request
+
+
+def test_null_checks_pass() -> None:
+    request = make_request()
+    assert NullAMLCheck().check(request).result is ComplianceResult.PASS
+    assert NullSanctionsCheck().check(request).result is ComplianceResult.PASS
+    assert NullFraudCheck().check(request).result is ComplianceResult.PASS
+
+
+def test_null_identity_resolves_none() -> None:
+    assert NullSanctionsIdentity().resolve("subj-1") is None
+
+
+def test_static_cost_source_returns_none() -> None:
+    assert StaticCostSource().usage_for("key-1") is None


### PR DESCRIPTION
## S5.2 — the compliance / confidence / cost PRODUCERS (audit gap #6)

Second of S5 (after S5.1 L1 router, #161). The 9 L2 client-facing agents accept
`compliance_result` (**default `PASS`**), `confidence_score` and `request_cost`
as **injected** keyword inputs — but nothing *produced* the verdict. A silent
default-`PASS` means every action passed compliance unchecked = **audit risk #6**.

This PR builds the **producer side of that seam**. The 9 agents are **not edited**
(the seam already exists); the composition root computes the three values and
feeds them into the params/intent that already exist.

### What's produced
- **`ComplianceProducer`** — real `PASS`/`FAIL`/`ESCALATE`/`N/A` verdict by
  orchestrating the existing L3 (AML / sanctions / fraud) via **injected Protocol
  ports**. Aggregate: any `FAIL`→`FAIL`; else any `ESCALATE`→`ESCALATE`; else
  all-`N/A`→`N/A`; else `PASS`. **Replaces the default-`PASS`.**
- **`ConfidenceScorer`** — deterministic `confidence_score ∈ [0,1]` from
  `match_source` / ambiguity / risk class (ADR-049 §D4 bands).
- **`CostEstimator`** — `RequestCost` (tokens + **Decimal**, no float) with
  ADR-047 cost-cap awareness (`NONE`/`WARN`/`BREACH`); optional live S1 per-key
  accounting via `CostSourcePort`.
- **`ProducerBundle`** — composition-root entry point; outputs map 1:1 onto the
  existing agent keyword params (no agent edits — see `services/producers/WIRING.md`).

### L3 is wrapped, never edited
`adapters.py` delegates to the live L3 services through **structural Protocols**
(no concrete L3 import, no L3 file edits):
| adapter | wraps | maps |
|---|---|---|
| `AMLCheckAdapter` | `services/aml` `TxMonitorService` | `sanctions_block`→FAIL; HITL flag→ESCALATE |
| `SanctionsCheckAdapter` | `services/sanctions_screening` `ScreeningEngine` | `CONFIRMED_MATCH`→FAIL; `POSSIBLE`/`ERROR`→ESCALATE |
| `FraudCheckAdapter` | `services/fraud` `FraudScoringPort` | `block`→FAIL; hold/APP-scam/HIGH-risk→ESCALATE |

### R-SEC
Producer core carries only an opaque `subject_ref`; the sanctions identity
(name/nationality — PII) is resolved L3-side inside the adapter via
`SanctionsIdentityPort` (owned by the composition root). Outputs carry the L3
report/decision id + non-PII policy codes only — never raw PII.

### Default-PASS-risk-closed proof
Tests drive **genuine L3 hits over the real services (no network)**: a real
`ScreeningEngine` blocked-jurisdiction `CONFIRMED_MATCH` → **FAIL**, a real
`TxMonitorService` £60k SAR breach → **ESCALATE**, sanctions hard-block → **FAIL**
— i.e. a hit yields FAIL/ESCALATE, **not** the old default-`PASS`.

### Quality
- **100% module coverage** on `services/producers/` (56 producer tests).
- Full repo gate: **10331 passed, 5 skipped** (pre-existing infra skips), 0 failed.
- `ruff format` + `ruff check` clean; `bandit -r services/producers`: **No issues**.
- Money is `Decimal` only — no float.

No edits to the 9 agents or any L3 service (wrapped via injected ports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)