### PR TITLE
feat(recon-core): shared reconciliation mechanics core — two CASS regimes, thresholds NOT unified [S6.2]

### DIFF
--- a/docs/architecture/RECON-CORE-BOUNDARY.md
+++ b/docs/architecture/RECON-CORE-BOUNDARY.md
@@ -1,0 +1,100 @@
+# Reconciliation Core Boundary — two CASS regimes, one shared mechanics core
+
+**Sprint:** S6.2 | **Created:** 2026-06-09
+**FCA rules:** FCA CASS 15 (IL-SAF-01 / "ADR-SAF-01"), FCA CASS 7.15
+**Code:** `src/recon_core/` (shared), `src/safeguarding/` (CASS 15), `services/recon/` (CASS 7.15)
+
+---
+
+## Decision (one line)
+
+The two safeguarding reconciliation paths share ONE regime-agnostic **mechanics** core
+(`src/recon_core/`); their **regulatory regimes stay distinct**, and every threshold is an
+injected parameter — **deliberately NOT unified**.
+
+## The two regimes (legitimately different — do NOT merge)
+
+| | Router A — CASS 15 | Router B — CASS 7.15 |
+|---|---|---|
+| Code | `src/safeguarding/*` | `services/recon/*` |
+| API | `/v1/safeguarding/*` | `/v1/safeguarding-recon/*` |
+| Engine | `DailyReconciliation` | `ReconciliationEngineV2` + `ReconAgent` |
+| Granularity | **aggregate** internal-vs-statutory-bank balance | **line-item** ledger-vs-statement per IBAN |
+| Match tolerance | £0.01 penny-exact | £0.01 penny-exact (per item) |
+| Breach rule | `> £0.01` → `ReconStatus.BREAK` | `> £100` net → `HITLProposal` (COMPLIANCE_OFFICER) |
+| Statutory output | FIN060 monthly return, 48h resolution pack | HITL breach-resolution workflow |
+| Governing record | IL-SAF-01, `docs/compliance/cass15-controls.md` | IL-REC-01 |
+
+The **£0.01** and **£100** thresholds are **NOT competing values of one rule**. They belong to
+two different FCA regimes:
+
+- **£0.01 (CASS 15)** = aggregate-balance *penny-exactness* — does the firm's total client-money
+  position match the statutory safeguarding bank balance to the penny?
+- **£100 (CASS 7.15)** = line-item *HITL escalation* — is a transaction-level discrepancy large
+  enough to require a human (COMPLIANCE_OFFICER) to resolve it rather than auto-recording it?
+
+Collapsing them would be a **compliance behaviour change** and is explicitly out of scope.
+
+## What IS shared — the mechanics core (`src/recon_core/`)
+
+Only the regime-agnostic plumbing, previously duplicated as inline loops in each engine:
+
+| Module | Mechanic | Consumed by |
+|---|---|---|
+| `compare.py` | Decimal-safe `signed_difference` / `absolute_difference` / `within_tolerance` (I-01 guarded) | A `DailyReconciliation`, B `ReconciliationEngineV2` |
+| `breach_evaluator.py` | `BreachEvaluator(threshold, breach_kind)` → `BreachDecision`; **breach ⟺ amount > threshold** (strict) | A (`£0.01`/`BREAK`), B `ReconAgent` (`£100`/`HITL`) |
+| `result.py` | `CoreReconResult` + `evaluate_balances()` — neutral outcome both **map to/from** (does NOT replace `ReconciliationResult` / `ReconciliationReport`) | A `DailyReconciliation` |
+| `audit.py` | `ReconAuditEvent` + `emit_recon_audit()` — normalized, Decimal-string, refs-not-balances audit emit (R-SEC), fail-open | A + B (additive) |
+
+**Thresholds are inputs.** The core enumerates no regimes and holds no threshold constant.
+Each regime injects its own:
+
+```python
+# CASS 15 (src/safeguarding/daily_reconciliation.py)
+BreachEvaluator(threshold=Decimal("0.01"), breach_kind="BREAK")
+
+# CASS 7.15 (services/recon/recon_agent.py)
+BreachEvaluator(threshold=BREACH_HITL_THRESHOLD, breach_kind="HITL")  # Decimal("100")
+```
+
+## Shared boundary rule (equivalence-critical)
+
+Both regimes previously used **strict `>`** for breach and **`<=`** for clear/match. The core
+preserves this exactly:
+
+```
+breach  ⟺  amount  >  threshold     # equal-to-threshold is NOT a breach
+clear   ⟺  amount  <= threshold
+```
+
+This means: CASS 15 still MATCHES at exactly £0.01 and BREAKS above it; CASS 7.15 still returns a
+report at exactly £100 net and escalates to HITL above it. Locked by
+`tests/test_recon_core/test_no_regime_drift.py` and the characterization tests.
+
+## Equivalence guarantee (no-loss)
+
+Characterization tests (`tests/test_recon_core/test_characterization.py`) captured each regime's
+observable behaviour **before** the refactor and stay green **after**. Both routers' pre-existing
+suites (`test_src_safeguarding.py`, `test_recon/`) pass **unchanged**. No public API, endpoint,
+status enum, threshold, FIN060 shape, or HITLProposal shape changed.
+
+## Out of scope (future dedup candidates — NOT touched in S6.2)
+
+`services/recon/breach_detector.py` (streak, £10/3-day), `src/safeguarding/breach_detector.py`
+(severity/streak), `services/recon/recon_engine.py` (£50k HITL_MLRO), and
+`services/recon/reconciliation_engine.py` (£1.00) solve *different* problems (streak detection,
+large-value flagging) and were left untouched to keep this change equivalence-provable.
+
+## Supersedes
+
+This decision **refines and supersedes** the recommendation in
+`docs/audit/SAFEGUARDING-BOUNDARY-AUDIT-2026-06-09.md`, which proposed a *single canonical engine /
+single breach model* that would "eliminate the £0.01/£100 breach divergence". That would merge two
+distinct regulatory regimes. S6.2 instead shares only the **mechanics** and keeps the regimes — and
+their thresholds — deliberately separate.
+
+## Cross-references
+
+- IL-SAF-01 / "ADR-SAF-01" — `docs/architecture/ARCHITECTURE-SAFEGUARDING-ENGINE.md`
+- `docs/compliance/cass15-controls.md` (CASS-02 daily recon, CASS-04 breach notification)
+- ADR-007 (Decimal for money, I-01), ADR-002 (ClickHouse audit log, I-24)

