### PR TITLE
feat(aml): LiveNCAClient — real SAR→NCA submission [S6.1]

### DIFF
--- a/api/routers/reporting.py
+++ b/api/routers/reporting.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from functools import lru_cache
+import os
 
 from fastapi import APIRouter, HTTPException
 
@@ -34,7 +35,15 @@ from api.models.reporting import (
     SARStatsResponse,
     WithdrawSARRequest,
 )
-from services.aml.sar_service import SARService, SARServiceError, SARStatus
+from services.aml.sar_service import (
+    LiveNCAClient,
+    NCAClient,
+    SARService,
+    SARServiceError,
+    SARStatus,
+    SARSubmissionError,
+    StubNCAClient,
+)
 from services.reporting.regdata_return import RegDataReturnService, ReturnStatus
 
 router = APIRouter(tags=["Compliance Reporting"])
@@ -43,9 +52,20 @@ router = APIRouter(tags=["Compliance Reporting"])
 # ── Service factories (overridable in tests via dependency_overrides) ──────────
 
 
+def _build_nca_client() -> NCAClient:
+    """Cutover seam (stub ↔ live).
+
+    LiveNCAClient IFF both NCA_SAR_API_KEY and NCA_ORGANISATION_ID are present;
+    otherwise StubNCAClient so dev/test/CI without credentials keep working.
+    """
+    if os.environ.get("NCA_SAR_API_KEY") and os.environ.get("NCA_ORGANISATION_ID"):
+        return LiveNCAClient()
+    return StubNCAClient()
+
+
 @lru_cache(maxsize=1)
 def _get_sar_service() -> SARService:
-    return SARService()
+    return SARService(nca_client=_build_nca_client())
 
 
 @lru_cache(maxsize=1)
@@ -257,17 +277,21 @@ def approve_sar(sar_id: str, body: MLRODecisionRequest) -> SARResponse:
     response_model=SARResponse,
     summary="Submit MLRO-approved SAR to NCA SAROnline",
 )
-def submit_sar(sar_id: str) -> SARResponse:
+async def submit_sar(sar_id: str) -> SARResponse:
     """
     Submit an MLRO-approved SAR to NCA SAROnline.
     Requires status=MLRO_APPROVED — POCA 2002 s.330 MLRO gate is mandatory.
-    STATUS: NCA SAROnline is STUBBED until NCA credentials are provisioned.
+    NCA client is selected by _build_nca_client(): LiveNCAClient when NCA
+    credentials are present, else StubNCAClient (offline).
     """
     svc = _get_sar_service()
     try:
-        sar = svc.submit_sar(sar_id=sar_id)
+        sar = await svc.submit_sar(sar_id=sar_id)
     except SARServiceError as exc:
         raise HTTPException(status_code=409, detail=str(exc))
+    except SARSubmissionError as exc:
+        # Upstream NCA SAROnline failure — surfaced, not swallowed (502).
+        raise HTTPException(status_code=502, detail=f"NCA SAROnline submission failed: {exc}")
     return _sar_to_response(sar)
 
 

--- a/services/aml/sar_service.py
+++ b/services/aml/sar_service.py
@@ -23,10 +23,23 @@ MLRO GATE (mandatory — cannot be bypassed):
   - All decisions logged for FCA audit (5-year retention — MLR 2017)
 
 NCA SAROnline:
-  STATUS: STUB — requires NCA account + SAROnline API credentials.
-  When credentials arrive:
-    1. Set NCA_SAR_API_KEY + NCA_ORGANISATION_ID in .env
-    2. Replace StubNCAClient with LiveNCAClient in get_sar_service()
+  Two clients implement the same async ``NCAClient`` seam:
+    - StubNCAClient  — offline/deterministic; the default with NO credentials.
+    - LiveNCAClient  — real httpx POST to NCA SAROnline (sandbox by default).
+  CUTOVER (stub → live) is automatic in ``_get_sar_service()`` (api/routers/
+  reporting.py): LiveNCAClient is selected IFF both NCA_SAR_API_KEY and
+  NCA_ORGANISATION_ID are present in the environment; otherwise StubNCAClient,
+  so dev/test/CI without credentials keep working offline.
+  ENV (LiveNCAClient):
+    - NCA_SAR_BASE_URL    — SAROnline base URL; DEFAULTS to the TEST/sandbox
+                            endpoint so S6 acceptance (a) runs against the NCA
+                            test env, not production. Operator overrides for prod.
+    - NCA_SAR_API_KEY     — SAROnline API key (bearer).
+    - NCA_ORGANISATION_ID — NCA-assigned organisation id.
+  PII: a SAR is a suspicious-activity report — its body is PII BY LAWFUL PURPOSE
+  (POCA 2002 s.330). That body is sent ONLY to NCA. Decision-lineage
+  (AgentDecisionRecord, ADR-046) carries ONLY the SAR id + status +
+  nca_reference — never the report body (see ``_emit_submission_lineage``).
 
 Retention: all SAR records retained 5 years in ClickHouse (MLR 2017 Reg.40).
 In sandbox: in-memory store only.