--- a/services/recon/recon_agent.py
+++ b/services/recon/recon_agent.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from datetime import date
 
+from src.recon_core import BreachEvaluator, ReconAuditEvent, emit_recon_audit
+
 from services.recon.reconciliation_engine_v2 import (
     BREACH_HITL_THRESHOLD,
     HITLProposal,
@@ -49,7 +51,25 @@ class ReconAgent:
             statement_entries or [],
         )
 
-        if report.breach_detected and report.net_discrepancy_gbp > BREACH_HITL_THRESHOLD:
+        # CASS 7.15 HITL gate via the shared recon core. breach_kind="HITL" +
+        # BREACH_HITL_THRESHOLD are this regime's injected parameters; the strict
+        # `net > £100` boundary is preserved exactly (== £100 is NOT a breach).
+        evaluator = BreachEvaluator(threshold=BREACH_HITL_THRESHOLD, breach_kind="HITL")
+        decision = evaluator.evaluate(report.net_discrepancy_gbp)
+
+        # Shared audit-trail emit (additive; recon-date ref + magnitude only — R-SEC).
+        emit_recon_audit(
+            ReconAuditEvent.from_magnitude(
+                regime="CASS7.15",
+                recon_ref=report.recon_date,
+                is_breach=report.breach_detected and decision.is_breach,
+                breach_kind=decision.breach_kind,
+                amount=report.net_discrepancy_gbp,
+                threshold=BREACH_HITL_THRESHOLD,
+            )
+        )
+
+        if report.breach_detected and decision.is_breach:
             return self._engine.resolve_breach(report.report_id, "recon_agent")
 
         return report

--- a/services/recon/reconciliation_engine_v2.py
+++ b/services/recon/reconciliation_engine_v2.py
@@ -15,11 +15,18 @@ import logging
 from typing import Protocol
 import uuid
 
+from src.recon_core import within_tolerance
+
 logger = logging.getLogger(__name__)
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
+# CASS 7.15 line-item penny-exact tolerance (per-IBAN MATCHED/DISCREPANCY).
 RECON_TOLERANCE_GBP: Decimal = Decimal("0.01")
+# CASS 7.15 HITL escalation threshold — a DIFFERENT regime parameter from the £0.01
+# tolerance and from CASS 15's aggregate break. Injected into the shared
+# BreachEvaluator by ReconAgent. Deliberately NOT unified — see ADR-SAF-01 and
+# docs/architecture/RECON-CORE-BOUNDARY.md.
 BREACH_HITL_THRESHOLD: Decimal = Decimal("100")
 
 
@@ -166,7 +173,8 @@ class ReconciliationEngineV2:
                 status = "MISSING_LEDGER"
             elif iban not in stmt_map:
                 status = "MISSING_STATEMENT"
-            elif discrepancy <= RECON_TOLERANCE_GBP:
+            elif within_tolerance(ledger_amt, stmt_amt, RECON_TOLERANCE_GBP):
+                # Shared Decimal-safe compare — same |ledger - stmt| <= tolerance rule.
                 status = "MATCHED"
             else:
                 status = "DISCREPANCY"

--- a/src/recon_core/__init__.py
+++ b/src/recon_core/__init__.py
@@ -1,0 +1,43 @@
+"""Shared reconciliation CORE — regime-agnostic safeguarding mechanics.
+
+This package holds the COMMON, regulation-agnostic reconciliation mechanics that
+were previously duplicated across the two safeguarding paths:
+
+  * Router A — ``src.safeguarding.*`` — CASS 15 EMI **aggregate** safeguarding:
+    internal-vs-statutory-bank balance, penny-exact tolerance £0.01 → MATCHED/BREAK.
+  * Router B — ``services.recon.*`` — CASS 7.15 **line-item** reconciliation +
+    HITL breach escalation > £100 → HITLProposal.
+
+CRITICAL BOUNDARY (S6.2):
+  The two paths are DIFFERENT regulatory regimes, NOT competing values of one rule.
+  This core extracts only the shared *mechanics*. Every regulatory threshold is an
+  INPUT, injected by the consuming regime — never unified here:
+
+    * CASS 15   injects threshold=Decimal("0.01"), breach_kind="BREAK"
+    * CASS 7.15 injects threshold=Decimal("100"),  breach_kind="HITL"
+
+  The core deliberately knows nothing about which regime calls it. See
+  ``docs/architecture/RECON-CORE-BOUNDARY.md`` and ADR-SAF-01.
+
+Invariants: I-01 / I-05 — money is Decimal only; serialised as string, never float.
+"""
+
+from __future__ import annotations
+
+from .audit import AuditSink, ReconAuditEvent, emit_recon_audit
+from .breach_evaluator import BreachDecision, BreachEvaluator
+from .compare import absolute_difference, signed_difference, within_tolerance
+from .result import CoreReconResult, evaluate_balances
+
+__all__ = [
+    "absolute_difference",
+    "signed_difference",
+    "within_tolerance",
+    "BreachEvaluator",
+    "BreachDecision",
+    "CoreReconResult",
+    "evaluate_balances",
+    "ReconAuditEvent",
+    "AuditSink",
+    "emit_recon_audit",
+]

--- a/src/recon_core/audit.py
+++ b/src/recon_core/audit.py
@@ -1,0 +1,95 @@
+"""Shared audit-trail emit for reconciliation breach decisions.
+
+A small, regime-agnostic structured-audit primitive both safeguarding paths emit
+through, so the breach-decision audit record has ONE shape. The regime label is an
+input (``"CASS15"`` / ``"CASS7.15"``); the core never decides which regime it is.
+
+R-SEC: the event carries the reconciliation MAGNITUDE (discrepancy / threshold) and
+a recon REFERENCE only — never raw account balances or client PII. Money is
+serialised as a Decimal string (I-01 / I-05), never float.
+
+Emission is additive and side-effect-only: it changes no reconciliation status,
+threshold, or report — it records what was already decided. A caller may inject an
+:class:`AuditSink` (e.g. a ClickHouse writer) or fall back to structured logging.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+import logging
+from typing import Protocol
+
+logger = logging.getLogger("banxe.recon_core.audit")
+
+
+@dataclass(frozen=True)
+class ReconAuditEvent:
+    """Immutable, regime-agnostic reconciliation audit record."""
+
+    regime: str  # injected regime label, e.g. "CASS15" | "CASS7.15"
+    event_type: str  # e.g. "RECON_RESULT"
+    recon_ref: str  # date / id reference — NOT raw balances (R-SEC)
+    is_breach: bool
+    breach_kind: str | None
+    amount_gbp: str  # Decimal as string (I-05)
+    threshold_gbp: str  # Decimal as string (I-05)
+    detail: str = ""
+
+    @classmethod
+    def from_magnitude(
+        cls,
+        regime: str,
+        recon_ref: str,
+        is_breach: bool,
+        breach_kind: str | None,
+        amount: Decimal,
+        threshold: Decimal,
+        event_type: str = "RECON_RESULT",
+        detail: str = "",
+    ) -> ReconAuditEvent:
+        """Build an event from Decimal magnitudes, serialising money to strings."""
+        return cls(
+            regime=regime,
+            event_type=event_type,
+            recon_ref=recon_ref,
+            is_breach=is_breach,
+            breach_kind=breach_kind,
+            amount_gbp=str(amount),
+            threshold_gbp=str(threshold),
+            detail=detail,
+        )
+
+
+class AuditSink(Protocol):
+    """Optional injection point for a durable audit writer (e.g. ClickHouse)."""
+
+    def emit(self, event: ReconAuditEvent) -> None: ...
+
+
+def emit_recon_audit(event: ReconAuditEvent, sink: AuditSink | None = None) -> ReconAuditEvent:
+    """Emit a reconciliation audit event.
+
+    Routes to the injected ``sink`` when provided; otherwise logs a structured line
+    (WARNING for a breach, INFO otherwise). Fail-open: a sink error is logged and
+    swallowed so audit emission can never block a reconciliation run. Returns the
+    event for convenience/testing.
+    """
+    if sink is not None:
+        try:
+            sink.emit(event)
+        except Exception as exc:  # fail-open — audit must not break recon
+            logger.error("recon audit sink failed for %s: %s", event.recon_ref, exc)
+
+    log_fn = logger.warning if event.is_breach else logger.info
+    log_fn(
+        "RECON_AUDIT regime=%s ref=%s breach=%s kind=%s amount=£%s threshold=£%s %s",
+        event.regime,
+        event.recon_ref,
+        event.is_breach,
+        event.breach_kind or "-",
+        event.amount_gbp,
+        event.threshold_gbp,
+        event.detail,
+    )
+    return event

--- a/src/recon_core/breach_evaluator.py
+++ b/src/recon_core/breach_evaluator.py
@@ -1,0 +1,70 @@
+"""Generic, regime-parameterised breach evaluator.
+
+The single breach-decision primitive shared by both safeguarding regimes. It is
+constructed with a ``threshold`` and a ``breach_kind`` LABEL — both injected by
+the caller — and answers one question: does a reconciliation magnitude exceed the
+threshold?
+
+    decision = BreachEvaluator(threshold, breach_kind).evaluate(amount)
+
+Regime wiring (thresholds are INPUTS, never unified — see S6.2 / ADR-SAF-01):
+    * CASS 15   → BreachEvaluator(Decimal("0.01"), "BREAK")  — aggregate penny-exact
+    * CASS 7.15 → BreachEvaluator(Decimal("100"),  "HITL")   — line-item HITL escalation
+
+Boundary semantics (shared, MANDATORY for equivalence):
+    breach  ⟺  amount  >  threshold     (strict — equal-to-threshold is NOT a breach)
+    clear   ⟺  amount  <= threshold
+
+``amount`` is expected to be a non-negative magnitude (an absolute difference or a
+net discrepancy). Invariant I-01: Decimal only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class BreachDecision:
+    """Immutable outcome of a single breach evaluation."""
+
+    is_breach: bool
+    breach_kind: str | None  # the injected regime label, or None when within threshold
+    amount: Decimal
+    threshold: Decimal
+
+
+class BreachEvaluator:
+    """Threshold-parameterised breach gate. Regime-agnostic and stateless."""
+
+    def __init__(self, threshold: Decimal, breach_kind: str) -> None:
+        if not isinstance(threshold, Decimal):
+            raise TypeError(f"threshold must be Decimal, got {type(threshold).__name__} (I-01)")
+        if not breach_kind:
+            raise ValueError("breach_kind must be a non-empty regime label")
+        self._threshold = threshold
+        self._breach_kind = breach_kind
+
+    @property
+    def threshold(self) -> Decimal:
+        return self._threshold
+
+    @property
+    def breach_kind(self) -> str:
+        return self._breach_kind
+
+    def evaluate(self, amount: Decimal) -> BreachDecision:
+        """Return a BreachDecision for ``amount`` against the injected threshold.
+
+        Breach iff ``amount > threshold`` (strict). At or below threshold clears.
+        """
+        if not isinstance(amount, Decimal):
+            raise TypeError(f"amount must be Decimal, got {type(amount).__name__} (I-01)")
+        is_breach = amount > self._threshold
+        return BreachDecision(
+            is_breach=is_breach,
+            breach_kind=self._breach_kind if is_breach else None,
+            amount=amount,
+            threshold=self._threshold,
+        )