@@ -39,7 +52,14 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from enum import Enum
 import logging
+import os
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 import uuid
+
+import httpx
+
+if TYPE_CHECKING:
+    from services.agents._lineage import DecisionRecorder
 
 # ─── BANXE COMPLIANCE RAG (auto-injected) ───
 try:
@@ -153,20 +173,201 @@ class SARStats:
     submission_rate: float  # submitted / (submitted + withdrawn) * 100
 
 
-# ── NCA Client (stub) ─────────────────────────────────────────────────────────
+# ── NCA Client seam ───────────────────────────────────────────────────────────
+
+
+class SARSubmissionError(Exception):
+    """
+    Raised when an NCA SAROnline submission fails (non-2xx, transport, or
+    timeout). NEVER swallowed silently — surfaces the upstream failure to the
+    caller so the SAR is not falsely recorded as SUBMITTED.
+
+    ``status_code`` is the NCA HTTP status when the failure was an HTTP response
+    (None for transport/timeout failures).
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@runtime_checkable
+class NCAClient(Protocol):
+    """Async submission seam — both Stub and Live clients satisfy it."""
+
+    async def submit(self, sar: SARReport) -> str:
+        """Submit ``sar`` to NCA SAROnline and return the NCA reference."""
+        ...
+
+
+# ── NCA test/sandbox default ────────────────────────────────────────────────
+# Default base URL points at the SAROnline TEST/sandbox env so S6 acceptance (a)
+# can never hit production by accident. The operator overrides NCA_SAR_BASE_URL
+# with the NCA-provided sandbox/prod URL at runtime.
+_NCA_SAR_TEST_BASE_URL = "https://test.saronline.nca.gov.uk"
+_NCA_SUBMIT_PATH = "/v1/sar/submit"
+# Response keys NCA SAROnline may use for the assigned reference (tolerant parse).
+_NCA_REFERENCE_KEYS = (
+    "nca_reference",
+    "ncaReference",
+    "reference",
+    "sarReference",
+    "submissionReference",
+    "reference_number",
+)
 
 
 class StubNCAClient:
     """