--- a/src/recon_core/compare.py
+++ b/src/recon_core/compare.py
@@ -1,0 +1,43 @@
+"""Decimal-safe comparison primitives for safeguarding reconciliation.
+
+Regime-agnostic. These functions encode the ONE arithmetic shared by every
+reconciliation path: compute a signed/absolute difference and test it against a
+penny-exact tolerance. They carry no thresholds and no regulatory meaning — the
+caller supplies the tolerance.
+
+Invariant I-01: money is Decimal only — never float. Each primitive guards its
+inputs so a stray float can never silently corrupt a safeguarding comparison.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def _require_decimal(name: str, value: Decimal) -> None:
+    """Guard: reject non-Decimal money (I-01)."""
+    if not isinstance(value, Decimal):
+        raise TypeError(f"{name} must be Decimal, got {type(value).__name__} (I-01)")
+
+
+def signed_difference(left: Decimal, right: Decimal) -> Decimal:
+    """Return ``left - right`` (signed). Positive ⇒ left exceeds right."""
+    _require_decimal("left", left)
+    _require_decimal("right", right)
+    return left - right
+
+
+def absolute_difference(left: Decimal, right: Decimal) -> Decimal:
+    """Return ``|left - right|`` — the non-negative reconciliation magnitude."""
+    return abs(signed_difference(left, right))
+
+
+def within_tolerance(left: Decimal, right: Decimal, tolerance: Decimal) -> bool:
+    """True iff ``|left - right| <= tolerance`` (penny-exact MATCH semantics).
+
+    Boundary rule (shared by both CASS regimes): a difference EQUAL to the
+    tolerance is *within* tolerance (matched). Only a strictly greater difference
+    is out of tolerance. Mirrors ``not (BreachEvaluator.evaluate(...).is_breach)``.
+    """
+    _require_decimal("tolerance", tolerance)
+    return absolute_difference(left, right) <= tolerance

--- a/src/recon_core/result.py
+++ b/src/recon_core/result.py
@@ -1,0 +1,58 @@
+"""Common reconciliation result value type both regimes map to/from.
+
+``CoreReconResult`` is a neutral, regime-agnostic carrier for a single
+balance-pair reconciliation: the two compared amounts, their signed and absolute
+difference, and the breach decision produced by a :class:`BreachEvaluator`.
+
+It is NOT a replacement for the regime-specific public result types
+(``ReconciliationResult`` for CASS 15, ``ReconciliationReport`` for CASS 7.15).
+Each regime MAPS to/from this internally and keeps its own public schema, status
+enum, and reporting artefacts unchanged.
+
+Invariant I-01: Decimal money only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from .breach_evaluator import BreachEvaluator
+from .compare import signed_difference
+
+
+@dataclass(frozen=True)
+class CoreReconResult:
+    """Neutral outcome of comparing one balance pair under one evaluator."""
+
+    left: Decimal
+    right: Decimal
+    difference: Decimal  # signed: left - right
+    abs_difference: Decimal
+    is_breach: bool
+    breach_kind: str | None
+    threshold: Decimal
+
+
+def evaluate_balances(
+    left: Decimal,
+    right: Decimal,
+    evaluator: BreachEvaluator,
+) -> CoreReconResult:
+    """Compare ``left`` vs ``right`` and classify via ``evaluator``.
+
+    The signed difference (``left - right``) is preserved for the caller (e.g. to
+    tell shortfall from surplus); the breach decision uses the absolute magnitude.
+    """
+    diff = signed_difference(left, right)
+    abs_diff = abs(diff)
+    decision = evaluator.evaluate(abs_diff)
+    return CoreReconResult(
+        left=left,
+        right=right,
+        difference=diff,
+        abs_difference=abs_diff,
+        is_breach=decision.is_breach,
+        breach_kind=decision.breach_kind,
+        threshold=evaluator.threshold,
+    )

--- a/src/safeguarding/daily_reconciliation.py
+++ b/src/safeguarding/daily_reconciliation.py
@@ -24,9 +24,19 @@ from decimal import Decimal
 from enum import Enum
 import logging
 
+from src.recon_core import (
+    BreachEvaluator,
+    ReconAuditEvent,
+    emit_recon_audit,
+    evaluate_balances,
+)
+
 logger = logging.getLogger(__name__)
 