-    Stub NCA SAROnline client.
-    Returns a deterministic reference. Does NOT send to NCA.
-    Replace with LiveNCAClient when NCA credentials are provisioned.
+    Stub NCA SAROnline client (offline fallback — DO NOT remove).
+    Returns a deterministic reference. Does NOT send to NCA. Used whenever NCA
+    credentials are absent (dev/test/CI). Async to match the NCAClient seam.
     """
 
-    def submit(self, sar: SARReport) -> str:
+    async def submit(self, sar: SARReport) -> str:
         """Returns fake NCA reference: SAR-YYYYMM-{sar_id[:8]}."""
         month = sar.created_at.strftime("%Y%m")
         return f"SAR-{month}-{sar.sar_id[:8].upper()}"
+
+
+class LiveNCAClient:
+    """
+    Live NCA SAROnline client — real async HTTP submission via httpx.
+
+    AWAIT DISCIPLINE (adapter bug class): every network call is ``await``ed.
+    A missing ``await`` would yield a coroutine instead of a Response and fail
+    loudly in tests (strict MockTransport/AsyncMock), never silently no-op.
+
+    Idempotency: the SAR id is sent as an ``Idempotency-Key`` so a transient
+    retry (timeout/5xx) cannot create a duplicate filing at NCA. Combined with
+    the service-level submission lock (already-SUBMITTED → no-op), submission is
+    safe to retry.
+
+    Credentials/endpoint come from the environment (NCA_SAR_BASE_URL defaults to
+    the TEST/sandbox URL). The httpx client is injectable for tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        organisation_id: str | None = None,
+        client: httpx.AsyncClient | None = None,
+        timeout_s: float = 30.0,
+        max_retries: int = 2,
+    ) -> None:
+        self._base_url = (
+            base_url or os.environ.get("NCA_SAR_BASE_URL", _NCA_SAR_TEST_BASE_URL)
+        ).rstrip("/")
+        self._api_key = api_key if api_key is not None else os.environ.get("NCA_SAR_API_KEY", "")
+        self._org_id = (
+            organisation_id
+            if organisation_id is not None
+            else os.environ.get("NCA_ORGANISATION_ID", "")
+        )
+        if not self._api_key or not self._org_id:
+            raise OSError(
+                "NCA_SAR_API_KEY and NCA_ORGANISATION_ID must be set to use "
+                "LiveNCAClient. Leave them unset to fall back to StubNCAClient "
+                "(offline) — see _get_sar_service()."
+            )
+        self._client = client if client is not None else httpx.AsyncClient()
+        self._owns_client = client is None
+        self._timeout_s = timeout_s
+        self._max_retries = max(0, max_retries)
+
+    async def submit(self, sar: SARReport) -> str:
+        """
+        POST the SAR to NCA SAROnline and return the assigned NCA reference.
+
+        2xx                  → parse + return the NCA reference
+        4xx                  → SARSubmissionError (client error — NOT retried)
+        5xx / transport / timeout → retried up to ``max_retries``; on exhaustion,
+                               SARSubmissionError (no silent swallow).
+        """
+        url = f"{self._base_url}{_NCA_SUBMIT_PATH}"
+        payload = self._build_payload(sar)  # PII by lawful purpose — NCA only.
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "X-Organisation-Id": self._org_id,
+            "Idempotency-Key": sar.sar_id,  # submission lock — safe retry
+        }
+        last_error: SARSubmissionError | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = await self._client.post(
+                    url, json=payload, headers=headers, timeout=self._timeout_s
+                )
+            except httpx.HTTPError as exc:
+                last_error = SARSubmissionError(
+                    f"NCA SAROnline transport error: {type(exc).__name__}: {exc}"
+                )
+                continue  # transient — retry
+            if 200 <= response.status_code < 300:
+                return self._parse_reference(response)
+            if response.status_code >= 500:
+                last_error = SARSubmissionError(
+                    f"NCA SAROnline server error: HTTP {response.status_code}",
+                    status_code=response.status_code,
+                )
+                continue  # transient — retry
+            # 4xx — client error; the request itself is wrong, retry won't help.
+            raise SARSubmissionError(
+                f"NCA SAROnline rejected SAR {sar.sar_id}: HTTP {response.status_code} "
+                f"{self._safe_snippet(response)}",
+                status_code=response.status_code,
+            )
+        raise last_error or SARSubmissionError(
+            f"NCA SAROnline submission failed for SAR {sar.sar_id}"
+        )
+
+    def _build_payload(self, sar: SARReport) -> dict[str, object]:
+        """Map a SARReport to the NCA SAROnline submission body.
+
+        Money is serialised via ``str(Decimal)`` — never float."""
+        return {
+            "organisationId": self._org_id,
+            "sarId": sar.sar_id,
+            "transactionId": sar.transaction_id,
+            "subject": {"customerId": sar.customer_id, "entityType": sar.entity_type},
+            "amount": str(sar.amount),
+            "currency": sar.currency,
+            "reasons": [r.value for r in sar.sar_reasons],
+            "amlFlags": list(sar.aml_flags),
+            "fraudScore": sar.fraud_score,
+            "createdAt": sar.created_at.isoformat(),
+        }
+
+    @staticmethod
+    def _parse_reference(response: httpx.Response) -> str:
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise SARSubmissionError(
+                f"NCA SAROnline returned non-JSON 2xx body: {exc}",
+                status_code=response.status_code,
+            ) from exc
+        if isinstance(data, dict):
+            for key in _NCA_REFERENCE_KEYS:
+                value = data.get(key)
+                if value:
+                    return str(value)
+        raise SARSubmissionError(
+            "NCA SAROnline accepted the SAR (2xx) but returned no reference",
+            status_code=response.status_code,
+        )
+
+    @staticmethod
+    def _safe_snippet(response: httpx.Response) -> str:
+        """A short, bounded slice of the NCA error body for diagnostics.
+
+        httpx decodes with errors='replace', so ``.text`` does not raise."""
+        return response.text[:200]
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
 
 
 # ── Service ────────────────────────────────────────────────────────────────────
@@ -182,9 +383,17 @@ class SARService:
     In production: persist to ClickHouse with 5-year TTL (MLR 2017 Reg.40).
     """
 
-    def __init__(self, nca_client: StubNCAClient | None = None) -> None:
+    def __init__(
+        self,
+        nca_client: NCAClient | None = None,
+        decision_recorder: DecisionRecorder | None = None,
+    ) -> None:
         self._sars: dict[str, SARReport] = {}
-        self._nca = nca_client or StubNCAClient()
+        self._nca: NCAClient = nca_client or StubNCAClient()
+        # Optional ADR-046 lineage sink. OFF by default → behaviour unchanged for
+        # existing callers/tests. When injected, a SUBMITTED SAR emits one
+        # decision record carrying ONLY id+status+nca_reference (never the body).
+        self._recorder = decision_recorder
 
     # ── File (create draft) ───────────────────────────────────────────────────
 
@@ -276,27 +485,81 @@ class SARService:
 
     # ── Submission ────────────────────────────────────────────────────────────
 
-    def submit_sar(self, sar_id: str) -> SARReport:
+    async def submit_sar(self, sar_id: str) -> SARReport:
         """