-# CASS 7.15.17R: penny-exact tolerance
+# CASS 7.15.17R: penny-exact tolerance.
+# Regime parameter — injected into the shared BreachEvaluator as breach_kind="BREAK".
+# Deliberately DISTINCT from the CASS 7.15 line-item HITL threshold (£100); see ADR-SAF-01
+# and docs/architecture/RECON-CORE-BOUNDARY.md. Thresholds are inputs, never unified.
 RECON_TOLERANCE_GBP = Decimal("0.01")
 
 
@@ -105,18 +115,24 @@ class DailyReconciliation:
                 notes="External bank statement not yet received.",
             )
 
-        diff = self.internal - self.external
-        abs_diff = abs(diff)
+        # CASS 15 aggregate penny-exact compare via the shared recon core.
+        # breach_kind="BREAK" + tolerance are this regime's injected parameters; the
+        # core stays regime-agnostic. abs_diff > tolerance ⇒ BREAK, else MATCHED —
+        # identical boundary to the previous inline `abs_diff <= tolerance` check.
+        evaluator = BreachEvaluator(threshold=self.tolerance, breach_kind="BREAK")
+        core = evaluate_balances(self.internal, self.external, evaluator)
+        diff = core.difference
+        abs_diff = core.abs_difference
 
-        if abs_diff <= self.tolerance:
-            status = ReconStatus.MATCHED
-            notes = "Reconciliation passed — within penny-exact tolerance."
-        else:
+        if core.is_breach:
             status = ReconStatus.BREAK
             notes = (
                 f"Reconciliation break: £{abs_diff:,.2f} exceeds tolerance £{self.tolerance}. "
                 "Escalate to MLRO + CFO immediately (CASS 7.15.17R)."
             )
+        else:
+            status = ReconStatus.MATCHED
+            notes = "Reconciliation passed — within penny-exact tolerance."
 
         result = ReconciliationResult(
             recon_date=self.recon_date,
@@ -129,4 +145,17 @@ class DailyReconciliation:
 
         log_fn = logger.info if status == ReconStatus.MATCHED else logger.critical
         log_fn("CASS recon: %s", result.summary())
+
+        # Shared audit-trail emit (additive; carries the recon date ref + magnitude,
+        # never raw balances — R-SEC). Does not affect the returned result.
+        emit_recon_audit(
+            ReconAuditEvent.from_magnitude(
+                regime="CASS15",
+                recon_ref=self.recon_date.isoformat(),
+                is_breach=core.is_breach,
+                breach_kind=core.breach_kind,
+                amount=abs_diff,
+                threshold=self.tolerance,
+            )
+        )
         return result

--- a/tests/test_recon_core/test_characterization.py
+++ b/tests/test_recon_core/test_characterization.py
@@ -1,0 +1,140 @@
+"""Characterization tests — lock CURRENT behaviour of BOTH safeguarding paths.
+
+These tests capture the observable compliance behaviour of each regime *before* the
+S6.2 shared-core refactor and MUST stay green *after* it. They are the equivalence
+contract: same inputs → same MATCHED/BREAK/PENDING (CASS 15) and same
+ReconciliationReport/HITLProposal + thresholds (CASS 7.15).
+
+If any assertion here changes, a compliance behaviour has drifted — STOP.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+# ── Router A — CASS 15 aggregate, penny-exact £0.01 ──────────────────────────
+from src.safeguarding.daily_reconciliation import DailyReconciliation, ReconStatus
+
+# ── Router B — CASS 7.15 line-item, HITL £100 ────────────────────────────────
+from services.recon.recon_agent import ReconAgent
+from services.recon.reconciliation_engine_v2 import (
+    HITLProposal,
+    InMemoryReconStore,
+    ReconciliationEngineV2,
+    ReconciliationReport,
+    StatementEntry,
+)
+
+
+def _recon(internal, external):
+    return DailyReconciliation(
+        internal_balance_gbp=Decimal(str(internal)),
+        external_balance_gbp=Decimal(str(external)) if external is not None else None,
+        recon_date=date(2026, 4, 13),
+    ).run()
+
+
+def _stmt(iban, amount):
+    return StatementEntry(
+        entry_id="e",
+        account_iban=iban,
+        amount=Decimal(amount),
+        currency="GBP",
+        value_date="2026-04-21",
+        description="d",
+        transaction_ref="REF",
+    )
+
+
+# ── CASS 15 (Router A) characterization ──────────────────────────────────────
+
+
+class TestCass15Characterization:
+    def test_exact_match_is_matched(self):
+        r = _recon("50000.00", "50000.00")
+        assert r.status == ReconStatus.MATCHED
+        assert r.difference_gbp == Decimal("0.00")
+
+    def test_diff_equal_to_tolerance_is_matched(self):
+        # |0.01| == tolerance → MATCHED (boundary: <= tolerance is within)
+        r = _recon("50000.00", "49999.99")
+        assert r.status == ReconStatus.MATCHED
+        assert r.difference_gbp == Decimal("0.01")
+
+    def test_diff_above_tolerance_is_break(self):
+        r = _recon("50000.00", "49999.98")
+        assert r.status == ReconStatus.BREAK
+        assert r.difference_gbp == Decimal("0.02")
+
+    def test_shortfall_preserves_signed_difference(self):
+        # internal < external → negative signed difference, still BREAK
+        r = _recon("49000.00", "50000.00")
+        assert r.status == ReconStatus.BREAK
+        assert r.difference_gbp == Decimal("-1000.00")
+
+    def test_sub_penny_within_tolerance_is_matched(self):
+        r = _recon("50000.00", "50000.005")
+        assert r.status == ReconStatus.MATCHED
+
+    def test_external_none_is_pending(self):
+        r = _recon("50000.00", None)
+        assert r.status == ReconStatus.PENDING
+        assert r.difference_gbp is None
+        assert r.external_balance_gbp is None
+
+
+# ── CASS 7.15 (Router B) characterization ────────────────────────────────────
+
+
+class TestCass715Characterization:
+    def _agent(self):
+        return ReconAgent(store=InMemoryReconStore())
+
+    def test_matched_returns_report_no_breach(self):
+        result = self._agent().run_daily_recon(
+            "2026-04-21",
+            [{"account_iban": "GB29", "amount": "1000.00"}],
+            [_stmt("GB29", "1000.00")],
+        )
+        assert isinstance(result, ReconciliationReport)
+        assert result.breach_detected is False
+
+    def test_small_breach_returns_report_breach_true(self):
+        result = self._agent().run_daily_recon(
+            "2026-04-21", [{"account_iban": "GB29", "amount": "1000.00"}], [_stmt("GB29", "950.00")]
+        )
+        assert isinstance(result, ReconciliationReport)
+        assert result.breach_detected is True
+
+    def test_net_exactly_100_is_not_hitl(self):
+        # net == BREACH_HITL_THRESHOLD → report (condition is strict >, not >=)
+        result = self._agent().run_daily_recon(
+            "2026-04-21", [{"account_iban": "GB29", "amount": "1000.00"}], [_stmt("GB29", "900.00")]
+        )
+        assert isinstance(result, ReconciliationReport)
+
+    def test_net_over_100_is_hitl(self):
+        result = self._agent().run_daily_recon(
+            "2026-04-21", [{"account_iban": "GB29", "amount": "1000.00"}], [_stmt("GB29", "899.99")]
+        )
+        assert isinstance(result, HITLProposal)
+        assert result.requires_approval_from == "COMPLIANCE_OFFICER"
+        assert result.autonomy_level == "L4"
+
+    @pytest.mark.parametrize(
+        "ledger,stmt,expected_status",
+        [
+            ("1000.00", "1000.00", "MATCHED"),
+            ("1000.00", "999.99", "MATCHED"),  # discrepancy == £0.01 tolerance → MATCHED
+            ("1000.00", "999.98", "DISCREPANCY"),  # > £0.01 → DISCREPANCY
+        ],
+    )
+    def test_line_item_tolerance_boundary(self, ledger, stmt, expected_status):
+        engine = ReconciliationEngineV2(InMemoryReconStore())
+        report = engine.run_daily(
+            "2026-04-21", [{"account_iban": "GB29", "amount": ledger}], [_stmt("GB29", stmt)]
+        )
+        assert report.items[0].status == expected_status

--- a/tests/test_recon_core/test_core_units.py
+++ b/tests/test_recon_core/test_core_units.py
@@ -1,0 +1,173 @@
+"""Unit tests for the shared recon_core mechanics (regime-agnostic)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from src.recon_core import (
+    BreachDecision,
+    BreachEvaluator,
+    CoreReconResult,
+    ReconAuditEvent,
+    absolute_difference,
+    emit_recon_audit,
+    evaluate_balances,
+    signed_difference,
+    within_tolerance,
+)
+
+# ── compare ──────────────────────────────────────────────────────────────────
+
+
+class TestCompare:
+    def test_signed_difference(self):
+        assert signed_difference(Decimal("100"), Decimal("40")) == Decimal("60")
+        assert signed_difference(Decimal("40"), Decimal("100")) == Decimal("-60")
+
+    def test_absolute_difference_non_negative(self):
+        assert absolute_difference(Decimal("40"), Decimal("100")) == Decimal("60")
+
+    def test_within_tolerance_boundary(self):
+        assert within_tolerance(Decimal("100.00"), Decimal("99.99"), Decimal("0.01")) is True
+        assert within_tolerance(Decimal("100.00"), Decimal("99.98"), Decimal("0.01")) is False
+
+    def test_within_tolerance_equal(self):
+        assert within_tolerance(Decimal("5"), Decimal("5"), Decimal("0")) is True
+
+    def test_float_rejected(self):
+        with pytest.raises(TypeError, match="I-01"):
+            signed_difference(100.0, Decimal("1"))  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="I-01"):
+            within_tolerance(Decimal("1"), Decimal("1"), 0.01)  # type: ignore[arg-type]
+
+
+# ── BreachEvaluator ──────────────────────────────────────────────────────────
+
+
+class TestBreachEvaluator:
+    def test_cass15_path_breaks_above_one_penny(self):
+        ev = BreachEvaluator(Decimal("0.01"), "BREAK")
+        assert ev.evaluate(Decimal("0.005")).is_breach is False
+        assert ev.evaluate(Decimal("0.01")).is_breach is False  # boundary: == is clear
+        breach = ev.evaluate(Decimal("0.02"))
+        assert breach.is_breach is True
+        assert breach.breach_kind == "BREAK"
+
+    def test_cass715_path_escalates_above_100(self):
+        ev = BreachEvaluator(Decimal("100"), "HITL")
+        assert ev.evaluate(Decimal("100")).is_breach is False  # boundary: == is clear
+        breach = ev.evaluate(Decimal("100.01"))
+        assert breach.is_breach is True
+        assert breach.breach_kind == "HITL"
+
+    def test_clear_decision_has_no_kind(self):
+        ev = BreachEvaluator(Decimal("0.01"), "BREAK")
+        d = ev.evaluate(Decimal("0.00"))
+        assert isinstance(d, BreachDecision)
+        assert d.breach_kind is None
+        assert d.threshold == Decimal("0.01")
+
+    def test_properties_exposed(self):
+        ev = BreachEvaluator(Decimal("100"), "HITL")
+        assert ev.threshold == Decimal("100")
+        assert ev.breach_kind == "HITL"
+
+    def test_float_threshold_rejected(self):
+        with pytest.raises(TypeError, match="I-01"):
+            BreachEvaluator(0.01, "BREAK")  # type: ignore[arg-type]
+
+    def test_empty_kind_rejected(self):
+        with pytest.raises(ValueError):
+            BreachEvaluator(Decimal("0.01"), "")
+
+    def test_float_amount_rejected(self):
+        ev = BreachEvaluator(Decimal("0.01"), "BREAK")
+        with pytest.raises(TypeError, match="I-01"):
+            ev.evaluate(0.02)  # type: ignore[arg-type]
+
+
+# ── evaluate_balances / CoreReconResult ──────────────────────────────────────
+
+
+class TestEvaluateBalances:
+    def test_signed_difference_preserved_on_shortfall(self):
+        ev = BreachEvaluator(Decimal("0.01"), "BREAK")
+        res = evaluate_balances(Decimal("49000"), Decimal("50000"), ev)
+        assert isinstance(res, CoreReconResult)
+        assert res.difference == Decimal("-1000")  # signed: internal < external
+        assert res.abs_difference == Decimal("1000")
+        assert res.is_breach is True
+        assert res.breach_kind == "BREAK"
+
+    def test_within_tolerance_no_breach(self):
+        ev = BreachEvaluator(Decimal("0.01"), "BREAK")
+        res = evaluate_balances(Decimal("50000.00"), Decimal("49999.99"), ev)
+        assert res.is_breach is False
+        assert res.breach_kind is None
+        assert res.threshold == Decimal("0.01")
+
+
+# ── audit ────────────────────────────────────────────────────────────────────
+
+
+class TestAudit:
+    def test_from_magnitude_serialises_money_to_string(self):
+        ev = ReconAuditEvent.from_magnitude(
+            regime="CASS15",
+            recon_ref="2026-04-13",
+            is_breach=True,
+            breach_kind="BREAK",
+            amount=Decimal("0.02"),
+            threshold=Decimal("0.01"),
+        )
+        assert ev.amount_gbp == "0.02"
+        assert ev.threshold_gbp == "0.01"
+        assert isinstance(ev.amount_gbp, str)
+        # R-SEC: no raw balances on the event, only magnitude + ref
+        assert ev.recon_ref == "2026-04-13"
+
+    def test_emit_without_sink_returns_event(self):
+        ev = ReconAuditEvent.from_magnitude(
+            regime="CASS7.15",
+            recon_ref="r1",
+            is_breach=False,
+            breach_kind=None,
+            amount=Decimal("0"),
+            threshold=Decimal("100"),
+        )
+        assert emit_recon_audit(ev) is ev
+
+    def test_emit_routes_to_sink(self):
+        captured: list[ReconAuditEvent] = []
+
+        class _Sink:
+            def emit(self, event: ReconAuditEvent) -> None:
+                captured.append(event)
+
+        ev = ReconAuditEvent.from_magnitude(
+            regime="CASS15",
+            recon_ref="r2",
+            is_breach=True,
+            breach_kind="BREAK",
+            amount=Decimal("5"),
+            threshold=Decimal("0.01"),
+        )
+        emit_recon_audit(ev, sink=_Sink())
+        assert captured == [ev]
+
+    def test_emit_fail_open_on_sink_error(self):
+        class _BadSink:
+            def emit(self, event: ReconAuditEvent) -> None:
+                raise RuntimeError("clickhouse down")
+
+        ev = ReconAuditEvent.from_magnitude(
+            regime="CASS15",
+            recon_ref="r3",
+            is_breach=True,
+            breach_kind="BREAK",
+            amount=Decimal("5"),
+            threshold=Decimal("0.01"),
+        )
+        # must not raise — audit emission is fail-open
+        assert emit_recon_audit(ev, sink=_BadSink()) is ev