-        Submit MLRO-approved SAR to NCA SAROnline.
-        Cannot submit without prior MLRO approval.
+        Submit an MLRO-approved SAR to NCA SAROnline (async — awaits the client).
+
+        Guard rails (preserve the state machine, POCA 2002 s.330):
+          - Submission lock / idempotency: an already-SUBMITTED SAR that has an
+            nca_reference is a NO-OP — never submitted twice.
+          - MLRO gate: only MLRO_APPROVED (or a prior SUBMISSION_FAILED retry)
+            SARs may submit; anything else raises SARServiceError.
+          - On NCA failure: status → SUBMISSION_FAILED, the error is recorded,
+            and SARSubmissionError is re-raised (no silent swallow).
         """
         sar = self._get_or_raise(sar_id)
-        if not sar.is_submittable:
+
+        # Idempotent submission lock — already filed → no-op (safe on retry).
+        if sar.status == SARStatus.SUBMITTED and sar.nca_reference:
+            logger.info(
+                "SAR already SUBMITTED — idempotent no-op: sar=%s nca_ref=%s",
+                sar_id,
+                sar.nca_reference,
+            )
+            return sar
+
+        # MLRO gate. MLRO_APPROVED is the entry state; SUBMISSION_FAILED is a
+        # retry of a previously-approved SAR (still gated — never bypasses MLRO).
+        if sar.status not in (SARStatus.MLRO_APPROVED, SARStatus.SUBMISSION_FAILED):
             raise SARServiceError(
                 f"SAR {sar_id} is {sar.status.value} — must be MLRO_APPROVED to submit"
             )
+
         try:
-            nca_ref = self._nca.submit(sar)
-            sar.status = SARStatus.SUBMITTED
-            sar.submitted_at = datetime.now(UTC)
-            sar.nca_reference = nca_ref
-            logger.warning("SAR SUBMITTED to NCA: sar=%s nca_ref=%s", sar_id, nca_ref)
-        except Exception as exc:
+            nca_ref = await self._nca.submit(sar)
+        except SARSubmissionError as exc:
             sar.status = SARStatus.SUBMISSION_FAILED
             sar.errors.append(f"NCA submission failed: {exc}")
             logger.error("SAR submission failed: sar=%s exc=%s", sar_id, exc)
+            raise
+
+        sar.status = SARStatus.SUBMITTED
+        sar.submitted_at = datetime.now(UTC)
+        sar.nca_reference = nca_ref
+        logger.warning("SAR SUBMITTED to NCA: sar=%s nca_ref=%s", sar_id, nca_ref)
+        await self._emit_submission_lineage(sar)
         return sar
+
+    async def _emit_submission_lineage(self, sar: SARReport) -> None:
+        """Emit one ADR-046 decision record for a submitted SAR.
+
+        R-SEC: the record carries ONLY the SAR id, status, and nca_reference plus
+        the MLRO reviewer id (operator, not subject PII). The SAR body — customer
+        id, transaction id, amount, reasons, flags — is NEVER placed on the
+        lineage record (it lives solely in the NCA payload). No-op if no recorder
+        is wired.
+        """
+        if self._recorder is None:
+            return
+        # Local import: keeps module load light and avoids pulling the agents
+        # package unless lineage recording is actually enabled.
+        from services.agents._lineage import AgentDecisionRecord, ComplianceResult
+
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id="banxe_aml_sar_agent",
+            triggering_event=f"sar_submit:{sar.sar_id}",
+            intent="sar.submit",
+            policies_evaluated=["POCA-2002-s330", "MLR-2017-Reg40"],
+            compliance_result=ComplianceResult.PASS,
+            reasoning_summary=f"SAR submitted to NCA SAROnline (status={sar.status.value})",
+            confidence_score=1.0,
+            action_taken=f"NCA_SUBMITTED nca_reference={sar.nca_reference}",
+            human_reviewed_by=sar.mlro_reviewed_by,
+            correlation_id=sar.sar_id,
+        )
+        await self._recorder.record(record)
 
     # ── Read ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_sar_nca_live.py
+++ b/tests/test_sar_nca_live.py
@@ -1,0 +1,371 @@
+"""
+tests/test_sar_nca_live.py — LiveNCAClient + SAR→NCA submission tests.
+S6.1 | POCA 2002 s.330 | banxe-emi-stack
+
+Covers the live NCA SAROnline submission path (LiveNCAClient), the SARService
+state-machine guards around it, and the R-SEC proof that SAR-body PII never
+reaches the ADR-046 decision lineage.
+
+Network is mocked two ways:
+  - httpx.MockTransport  — behavioural tests (a real async client + transport;
+    a missing ``await`` would yield a coroutine, not a Response, and fail).
+  - strict AsyncMock(spec=httpx.AsyncClient) — proves ``.post`` is AWAITED
+    exactly once (the adapter-bug-class await discipline).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from decimal import Decimal
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+import api.routers.reporting as reporting
+from services.agents._lineage import AgentDecisionRecord, DecisionRecorder
+from services.aml.sar_service import (
+    LiveNCAClient,
+    NCAClient,
+    SARReason,
+    SARReport,
+    SARService,
+    SARServiceError,
+    SARStatus,
+    SARSubmissionError,
+    StubNCAClient,
+)
+
+# ── Fixtures / helpers ─────────────────────────────────────────────────────────
+
+
+def _make_draft(svc: SARService) -> SARReport:
+    return svc.file_sar(
+        transaction_id="tx-PII-999",
+        customer_id="cust-PII-001",
+        entity_type="INDIVIDUAL",
+        amount=Decimal("12500"),
+        currency="GBP",
+        sar_reasons=[SARReason.VELOCITY_BREACH, SARReason.STRUCTURING],
+        aml_flags=["VELOCITY_30D"],
+        fraud_score=72,
+    )
+
+
+def _approved(svc: SARService) -> SARReport:
+    sar = _make_draft(svc)
+    svc.approve_sar(sar_id=sar.sar_id, mlro_id="mlro-001", notes="clear ML indicators")
+    return sar
+
+
+def _live_with(handler, **kwargs) -> LiveNCAClient:
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    return LiveNCAClient(api_key="k-test", organisation_id="org-test", client=client, **kwargs)
+
+
+def _ok(reference: str = "NCA-REF-123"):
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"reference": reference})
+
+    return handler
+
+
+class _CapturingRecorder(DecisionRecorder):
+    """Captures every emitted AgentDecisionRecord for inspection."""
+
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+# ── LiveNCAClient construction / cutover ───────────────────────────────────────
+
+
+class TestLiveNCAClientConstruction:
+    def test_satisfies_nca_client_protocol(self) -> None:
+        client = _live_with(_ok())
+        assert isinstance(client, NCAClient)
+
+    def test_missing_api_key_raises(self) -> None:
+        with pytest.raises(OSError, match="NCA_SAR_API_KEY"):
+            LiveNCAClient(api_key="", organisation_id="org")
+
+    def test_missing_org_id_raises(self) -> None:
+        with pytest.raises(OSError, match="NCA_ORGANISATION_ID"):
+            LiveNCAClient(api_key="k", organisation_id="")
+
+    def test_base_url_defaults_to_test_sandbox(self) -> None:
+        client = _live_with(_ok())
+        assert "test" in client._base_url  # TEST/sandbox default for acceptance (a)
+
+    def test_base_url_override(self) -> None:
+        client = LiveNCAClient(
+            api_key="k", organisation_id="o", base_url="https://prod.example/", client=None
+        )
+        assert client._base_url == "https://prod.example"
+
+
+class TestCutover:
+    """_build_nca_client(): live IFF both creds present, else stub (offline)."""
+
+    def test_stub_when_no_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NCA_SAR_API_KEY", raising=False)
+        monkeypatch.delenv("NCA_ORGANISATION_ID", raising=False)
+        assert isinstance(reporting._build_nca_client(), StubNCAClient)
+
+    def test_stub_when_only_one_credential(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NCA_SAR_API_KEY", "k")
+        monkeypatch.delenv("NCA_ORGANISATION_ID", raising=False)
+        assert isinstance(reporting._build_nca_client(), StubNCAClient)
+
+    def test_live_when_both_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NCA_SAR_API_KEY", "k")
+        monkeypatch.setenv("NCA_ORGANISATION_ID", "org")
+        assert isinstance(reporting._build_nca_client(), LiveNCAClient)
+
+
+# ── LiveNCAClient.submit — happy path / await discipline ───────────────────────
+
+
+class TestLiveSubmit:
+    async def test_2xx_returns_reference(self) -> None:
+        client = _live_with(_ok("NCA-OK-1"))
+        svc = SARService(nca_client=client)
+        sar = _approved(svc)
+        ref = await client.submit(sar)
+        assert ref == "NCA-OK-1"
+
+    async def test_await_discipline_strict_asyncmock(self) -> None:
+        """A missing ``await`` on .post would yield a coroutine and blow up."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = httpx.Response(200, json={"reference": "NCA-AM-1"})
+        client = LiveNCAClient(api_key="k", organisation_id="o", client=mock_client)
+        sar = _approved(SARService())
+        ref = await client.submit(sar)
+        assert ref == "NCA-AM-1"
+        mock_client.post.assert_awaited_once()  # proves the await happened
+
+    async def test_payload_and_headers(self) -> None:
+        seen: dict = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["headers"] = dict(req.headers)
+            seen["body"] = json.loads(req.content)
+            seen["url"] = str(req.url)
+            return httpx.Response(200, json={"reference": "R"})
+
+        client = _live_with(handler)
+        sar = _approved(SARService())
+        await client.submit(sar)
+        assert seen["url"].endswith("/v1/sar/submit")
+        assert seen["headers"]["authorization"] == "Bearer k-test"
+        assert seen["headers"]["x-organisation-id"] == "org-test"
+        # Submission lock: idempotency key == SAR id (safe retry).
+        assert seen["headers"]["idempotency-key"] == sar.sar_id
+        # Money is a string (Decimal), never a float.
+        assert seen["body"]["amount"] == "12500"
+        assert isinstance(seen["body"]["amount"], str)
+        assert seen["body"]["sarId"] == sar.sar_id
+
+    async def test_reference_alternate_key(self) -> None:
+        def handler(_req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"ncaReference": "ALT-1"})
+
+        client = _live_with(handler)
+        assert await client.submit(_approved(SARService())) == "ALT-1"
+
+
+# ── LiveNCAClient.submit — error mapping / retry ───────────────────────────────
+
+
+class TestLiveSubmitErrors:
+    async def test_4xx_raises_no_retry(self) -> None:
+        calls = {"n": 0}
+
+        def handler(_req: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(400, text="bad request body")
+
+        client = _live_with(handler, max_retries=3)
+        with pytest.raises(SARSubmissionError) as ei:
+            await client.submit(_approved(SARService()))
+        assert ei.value.status_code == 400
+        assert "bad request body" in str(ei.value)  # _safe_snippet
+        assert calls["n"] == 1  # 4xx is NOT retried
+
+    async def test_5xx_retried_then_raises(self) -> None:
+        calls = {"n": 0}
+
+        def handler(_req: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(500)
+
+        client = _live_with(handler, max_retries=2)
+        with pytest.raises(SARSubmissionError) as ei:
+            await client.submit(_approved(SARService()))
+        assert ei.value.status_code == 500
+        assert calls["n"] == 3  # initial + 2 retries
+
+    async def test_5xx_then_2xx_succeeds(self) -> None:
+        seq = [503, 200]
+
+        def handler(_req: httpx.Request) -> httpx.Response:
+            code = seq.pop(0)
+            if code == 200:
+                return httpx.Response(200, json={"reference": "RECOVERED"})
+            return httpx.Response(code)
+
+        client = _live_with(handler, max_retries=2)
+        assert await client.submit(_approved(SARService())) == "RECOVERED"
+
+    async def test_transport_error_raises(self) -> None:
+        def handler(_req: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("dns failure")
+
+        client = _live_with(handler, max_retries=1)
+        with pytest.raises(SARSubmissionError, match="transport error"):
+            await client.submit(_approved(SARService()))
+
+    async def test_2xx_without_reference_raises(self) -> None:
+        def handler(_req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"status": "ok"})
+
+        client = _live_with(handler)
+        with pytest.raises(SARSubmissionError, match="no reference"):
+            await client.submit(_approved(SARService()))
+
+    async def test_2xx_non_json_raises(self) -> None:
+        def handler(_req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="not json", headers={"content-type": "text/plain"})
+
+        client = _live_with(handler)
+        with pytest.raises(SARSubmissionError, match="non-JSON"):
+            await client.submit(_approved(SARService()))
+
+
+# ── aclose ─────────────────────────────────────────────────────────────────────
+
+
+class TestAclose:
+    async def test_aclose_owned_client(self) -> None:
+        client = LiveNCAClient(api_key="k", organisation_id="o")  # owns its client
+        await client.aclose()
+        assert client._client.is_closed
+
+    async def test_aclose_injected_client_not_closed(self) -> None:
+        injected = httpx.AsyncClient()
+        client = LiveNCAClient(api_key="k", organisation_id="o", client=injected)
+        await client.aclose()  # must NOT close a client it does not own
+        assert not injected.is_closed
+        await injected.aclose()
+
+
+# ── SARService submission guards (with live client) ────────────────────────────
+
+
+class TestServiceSubmissionGuards:
+    async def test_submit_sets_reference_and_status(self) -> None:
+        svc = SARService(nca_client=_live_with(_ok("NCA-S-1")))
+        sar = _approved(svc)
+        result = await svc.submit_sar(sar.sar_id)
+        assert result.status == SARStatus.SUBMITTED
+        assert result.nca_reference == "NCA-S-1"
+        assert result.submitted_at is not None
+
+    async def test_refuses_non_mlro_approved(self) -> None:
+        svc = SARService(nca_client=_live_with(_ok()))
+        draft = _make_draft(svc)  # DRAFT, not approved
+        with pytest.raises(SARServiceError, match="must be MLRO_APPROVED"):
+            await svc.submit_sar(draft.sar_id)
+
+    async def test_double_submit_is_noop(self) -> None:
+        calls = {"n": 0}
+
+        def handler(_req: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(200, json={"reference": "ONCE"})
+
+        svc = SARService(nca_client=_live_with(handler))
+        sar = _approved(svc)
+        first = await svc.submit_sar(sar.sar_id)
+        second = await svc.submit_sar(sar.sar_id)  # idempotent no-op
+        assert first.nca_reference == second.nca_reference == "ONCE"
+        assert calls["n"] == 1  # NCA hit exactly once
+
+    async def test_submission_failure_sets_failed_status_and_raises(self) -> None:
+        svc = SARService(nca_client=_live_with(lambda _r: httpx.Response(400, text="rejected")))
+        sar = _approved(svc)
+        with pytest.raises(SARSubmissionError):
+            await svc.submit_sar(sar.sar_id)
+        failed = svc.get_sar(sar.sar_id)
+        assert failed is not None
+        assert failed.status == SARStatus.SUBMISSION_FAILED
+        assert failed.errors  # error recorded, not swallowed
+
+    async def test_retry_after_failure_succeeds(self) -> None:
+        seq = [httpx.Response(500), httpx.Response(200, json={"reference": "RETRY-OK"})]
+        svc = SARService(nca_client=_live_with(lambda _r: seq.pop(0), max_retries=0))
+        sar = _approved(svc)
+        with pytest.raises(SARSubmissionError):
+            await svc.submit_sar(sar.sar_id)  # first attempt fails → SUBMISSION_FAILED
+        result = await svc.submit_sar(sar.sar_id)  # retry from SUBMISSION_FAILED
+        assert result.status == SARStatus.SUBMITTED
+        assert result.nca_reference == "RETRY-OK"
+
+
+# ── R-SEC: SAR-body PII never reaches the ADR-046 lineage ──────────────────────
+
+
+class TestLineagePIISafety:
+    async def test_submitted_emits_lineage_without_pii(self) -> None:
+        recorder = _CapturingRecorder()
+        svc = SARService(nca_client=StubNCAClient(), decision_recorder=recorder)
+        sar = _approved(svc)
+        await svc.submit_sar(sar.sar_id)
+
+        assert len(recorder.records) == 1
+        record = recorder.records[0]
+        blob = str(asdict(record))
+
+        # Safe identifiers ARE present.
+        assert sar.sar_id in blob
+        assert sar.nca_reference is not None
+        assert sar.nca_reference in blob
+        assert "SUBMITTED" in blob
+
+        # SAR-body PII is NEVER present.
+        assert sar.customer_id not in blob  # cust-PII-001
+        assert sar.transaction_id not in blob  # tx-PII-999
+        assert str(sar.amount) not in blob  # 12500
+        for reason in sar.sar_reasons:
+            assert reason.value not in blob
+        for flag in sar.aml_flags:
+            assert flag not in blob
+
+    async def test_no_recorder_means_no_emission(self) -> None:
+        svc = SARService(nca_client=StubNCAClient())  # no recorder
+        sar = _approved(svc)
+        result = await svc.submit_sar(sar.sar_id)  # must not raise
+        assert result.status == SARStatus.SUBMITTED
+
+
+# ── API endpoint: NCA failure surfaces as 502 (no silent swallow) ──────────────
+
+
+class TestSubmitEndpointErrorMapping:
+    def test_nca_failure_maps_to_502(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fastapi.testclient import TestClient
+
+        from api.main import app
+
+        failing = SARService(nca_client=_live_with(lambda _r: httpx.Response(503), max_retries=0))
+        sar = _approved(failing)
+        monkeypatch.setattr(reporting, "_get_sar_service", lambda: failing)
+        with TestClient(app) as client:
+            res = client.post(f"/v1/reporting/sar/{sar.sar_id}/submit")
+        assert res.status_code == 502
+        assert "NCA SAROnline submission failed" in res.json()["detail"]

--- a/tests/test_sar_service.py
+++ b/tests/test_sar_service.py
@@ -184,9 +184,9 @@ class TestWithdrawSAR:
         )
         assert withdrawn.status == SARStatus.WITHDRAWN
 
-    def test_cannot_withdraw_submitted(self, svc: SARService, draft_sar: SARReport) -> None:
+    async def test_cannot_withdraw_submitted(self, svc: SARService, draft_sar: SARReport) -> None:
         svc.approve_sar(sar_id=draft_sar.sar_id, mlro_id="mlro-001")
-        svc.submit_sar(sar_id=draft_sar.sar_id)
+        await svc.submit_sar(sar_id=draft_sar.sar_id)
         with pytest.raises(SARServiceError, match="cannot withdraw"):
             svc.withdraw_sar(
                 sar_id=draft_sar.sar_id,
@@ -196,30 +196,32 @@ class TestWithdrawSAR:
 
 
 class TestSubmitSAR:
-    def test_submit_approved_sar(self, svc: SARService, draft_sar: SARReport) -> None:
+    async def test_submit_approved_sar(self, svc: SARService, draft_sar: SARReport) -> None:
         svc.approve_sar(sar_id=draft_sar.sar_id, mlro_id="mlro-001")
-        submitted = svc.submit_sar(sar_id=draft_sar.sar_id)
+        submitted = await svc.submit_sar(sar_id=draft_sar.sar_id)
         assert submitted.status == SARStatus.SUBMITTED
         assert submitted.nca_reference is not None
         assert submitted.nca_reference.startswith("SAR-")
         assert submitted.submitted_at is not None
 
-    def test_cannot_submit_draft(self, svc: SARService, draft_sar: SARReport) -> None:
+    async def test_cannot_submit_draft(self, svc: SARService, draft_sar: SARReport) -> None:
         with pytest.raises(SARServiceError, match="must be MLRO_APPROVED"):
-            svc.submit_sar(sar_id=draft_sar.sar_id)
+            await svc.submit_sar(sar_id=draft_sar.sar_id)
 
-    def test_nca_reference_format(self, svc: SARService, draft_sar: SARReport) -> None:
+    async def test_nca_reference_format(self, svc: SARService, draft_sar: SARReport) -> None:
         svc.approve_sar(sar_id=draft_sar.sar_id, mlro_id="mlro-001")
-        submitted = svc.submit_sar(sar_id=draft_sar.sar_id)
+        submitted = await svc.submit_sar(sar_id=draft_sar.sar_id)
         # Format: SAR-YYYYMM-{8 hex chars uppercase}
         parts = submitted.nca_reference.split("-")
         assert len(parts) == 3
         assert parts[0] == "SAR"
         assert len(parts[1]) == 6  # YYYYMM
 
-    def test_is_submittable_false_after_submit(self, svc: SARService, draft_sar: SARReport) -> None:
+    async def test_is_submittable_false_after_submit(
+        self, svc: SARService, draft_sar: SARReport
+    ) -> None:
         svc.approve_sar(sar_id=draft_sar.sar_id, mlro_id="mlro-001")
-        submitted = svc.submit_sar(sar_id=draft_sar.sar_id)
+        submitted = await svc.submit_sar(sar_id=draft_sar.sar_id)
         assert submitted.is_submittable is False
 
 
@@ -279,7 +281,7 @@ class TestListAndStats:
         assert s.total == 0
         assert s.submission_rate == 0.0
 
-    def test_stats_submission_rate(self, svc: SARService) -> None:
+    async def test_stats_submission_rate(self, svc: SARService) -> None:
         # Create 2 SARs: 1 submitted, 1 withdrawn → rate = 50%
         sar1 = svc.file_sar(
             transaction_id="tx-e",
@@ -302,7 +304,7 @@ class TestListAndStats:
             fraud_score=0,
         )
         svc.approve_sar(sar_id=sar1.sar_id, mlro_id="mlro-001")
-        svc.submit_sar(sar_id=sar1.sar_id)
+        await svc.submit_sar(sar_id=sar1.sar_id)
         svc.withdraw_sar(sar_id=sar2.sar_id, mlro_id="mlro-001", reason="not suspicious")
         s = svc.stats()
         assert s.total == 2


### PR DESCRIPTION
## S6.1 — implement real SAR→NCA submission (LiveNCAClient)

Closes audit gap **SAR→NCA stub**. S6 acceptance (a): a SAR submits to the NCA SAROnline **test** endpoint. Live submission to the real NCA test env is an **operator runtime step** (needs NCA sandbox creds); the code + tests prove it deployable.

### LiveNCAClient (`services/aml/sar_service.py`)
- Async `httpx.AsyncClient` POST to NCA SAROnline. **Await discipline** (adapter bug class): every network call `await`ed; a strict `AsyncMock(spec=httpx.AsyncClient)` test asserts `.post` is awaited exactly once.
- Endpoint + credentials from env: `NCA_SAR_BASE_URL` (**defaults to TEST/sandbox** so acceptance (a) never hits prod), `NCA_SAR_API_KEY`, `NCA_ORGANISATION_ID`.
- Parses the NCA reference (tolerant key match) → sets `nca_reference` + `SUBMITTED` + `submitted_at`.
- **StubNCAClient kept** as offline fallback (now async to match the `NCAClient` seam — **not removed**).

### Cutover (stub ↔ live)
`_get_sar_service()` → `_build_nca_client()`: **LiveNCAClient IFF both** `NCA_SAR_API_KEY` and `NCA_ORGANISATION_ID` present, else StubNCAClient. Dev/test/CI without creds keep working offline.

### State-machine guards (POCA 2002 s.330)
- MLRO gate: refuse to submit anything not `MLRO_APPROVED` (raises).
- **Idempotent submission lock**: already-`SUBMITTED` + `nca_reference` → no-op (NCA hit once); `Idempotency-Key: sar_id` sent so transient retry can't double-file. `SUBMISSION_FAILED` retry path supported.

### Error mapping
non-2xx → typed `SARSubmissionError` (**no silent swallow**); 5xx/transport/timeout retried, 4xx not; submit endpoint maps it to **HTTP 502**.

### R-SEC — SAR PII never in lineage
Optional ADR-046 `DecisionRecorder`; the emitted `AgentDecisionRecord` carries **only** sar_id + status + nca_reference (+ MLRO reviewer id). SAR-body PII (customer/tx ids, amount, reasons, flags) **never** appears — proven by `TestLineagePIISafety`. Money serialised as `str(Decimal)`, never float.

### Tests / quality
- New `tests/test_sar_nca_live.py` (construction, cutover, happy path, await discipline, payload/headers, error/retry mapping, idempotency, guards, lineage-PII, 502 mapping). Existing direct-call `submit_sar` tests converted to async.
- **New client 100% covered**; ruff format+check clean; bandit clean; **full suite: 10327 passed, 37 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)