--- a/tests/test_recon_core/test_no_regime_drift.py
+++ b/tests/test_recon_core/test_no_regime_drift.py
@@ -1,0 +1,83 @@
+"""No-regime-drift contract — the two CASS thresholds stay DISTINCT.
+
+S6.2 extracts shared *mechanics* but deliberately does NOT unify the two
+regulatory regimes. This test fails loudly if anyone later collapses the
+£0.01 (CASS 15 aggregate penny-exact) and £100 (CASS 7.15 line-item HITL)
+thresholds into one rule.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from src.recon_core import BreachEvaluator
+from src.safeguarding.daily_reconciliation import (
+    RECON_TOLERANCE_GBP,
+    DailyReconciliation,
+    ReconStatus,
+)
+
+from services.recon.recon_agent import ReconAgent
+from services.recon.reconciliation_engine_v2 import (
+    BREACH_HITL_THRESHOLD,
+    HITLProposal,
+    InMemoryReconStore,
+    ReconciliationReport,
+    StatementEntry,
+)
+
+
+def _stmt(iban, amount):
+    return StatementEntry(
+        entry_id="e",
+        account_iban=iban,
+        amount=Decimal(amount),
+        currency="GBP",
+        value_date="2026-04-21",
+        description="d",
+        transaction_ref="REF",
+    )
+
+
+def test_thresholds_are_distinct_and_unchanged():
+    # The two regimes keep their own, different thresholds — NOT unified.
+    assert Decimal("0.01") == RECON_TOLERANCE_GBP  # CASS 15 aggregate penny-exact
+    assert Decimal("100") == BREACH_HITL_THRESHOLD  # CASS 7.15 line-item HITL
+    assert RECON_TOLERANCE_GBP != BREACH_HITL_THRESHOLD
+
+
+def test_cass15_still_breaks_at_one_penny_not_below():
+    # CASS 15: MATCHED at exactly £0.01, BREAK just above.
+    matched = DailyReconciliation(
+        Decimal("50000.00"), Decimal("49999.99"), recon_date=date(2026, 4, 13)
+    ).run()
+    broken = DailyReconciliation(
+        Decimal("50000.00"), Decimal("49999.98"), recon_date=date(2026, 4, 13)
+    ).run()
+    assert matched.status == ReconStatus.MATCHED
+    assert broken.status == ReconStatus.BREAK
+
+
+def test_cass715_still_escalates_at_100_not_below():
+    # CASS 7.15: report at exactly £100, HITLProposal just above.
+    agent = ReconAgent(store=InMemoryReconStore())
+    at_threshold = agent.run_daily_recon(
+        "2026-04-21", [{"account_iban": "GB29", "amount": "1000.00"}], [_stmt("GB29", "900.00")]
+    )
+    over_threshold = ReconAgent(store=InMemoryReconStore()).run_daily_recon(
+        "2026-04-21", [{"account_iban": "GB29", "amount": "1000.00"}], [_stmt("GB29", "899.99")]
+    )
+    assert isinstance(at_threshold, ReconciliationReport)
+    assert isinstance(over_threshold, HITLProposal)
+
+
+def test_evaluators_carry_each_regimes_own_threshold():
+    # The shared core treats thresholds as injected inputs, never a shared constant.
+    cass15 = BreachEvaluator(RECON_TOLERANCE_GBP, "BREAK")
+    cass715 = BreachEvaluator(BREACH_HITL_THRESHOLD, "HITL")
+    assert cass15.threshold == Decimal("0.01")
+    assert cass715.threshold == Decimal("100")
+    # A £50 discrepancy: a CASS 15 BREAK, but below the CASS 7.15 HITL line.
+    assert cass15.evaluate(Decimal("50")).is_breach is True
+    assert cass715.evaluate(Decimal("50")).is_breach is False


### PR DESCRIPTION
## S6.2 — extract a shared reconciliation CORE from the two safeguarding paths, WITHOUT merging their regulatory regimes

Compliance-sensitive, equivalence-first, no-loss. The £0.01 (CASS 15 aggregate penny-exact) and £100 (CASS 7.15 line-item HITL) thresholds are **different regulatory regimes**, not competing values of one rule — they stay **distinct** and are injected as parameters.

### Shared core (`src/recon_core/`) — regime-agnostic mechanics only
| Module | Mechanic |
|---|---|
| `compare.py` | Decimal-safe `signed_difference` / `absolute_difference` / `within_tolerance` (I-01 guarded) |
| `breach_evaluator.py` | `BreachEvaluator(threshold, breach_kind)` → `BreachDecision`; **breach ⟺ amount > threshold** (strict) |
| `result.py` | `CoreReconResult` + `evaluate_balances()` — neutral, **map to/from** (does NOT replace `ReconciliationResult`/`ReconciliationReport`) |
| `audit.py` | `ReconAuditEvent` + `emit_recon_audit()` — Decimal-string, refs-not-balances (R-SEC), fail-open |

### Both regimes refactored to consume it (thresholds injected, NOT unified)
- **CASS 15** `src/safeguarding/daily_reconciliation.py` → `BreachEvaluator(£0.01, "BREAK")`
- **CASS 7.15** `services/recon/recon_agent.py` + `reconciliation_engine_v2.py` → `BreachEvaluator(£100, "HITL")`

### Equivalence-first (no-loss — MANDATORY)
- Characterization tests lock each regime's pre-refactor behaviour and stay **green** post-refactor.
- Both routers' existing suites (`test_src_safeguarding.py`, `test_recon/`) pass **unchanged**.
- `test_no_regime_drift.py` asserts £0.01 (CASS15) and £100 (CASS7.15) remain distinct.
- **No** public API / endpoint / status enum / threshold / FIN060 / HITLProposal change.

### Boundary
Documented in `docs/architecture/RECON-CORE-BOUNDARY.md` — **supersedes** the prior boundary-audit's "single engine / eliminate £0.01-£100 divergence" recommendation (which would merge two regimes). Cross-ref IL-SAF-01 / ADR-SAF-01, `docs/compliance/cass15-controls.md`.

### Quality
- `ruff format` + `ruff check`: clean
- `bandit`: clean
- `recon_core` coverage: **100%**; full suite: **10362 passed, 37 skipped** (91% total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced shared reconciliation mechanics core used by both CASS 15 and CASS 7.15 regimes, ensuring consistent breach evaluation logic while preserving regime-specific thresholds.
  * Added structured audit event emission for reconciliation decisions, capturing breach status and monetary magnitudes.

* **Tests**
  * Added comprehensive unit and characterization tests for reconciliation core utilities and regime-specific boundary behavior.
  * Added drift-detection tests ensuring CASS 15 (£0.01 tolerance) and CASS 7.15 (£100 HITL threshold) maintain distinct thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->