### PR TITLE
feat(intent-layer): S8 chat→L1→L2→port→lineage HTTP entrypoint + e2e proof

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -74,6 +74,7 @@ from api.routers import (
     hitl,
     hmrc_reporting,
     insurance,
+    intent,
     kyb_onboarding,
     kyc,
     ledger,
@@ -175,6 +176,7 @@ app.include_router(notifications.router, prefix="/v1")
 app.include_router(fraud.router, prefix="/v1")
 app.include_router(consumer_duty.router, prefix="/v1")
 app.include_router(hitl.router, prefix="/v1")
+app.include_router(intent.router, prefix="/v1")  # L1 Intent Layer (ADR-049, S8)
 app.include_router(reporting.router, prefix="/v1")
 app.include_router(statements.router, prefix="/v1")
 app.include_router(watchman_webhook.router)  # POST /webhooks/watchman (IL-068)

--- a/api/routers/intent.py
+++ b/api/routers/intent.py
@@ -1,0 +1,291 @@
+"""
+api/routers/intent.py — L1 Intent Layer HTTP entrypoint (S8).
+
+The first HTTP surface for the ADR-049 client L1 Intent Layer. It is the chat→L1
+seam: a free-form client intent enters here, L1 classifies + routes it, the
+composition root populates the agent inputs from the S5.2 producers and dispatches
+to the in-process L2 mask, and the emitted ADR-046 lineage record is returned and
+made retrievable by ``correlation_id``.
+
+  POST /v1/intent                          — classify + route + dispatch one intent
+  GET  /v1/intent/decision/{correlation_id} — fetch the emitted lineage record
+
+Gating (R-SEC, safe pre-activation): the whole flow sits behind
+``INTENT_LAYER_ENABLED`` (default false). Disabled → a NOT_ENABLED response with NO
+dispatch. The producers default to Null L3 ports (PASS) and the sink is the
+in-memory recorder; the live cross-repo masks, real L3, the S1 LLM gateway and the
+ClickHouse sink are the operator runtime step (do not fabricate a live run).
+
+R-SEC: the request/record carry only the PII-minimised envelope — opaque handles,
+governance metadata and a regulator-legible summary; never secrets or raw PII.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    DecisionRecorder,
+)
+from services.agents._lineage import (
+    ProcessRef as LineageProcessRef,
+)
+from services.agents.notification_agent import (
+    ChannelCheckIntent,
+    NotificationAgent,
+    NotificationMask,
+)
+from services.intent_layer.catalog import IntentCatalog
+from services.intent_layer.classifier import IntentClassifier
+from services.intent_layer.composition import (
+    CapabilityDispatcher,
+    InMemoryDecisionRecorder,
+)
+from services.intent_layer.config import intent_layer_enabled
+from services.intent_layer.models import DispositionKind
+from services.intent_layer.ports import DispatchRequest
+from services.intent_layer.router import IntentRouter
+from services.notifications.notification_provider_port import (
+    DeliveryResult,
+    NotificationChannel,
+    NotificationMessage,
+    NotificationProviderPort,
+    Recipient,
+)
+from services.producers.bundle import ProducerBundle
+from services.producers.ports import DEFAULT_COST_CAP
+
+router = APIRouter(tags=["Intent Layer"])
+
+
+# ── Request / response schemas ───────────────────────────────────────────────
+
+
+class IntentRequest(BaseModel):
+    """A free-form client intent submitted from the chat surface."""
+
+    intent_text: str = Field(..., min_length=1, description="Free-form client intent")
+    correlation_id: str | None = Field(
+        default=None, description="Optional caller-supplied trace id; generated when absent"
+    )
+
+
+class DecisionRecordModel(BaseModel):
+    """Wire form of an ADR-046 ``AgentDecisionRecord`` (mirrors the agent_decision_record
+    schema 1:1; ``cost_amount`` is a Decimal STRING, never a float — I-05)."""
+
+    record_id: str
+    timestamp: str
+    agent_id: str
+    triggering_event: str
+    intent: str
+    policies_evaluated: list[str]
+    compliance_result: str
+    reasoning_summary: str
+    confidence_score: float
+    action_taken: str
+    human_reviewed_by: str | None
+    correlation_id: str
+    cost_tokens: int
+    cost_amount: str
+    budget_window_ref: str
+    budget_breach_flag: str
+    immutable_storage_ref: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+
+class GovernanceEventModel(BaseModel):
+    """Emitted when an intent resolves to no canonical process (ADR-048 D3.3) —
+    HITL / process-gap backlog, never improvised, no dispatch."""
+
+    correlation_id: str
+    status: str = "UNRESOLVED"
+    reason: str
+
+
+class IntentResponse(BaseModel):
+    """The L1 disposition: a dispatched decision record, a governance event, or a
+    safe NOT_ENABLED no-op."""
+
+    enabled: bool
+    disposition: str
+    decision_record: DecisionRecordModel | None = None
+    governance_event: GovernanceEventModel | None = None
+    detail: str | None = None
+
+
+# ── Live composition root (in-process masks + Null producers + in-memory sink) ──
+
+
+class _StubNotificationProvider(NotificationProviderPort):
+    """In-process provider stub for the live demo: the read probe is always
+    reachable, so a channel-availability intent flows end-to-end without live
+    infra. A real adapter replaces it at the operator runtime step."""
+
+    async def send(
+        self, recipient: Recipient, message: NotificationMessage
+    ) -> list[DeliveryResult]:
+        return [DeliveryResult(channel=NotificationChannel.IN_APP, delivered=True, deduped=False)]
+
+    async def is_channel_available(self, channel: NotificationChannel) -> bool:
+        return True
+
+
+def _lineage_ref(process_refs: tuple) -> LineageProcessRef:
+    """Adapt the L1 ``ProcessRef`` to the agents' lineage ``ProcessRef`` (distinct
+    classes by design — L1 must not depend on the agent package's internals)."""
+    primary = process_refs[0]
+    return LineageProcessRef(process_id=primary.process_id, version=primary.version)
+
+
+async def _notifications_handler(
+    request: DispatchRequest, outputs, recorder: DecisionRecorder
+) -> AgentOutcome:
+    """Dispatch a resolved Notifications intent to the real ``NotificationAgent``
+    mask (the low-consequence channel-availability read), passing the producer
+    outputs as the agent inputs (compliance/confidence/cost — not default-PASS)."""
+    agent = NotificationAgent(
+        provider_port=_StubNotificationProvider(),
+        recorder=recorder,
+        mask=NotificationMask(cost_cap=DEFAULT_COST_CAP),
+    )
+    intent = ChannelCheckIntent(
+        intent_text=request.resolved_intent.raw_text,
+        process_ref=_lineage_ref(request.process_refs),
+        channel=NotificationChannel.IN_APP,
+        correlation_id=request.correlation_id,
+        confidence_score=outputs.confidence_score,
+        request_cost=outputs.request_cost,
+    )
+    return await agent.check_channel(intent, compliance_result=outputs.compliance_result)
+
+
+# In-process masks this deployment can dispatch. Payments/FX/Wallet are owned by
+# banxe-payment-core and are reached cross-repo at the operator runtime step;
+# they return an honest "unrouted" receipt here.
+_LIVE_HANDLERS = {"Notifications": _notifications_handler}
+
+# Stable singleton sink so the GET endpoint can resolve a record by the same
+# correlation_id the POST returned (a per-request recorder would lose it).
+_RECORDER = InMemoryDecisionRecorder()
+
+
+@dataclass(frozen=True)
+class _Composition:
+    classifier: IntentClassifier
+    router: IntentRouter
+    recorder: InMemoryDecisionRecorder
+    enabled: bool
+
+
+@lru_cache(maxsize=1)
+def _catalog() -> IntentCatalog:
+    """Resolved intent→process catalogue. Prefers the live S3 files when their
+    paths are supplied (operator wiring); otherwise an embedded snapshot keeps the
+    endpoint self-contained (the canonical map lives in banxe-business-processes)."""
+    from services.intent_layer.catalog_snapshot import load_catalog
+
+    return load_catalog()
+
+
+def get_composition() -> _Composition:
+    """Build the request-time composition. The flag is read fresh each call (safe
+    pre-activation toggling); the catalogue and the lineage sink are singletons."""
+    enabled = intent_layer_enabled()
+    dispatcher = CapabilityDispatcher(
+        handlers=_LIVE_HANDLERS,
+        producers=ProducerBundle.null(),
+        recorder=_RECORDER,
+    )
+    return _Composition(
+        classifier=IntentClassifier(_catalog(), enabled=enabled),
+        router=IntentRouter(dispatcher, enabled=enabled),
+        recorder=_RECORDER,
+        enabled=enabled,
+    )
+
+
+# ── Serialisation ────────────────────────────────────────────────────────────
+
+
+def _to_record_model(record: AgentDecisionRecord) -> DecisionRecordModel:
+    return DecisionRecordModel(
+        record_id=record.record_id,
+        timestamp=record.timestamp.isoformat(),
+        agent_id=record.agent_id,
+        triggering_event=record.triggering_event,
+        intent=record.intent,
+        policies_evaluated=list(record.policies_evaluated),
+        compliance_result=record.compliance_result.value,
+        reasoning_summary=record.reasoning_summary,
+        confidence_score=record.confidence_score,
+        action_taken=record.action_taken,
+        human_reviewed_by=record.human_reviewed_by,
+        correlation_id=record.correlation_id,
+        cost_tokens=record.cost_tokens,
+        cost_amount=str(record.cost_amount),  # Decimal → string (I-05)
+        budget_window_ref=record.budget_window_ref,
+        budget_breach_flag=record.budget_breach_flag.value,
+        immutable_storage_ref=record.immutable_storage_ref,
+        input_tokens=record.input_tokens,
+        output_tokens=record.output_tokens,
+    )
+
+
+# ── Routes ───────────────────────────────────────────────────────────────────
+
+
+@router.post("/intent", response_model=IntentResponse)
+def submit_intent(body: IntentRequest) -> IntentResponse:
+    """Classify + route + dispatch one client intent (chat→L1→L2→port→lineage).
+
+    Synchronous handler by design: FastAPI runs it in the threadpool, so the
+    composition's async L2 masks are driven via ``asyncio.run`` with no nested
+    event loop. Off → NOT_ENABLED (no dispatch). UNRESOLVED → governance event.
+    """
+    comp = get_composition()
+    resolved = comp.classifier.classify(body.intent_text, correlation_id=body.correlation_id)
+    disposition = comp.router.route(resolved)
+
+    if disposition.kind is DispositionKind.NOT_ENABLED:
+        return IntentResponse(enabled=False, disposition="NOT_ENABLED", detail=disposition.reason)
+
+    if disposition.kind is DispositionKind.GOVERNANCE_EVENT:
+        return IntentResponse(
+            enabled=True,
+            disposition="GOVERNANCE_EVENT",
+            governance_event=GovernanceEventModel(
+                correlation_id=disposition.correlation_id,
+                reason=disposition.reason or "intent resolved to no canonical process",
+            ),
+        )
+
+    receipt = disposition.receipt
+    if receipt is None or not getattr(receipt, "accepted", False):
+        detail = getattr(receipt, "detail", None) if receipt else None
+        return IntentResponse(enabled=True, disposition="DISPATCHED", detail=detail)
+
+    record = comp.recorder.get_by_correlation(disposition.correlation_id)
+    return IntentResponse(
+        enabled=True,
+        disposition="DISPATCHED",
+        decision_record=_to_record_model(record) if record else None,
+        detail=getattr(receipt, "detail", None),
+    )
+
+
+@router.get("/intent/decision/{correlation_id}", response_model=DecisionRecordModel)
+def get_decision(correlation_id: str) -> DecisionRecordModel:
+    """Fetch the lineage record emitted for a correlation id (backs the UI
+    decisions.getByCorrelation client). 404 when none was recorded."""
+    record = _RECORDER.get_by_correlation(correlation_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="no decision record for correlation_id")
+    return _to_record_model(record)

--- a/services/intent_layer/catalog_snapshot.py
+++ b/services/intent_layer/catalog_snapshot.py
@@ -1,0 +1,120 @@
+"""
+services/intent_layer/catalog_snapshot.py — self-contained intent catalogue loader.
+
+The canonical intent→process map + registry live in banxe-business-processes
+(``ai-agent-context/intent-process-map.yaml`` + ``processes-registry.json``). The
+HTTP entrypoint must build a catalogue without a hard dependency on that sibling
+repo being present, so this loader:
+
+  1. prefers the live S3 files when their paths are supplied via
+     ``INTENT_PROCESS_MAP_PATH`` + ``INTENT_PROCESS_REGISTRY_PATH`` (operator
+     wiring — always the source of truth when available); else
+  2. falls back to an EMBEDDED SNAPSHOT of the canonical rows, so the endpoint is
+     self-contained in CI / dev.
+
+The snapshot mirrors the canonical capabilities + process_ids; every process
+version is ``1.0.0`` exactly as in the committed registry. It is a convenience
+mirror, NOT a second source of truth — the operator path (1) overrides it.
+"""
+
+from __future__ import annotations
+
+import os
+
+from services.intent_layer.catalog import IntentCatalog
+
+MAP_PATH_ENV = "INTENT_PROCESS_MAP_PATH"
+REGISTRY_PATH_ENV = "INTENT_PROCESS_REGISTRY_PATH"
+
+# Embedded snapshot of the canonical intent→process map (the 9 client-facing
+# capabilities + adjacent card intents). process_ids resolve against the snapshot
+# registry below; versions match the committed processes-registry.json (all 1.0.0).
+_SNAPSHOT_INTENTS = [
+    {
+        "intent": "pay",
+        "aliases": ["transfer", "send money", "make a payment", "move funds"],
+        "capability": "Payments",
+        "process_ids": ["payment-processing-process"],
+    },
+    {
+        "intent": "exchange",
+        "aliases": ["fx", "convert currency", "currency exchange", "swap currency"],
+        "capability": "FX / Exchange",
+        "process_ids": ["fx-exchange"],
+    },
+    {
+        "intent": "view-balance",
+        "aliases": ["check balance", "view balance", "what's my balance", "manage wallet"],
+        "capability": "Wallet",
+        "process_ids": ["wallet-balance-inquiry"],
+    },
+    {
+        "intent": "freeze-card",
+        "aliases": ["block card", "freeze my card", "lock card", "report card lost/stolen"],
+        "capability": "Card (Wallet/Payments-adjacent)",
+        "process_ids": ["card-blocking"],
+    },
+    {
+        "intent": "onboard-kyc",
+        "aliases": ["sign up", "open an account", "register", "complete KYC", "verify identity"],
+        "capability": "KYC onboarding",
+        "process_ids": ["onboarding-process"],
+    },
+    {
+        "intent": "get-statement",
+        "aliases": ["statement", "download statement", "account statement", "get my statement"],
+        "capability": "Statements (ADR-055)",
+        "process_ids": ["statement-generation"],
+    },
+    {
+        "intent": "see-spending",
+        "aliases": ["spending", "spending breakdown", "where did my money go", "insights"],
+        "capability": "Analytics / Reporting (ADR-054)",
+        "process_ids": ["spending-analytics"],
+    },
+    {
+        "intent": "refer-a-friend",
+        "aliases": ["referral", "invite a friend", "refer", "share invite"],
+        "capability": "Referral / CRM",
+        "process_ids": ["referral-management"],
+    },
+    {
+        "intent": "get-notified",
+        "aliases": ["notifications", "alerts", "notify me", "manage notifications"],
+        "capability": "Notifications",
+        "process_ids": ["notification-dispatch"],
+    },
+]
+
+_SNAPSHOT_PROCESS_IDS = [
+    "payment-processing-process",
+    "fx-exchange",
+    "wallet-balance-inquiry",
+    "card-blocking",
+    "onboarding-process",
+    "statement-generation",
+    "spending-analytics",
+    "referral-management",
+    "notification-dispatch",
+]
+
+
+def _snapshot_catalog() -> IntentCatalog:
+    intent_map = {"intents": _SNAPSHOT_INTENTS}
+    registry = {
+        "processes": [{"process_id": pid, "version": "1.0.0"} for pid in _SNAPSHOT_PROCESS_IDS]
+    }
+    return IntentCatalog.from_data(intent_map, registry)
+
+
+def load_catalog(env: dict[str, str] | None = None) -> IntentCatalog:
+    """Load the catalogue: live S3 files when their paths are set, else the snapshot."""
+    source = env if env is not None else os.environ
+    map_path = source.get(MAP_PATH_ENV)
+    registry_path = source.get(REGISTRY_PATH_ENV)
+    if map_path and registry_path:
+        return IntentCatalog.from_files(map_path, registry_path)
+    return _snapshot_catalog()
+
+
+__all__ = ["MAP_PATH_ENV", "REGISTRY_PATH_ENV", "load_catalog"]

--- a/services/intent_layer/composition.py
+++ b/services/intent_layer/composition.py
@@ -1,0 +1,222 @@
+"""
+services/intent_layer/composition.py — L1→L2 composition root (S8).
+
+This is the COMPOSITION ROOT the ADR-049 ports were designed for. The pure layer
+(``classifier``/``router``/``ports``/``models``) never imports it, so the
+dependency is one-way (composition → layer + agents + producers) and the layer
+stays unit-testable in isolation; this module MAY import the L2 agents and the
+S5.2 producers to build the concrete seam implementations.
+
+It provides the two pieces that turn the L1 seam into a working chat→L1→L2→port→
+lineage flow:
+
+  • :class:`InMemoryDecisionRecorder` — a :class:`DecisionRecorder` (ADR-046 sink)
+    that keeps records in memory keyed by ``correlation_id``. It backs the GET
+    lineage endpoint and the in-memory acceptance proof; the ClickHouse sink
+    (ADR-002, S4) is the operator runtime step, injected in its place when live.
+
+  • :class:`CapabilityDispatcher` — an :class:`AgentDispatchPort` that runs the
+    S5.2 :class:`ProducerBundle` (compliance/confidence/cost — REPLACING the
+    agents' default-PASS) and dispatches the resolved intent to the in-process L2
+    mask registered for its capability, capturing the emitted
+    :class:`AgentDecisionRecord`. A capability with no in-process mask (e.g.
+    Payments/FX/Wallet — owned by banxe-payment-core) returns an *unrouted*
+    receipt; the cross-repo dispatch is the operator runtime step.
+
+R-SEC: only opaque handles cross the seam — :class:`ComplianceCheckRequest`
+carries an opaque ``subject_ref`` derived from the correlation id, never PII.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from concurrent.futures import ThreadPoolExecutor
+
+from services.agents._lineage import AgentDecisionRecord, AgentOutcome, DecisionRecorder
+from services.intent_layer.ports import (
+    AgentDispatchPort,
+    DispatchReceipt,
+    DispatchRequest,
+)
+from services.producers.bundle import ProducerBundle, ProducerOutputs
+from services.producers.confidence_scorer import ScoringSignals
+from services.producers.ports import ComplianceCheckRequest
+
+# A capability handler builds the target mask's typed intent from the resolved
+# envelope + the produced inputs, invokes the mask's §D2 chain, and returns the
+# resulting :class:`AgentOutcome` (which always carries an emitted record). It is
+# async because every L2 mask action is async; the dispatcher bridges to sync.
+CapabilityHandler = Callable[
+    [DispatchRequest, ProducerOutputs, DecisionRecorder], Awaitable[AgentOutcome]
+]
+
+# Tokens estimated per L1-dispatched invocation for the cost producer (static
+# default; live S1-gateway accounting overrides it via CostSourcePort when wired).
+_DEFAULT_EST_TOKENS = 256
+
+
+# ── Lineage sink ─────────────────────────────────────────────────────────────
+
+
+class InMemoryDecisionRecorder(DecisionRecorder):
+    """In-memory :class:`DecisionRecorder` — the safe default sink (ADR-046).
+
+    Keyed by ``correlation_id`` so the GET lineage endpoint can resolve a decision
+    by the same id the chat surface holds. The durable ClickHouse sink (S4) is
+    injected in its place when live; the agents depend only on the interface.
+    """
+
+    def __init__(self) -> None:
+        self._by_correlation: dict[str, AgentDecisionRecord] = {}
+        self._by_record: dict[str, AgentDecisionRecord] = {}
+        self._all: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self._by_correlation[record.correlation_id] = record
+        self._by_record[record.record_id] = record
+        self._all.append(record)
+
+    def get_by_correlation(self, correlation_id: str) -> AgentDecisionRecord | None:
+        """Latest record emitted for a correlation id; None when none was recorded."""
+        return self._by_correlation.get(correlation_id)
+
+    @property
+    def records(self) -> list[AgentDecisionRecord]:
+        """All records in emission order (diagnostics / tests)."""
+        return list(self._all)
+
+
+# ── Producer inputs ──────────────────────────────────────────────────────────
+
+
+def _subject_ref(correlation_id: str) -> str:
+    """Opaque, derived subject handle for the compliance check — NEVER PII.
+
+    The real screening identity is resolved L3-side inside an adapter behind
+    :class:`SanctionsIdentityPort`; nothing here threads a name/account number.
+    """
+    return f"subj-{correlation_id}"
+
+
+def default_check_request(request: DispatchRequest) -> ComplianceCheckRequest:
+    """Build the non-PII compliance-check input for a dispatched intent.
+
+    The live router uses this benign default (no sanctions/PEP flags); a wired
+    composition (or a test) injects a builder that derives the risk flags from an
+    upstream structured signal — never by regex-parsing the free-form text.
+    """
+    resolved = request.resolved_intent
+    return ComplianceCheckRequest(
+        action=resolved.matched_intent or request.capability,
+        correlation_id=request.correlation_id,
+        subject_ref=_subject_ref(request.correlation_id),
+    )
+
+
+# ── Async→sync bridge ────────────────────────────────────────────────────────
+
+
+def _run_sync(coro: Awaitable[AgentOutcome]) -> AgentOutcome:
+    """Drive an async mask action to completion from the sync dispatch boundary.
+
+    ``AgentDispatchPort.dispatch`` is synchronous (ADR-049 seam); the masks are
+    async. When called outside an event loop (sync FastAPI route in the
+    threadpool, or a sync test) we use ``asyncio.run``; if a loop is already
+    running we hand the coroutine to a fresh loop on a worker thread so we never
+    nest event loops.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)  # no running loop — safe
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(lambda: asyncio.run(coro)).result()
+
+
+# ── L1 → L2 dispatch ─────────────────────────────────────────────────────────
+
+
+def _cap_key(capability: str) -> str:
+    """Normalise a catalogue capability label to a stable registry key.
+
+    Catalogue labels carry adornments (``"Analytics / Reporting (ADR-054)"``);
+    the key is the lowercased lead token before any ``/`` or ``(`` — so
+    ``"Notifications"`` → ``"notifications"`` and the example above → ``"analytics"``.
+    """
+    head = capability.split("(")[0].split("/")[0]
+    return " ".join(head.lower().split())
+
+
+class CapabilityDispatcher(AgentDispatchPort):
+    """Routes a resolved intent to its in-process L2 mask, populating the agent
+    inputs from the S5.2 producers and capturing the emitted lineage record."""
+
+    def __init__(
+        self,
+        *,
+        handlers: dict[str, CapabilityHandler],
+        producers: ProducerBundle,
+        recorder: DecisionRecorder,
+        check_request_builder: Callable[[DispatchRequest], ComplianceCheckRequest] | None = None,
+        est_tokens: int = _DEFAULT_EST_TOKENS,
+        risk_class: str = "STANDARD",
+    ) -> None:
+        self._handlers = {_cap_key(k): v for k, v in handlers.items()}
+        self._producers = producers
+        self._recorder = recorder
+        self._build_check = check_request_builder or default_check_request
+        self._est_tokens = est_tokens
+        self._risk_class = risk_class
+
+    def dispatch(self, request: DispatchRequest) -> DispatchReceipt:
+        outputs = self._produce(request)
+        handler = self._handlers.get(_cap_key(request.capability))
+        if handler is None:
+            return DispatchReceipt(
+                accepted=False,
+                agent="(unrouted)",
+                detail=(
+                    f"no in-process L2 mask for capability {request.capability!r} "
+                    "(cross-repo masks are the operator runtime step)"
+                ),
+                metadata={"capability_key": _cap_key(request.capability)},
+            )
+        outcome = _run_sync(handler(request, outputs, self._recorder))
+        return self._receipt(outcome)
+
+    def _produce(self, request: DispatchRequest) -> ProducerOutputs:
+        """Run the three producers — the real compliance/confidence/cost inputs
+        that REPLACE the agents' default-PASS (S5.2 audit gap #6)."""
+        signals = ScoringSignals.from_resolved_intent(
+            request.resolved_intent, risk_class=self._risk_class
+        )
+        return self._producers.produce(
+            check_request=self._build_check(request),
+            signals=signals,
+            est_tokens=self._est_tokens,
+        )
+
+    @staticmethod
+    def _receipt(outcome: AgentOutcome) -> DispatchReceipt:
+        record = outcome.record
+        return DispatchReceipt(
+            accepted=True,  # the mask accepted the hand-off and emitted a record
+            agent=record.agent_id,
+            detail=record.action_taken,
+            metadata={
+                "record_id": record.record_id,
+                "correlation_id": record.correlation_id,
+                "compliance_result": str(record.compliance_result),
+                "decision": str(outcome.decision),
+                "executed": str(outcome.executed).lower(),
+            },
+        )
+
+
+__all__ = [
+    "CapabilityDispatcher",
+    "CapabilityHandler",
+    "InMemoryDecisionRecorder",
+    "default_check_request",
+]

--- a/tests/test_api_intent.py
+++ b/tests/test_api_intent.py
@@ -1,0 +1,94 @@
+"""
+tests/test_api_intent.py — HTTP tests for the L1 Intent Layer entrypoint (S8).
+
+Exercises POST /v1/intent + GET /v1/intent/decision/{id} through FastAPI's
+TestClient with the in-memory composition (NullLLM, Null L3 producers, in-memory
+sink). Proves the gate (INTENT_LAYER_ENABLED), the in-process real-mask dispatch
+(Notifications → NotificationAgent), the governance-event path, the honest
+unrouted path (Payments — owned by banxe-payment-core), and lineage retrieval.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import pytest
+
+from api.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture()
+def enabled(monkeypatch) -> None:
+    monkeypatch.setenv("INTENT_LAYER_ENABLED", "true")
+
+
+@pytest.fixture()
+def disabled(monkeypatch) -> None:
+    monkeypatch.setenv("INTENT_LAYER_ENABLED", "false")
+
+
+def test_disabled_returns_not_enabled_no_dispatch(disabled):
+    resp = client.post(
+        "/v1/intent", json={"intent_text": "notifications", "correlation_id": "c-off-1"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is False
+    assert body["disposition"] == "NOT_ENABLED"
+    assert body["decision_record"] is None
+    # No record was emitted while disabled.
+    assert client.get("/v1/intent/decision/c-off-1").status_code == 404
+
+
+def test_enabled_notifications_dispatches_real_mask(enabled):
+    resp = client.post(
+        "/v1/intent", json={"intent_text": "notifications", "correlation_id": "c-notif-1"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    assert body["disposition"] == "DISPATCHED"
+    record = body["decision_record"]
+    assert record is not None
+    assert record["agent_id"] == "notification_agent"
+    assert record["action_taken"] == "CHECK_CHANNEL_AVAILABLE"
+    assert record["compliance_result"] == "PASS"
+    # cost_amount is a Decimal STRING — never a float (I-05).
+    assert isinstance(record["cost_amount"], str)
+
+
+def test_get_decision_retrieves_emitted_record(enabled):
+    client.post("/v1/intent", json={"intent_text": "alerts", "correlation_id": "c-get-1"})
+    resp = client.get("/v1/intent/decision/c-get-1")
+    assert resp.status_code == 200
+    assert resp.json()["correlation_id"] == "c-get-1"
+
+
+def test_unresolved_intent_returns_governance_event(enabled):
+    resp = client.post(
+        "/v1/intent", json={"intent_text": "zxcvbnm nonsense", "correlation_id": "c-unres-1"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["disposition"] == "GOVERNANCE_EVENT"
+    assert body["decision_record"] is None
+    assert body["governance_event"]["status"] == "UNRESOLVED"
+
+
+def test_payments_is_unrouted_in_process(enabled):
+    """Payments is owned by banxe-payment-core — honestly unrouted in-process, no record."""
+    resp = client.post("/v1/intent", json={"intent_text": "pay", "correlation_id": "c-pay-1"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["disposition"] == "DISPATCHED"
+    assert body["decision_record"] is None
+    assert "no in-process L2 mask" in body["detail"]
+
+
+def test_get_decision_missing_returns_404(enabled):
+    assert client.get("/v1/intent/decision/does-not-exist").status_code == 404
+
+
+def test_empty_intent_text_is_rejected(enabled):
+    assert client.post("/v1/intent", json={"intent_text": ""}).status_code == 422

--- a/tests/test_intent_layer/test_composition.py
+++ b/tests/test_intent_layer/test_composition.py
@@ -1,0 +1,160 @@
+"""
+tests/test_intent_layer/test_composition.py — unit tests for the S8 composition root.
+
+Covers the seam pieces directly: the in-memory lineage sink, the unrouted-capability
+receipt, the live-file catalogue loader, and the async→sync bridge under a running
+event loop (so dispatch works from both sync and async callers).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+)
+from services.intent_layer.catalog_snapshot import (
+    MAP_PATH_ENV,
+    REGISTRY_PATH_ENV,
+    load_catalog,
+)
+from services.intent_layer.composition import (
+    CapabilityDispatcher,
+    InMemoryDecisionRecorder,
+    default_check_request,
+)
+from services.intent_layer.models import (
+    IntentStatus,
+    MatchSource,
+    ProcessRef,
+    ResolvedIntent,
+)
+from services.intent_layer.ports import DispatchRequest
+from services.producers.bundle import ProducerBundle
+from services.producers.confidence_scorer import ScoringSignals
+
+
+def _resolved(capability: str = "Notifications") -> ResolvedIntent:
+    return ResolvedIntent(
+        raw_text="notifications",
+        correlation_id="corr-x",
+        status=IntentStatus.RESOLVED,
+        confidence=1.0,
+        match_source=MatchSource.ALIAS,
+        matched_intent="get-notified",
+        capability=capability,
+        process_refs=(ProcessRef(process_id="notification-dispatch", version="1.0.0"),),
+    )
+
+
+def _request(capability: str = "Notifications") -> DispatchRequest:
+    r = _resolved(capability)
+    return DispatchRequest(
+        capability=capability,
+        process_refs=r.process_refs,
+        resolved_intent=r,
+        correlation_id=r.correlation_id,
+    )
+
+
+async def _ok_handler(request, outputs, recorder) -> AgentOutcome:
+    record = AgentDecisionRecord(
+        record_id=str(uuid.uuid4()),
+        timestamp=datetime.now(UTC),
+        agent_id="unit_agent",
+        triggering_event="unit",
+        intent=request.resolved_intent.raw_text,
+        policies_evaluated=["ADR-048-process-resolution"],
+        compliance_result=ComplianceResult.PASS,
+        reasoning_summary="ok",
+        confidence_score=outputs.confidence_score,
+        action_taken="UNIT_OK",
+        human_reviewed_by=None,
+        correlation_id=request.correlation_id,
+        cost_tokens=outputs.request_cost.tokens,
+        cost_amount=outputs.request_cost.cost,
+        budget_window_ref="unit:default",
+        budget_breach_flag=BudgetBreach.NONE,
+    )
+    await recorder.record(record)
+    return AgentOutcome(decision=ConfirmationDecision.AUTO, executed=True, record=record)
+
+
+async def test_in_memory_recorder_keys_by_correlation():
+    recorder = InMemoryDecisionRecorder()
+    assert recorder.get_by_correlation("nope") is None
+    await _ok_handler(_request(), _stub_outputs(), recorder)
+    rec = recorder.get_by_correlation("corr-x")
+    assert rec is not None and rec.action_taken == "UNIT_OK"
+    assert len(recorder.records) == 1
+
+
+def _stub_outputs():
+    return ProducerBundle.null().produce(
+        check_request=default_check_request(_request()),
+        signals=ScoringSignals.from_resolved_intent(_resolved()),
+        est_tokens=128,
+    )
+
+
+def test_unrouted_capability_returns_not_accepted_receipt():
+    dispatcher = CapabilityDispatcher(
+        handlers={"Notifications": _ok_handler},
+        producers=ProducerBundle.null(),
+        recorder=InMemoryDecisionRecorder(),
+    )
+    receipt = dispatcher.dispatch(_request(capability="Payments"))
+    assert receipt.accepted is False
+    assert receipt.agent == "(unrouted)"
+    assert "no in-process L2 mask" in (receipt.detail or "")
+
+
+def test_dispatch_from_sync_context_runs_handler():
+    recorder = InMemoryDecisionRecorder()
+    dispatcher = CapabilityDispatcher(
+        handlers={"Notifications": _ok_handler},
+        producers=ProducerBundle.null(),
+        recorder=recorder,
+    )
+    receipt = dispatcher.dispatch(_request())
+    assert receipt.accepted is True
+    assert recorder.get_by_correlation("corr-x") is not None
+
+
+async def test_dispatch_bridges_under_running_event_loop():
+    """dispatch() is sync but is invoked here from inside a running loop — the
+    async→sync bridge must hand the coroutine to a worker thread, not nest loops."""
+    recorder = InMemoryDecisionRecorder()
+    dispatcher = CapabilityDispatcher(
+        handlers={"Notifications": _ok_handler},
+        producers=ProducerBundle.null(),
+        recorder=recorder,
+    )
+    receipt = dispatcher.dispatch(_request())  # called within the test's event loop
+    assert receipt.accepted is True
+    assert recorder.get_by_correlation("corr-x").action_taken == "UNIT_OK"
+
+
+def test_load_catalog_prefers_live_files(map_files):
+    map_path, registry_path = map_files
+    catalog = load_catalog(env={MAP_PATH_ENV: map_path, REGISTRY_PATH_ENV: registry_path})
+    definition = catalog.lookup("pay")
+    assert definition is not None
+    assert definition.capability == "Payments"
+
+
+def test_load_catalog_falls_back_to_snapshot():
+    catalog = load_catalog(env={})  # no file paths → embedded snapshot
+    assert catalog.lookup("notifications").capability == "Notifications"
+    assert catalog.lookup("pay").process_refs[0].version == "1.0.0"
+
+
+def test_decimal_money_preserved_through_recorder():
+    outputs = _stub_outputs()
+    assert isinstance(outputs.request_cost.cost, Decimal)

--- a/tests/test_intent_layer/test_e2e_chat_to_lineage.py
+++ b/tests/test_intent_layer/test_e2e_chat_to_lineage.py
@@ -1,0 +1,455 @@
+"""
+tests/test_intent_layer/test_e2e_chat_to_lineage.py — S8 ACCEPTANCE PROOF.
+
+Drives a client intent string through the REAL chat→L1→L2→port→lineage chain with
+an entirely in-memory stack — NO live models, NO network, NO ClickHouse:
+
+  L1 classify (deterministic, NullLLM)
+    → IntentRouter.route
+      → CapabilityDispatcher runs the REAL S5.2 producers (compliance/confidence/
+        cost — NOT default-PASS) and dispatches to an L2 mask
+        → the mask runs its real ADR-049 §D2 gate-chain
+          → emits exactly one ADR-046 AgentDecisionRecord to the in-memory sink
+            → the record is retrievable by correlation_id and shape-valid.
+
+Three required cases + one real-mask flow:
+  (i)   "pay Alice £10"        → classify→route→Payments mask→PASS record
+                                 (action + compliance + process_ref present);
+  (ii)  a sanctions-hit intent → FAIL/ESCALATE record (producers real: a real
+                                 ComplianceProducer + a sanctions check that FAILs);
+  (iii) an UNRESOLVED intent   → governance event, NO dispatch (dispatcher untouched);
+  (iv)  a real NotificationAgent mask flows through the SAME dispatcher (proving
+        the wiring drives real masks, not only the faithful test mask).
+
+The faithful test Payments mask mirrors the canonical §D2 chain (the same one
+``services/agents/cards_agent.py`` and banxe-payment-core's ``payments_agent.py``
+enforce) and uses the shared ``services/agents/_lineage`` primitives, so the
+emitted record is the real schema. Live cross-repo Payments dispatch + real L3 +
+the ClickHouse sink are the operator runtime step (not fabricated here).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    RequestCost,
+)
+from services.agents._lineage import (
+    ProcessRef as LineageProcessRef,
+)
+from services.intent_layer.classifier import IntentClassifier
+from services.intent_layer.composition import (
+    CapabilityDispatcher,
+    InMemoryDecisionRecorder,
+)
+from services.intent_layer.models import DispositionKind, IntentStatus
+from services.intent_layer.ports import DispatchRequest
+from services.intent_layer.router import IntentRouter
+from services.producers.bundle import ProducerBundle
+from services.producers.compliance_producer import ComplianceProducer
+from services.producers.confidence_scorer import ConfidenceScorer
+from services.producers.cost_estimator import CostEstimator
+from services.producers.ports import (
+    DEFAULT_COST_CAP,
+    CheckOutcome,
+    ComplianceCheckRequest,
+)
+
+# ── A faithful test Payments mask (real ADR-049 §D2 chain) ───────────────────
+
+
+@dataclass
+class _PayIntent:
+    intent_text: str
+    process_ref: LineageProcessRef
+    amount: Decimal
+    currency: str
+    recipient_ref: str  # opaque handle — never a name (R-SEC)
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass(frozen=True)
+class _PayMask:
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    agent_id: str = "payments_agent"
+    aml_role: str = "AML"
+    scope: tuple[str, ...] = ("PaymentPort.pay",)
+    compliance_gate: tuple[str, ...] = ("AML",)
+
+
+class _StubPaymentPort:
+    """In-memory payment port — accepts the bounded transfer, returns an opaque ref."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Decimal, str]] = []
+
+    async def pay(self, amount: Decimal, currency: str, recipient_ref: str) -> str:
+        self.calls.append((amount, currency))
+        return f"pay-receipt:{recipient_ref}"
+
+
+class _PaymentsTestAgent:
+    """Minimal but FAITHFUL Payments mask: enforces the fixed §D2 order
+    (process_ref → scope → band → cost_cap → compliance → port) and emits exactly
+    one ADR-046 record on every exit path, exactly like the real masks."""
+
+    def __init__(self, *, port: _StubPaymentPort, recorder: DecisionRecorder, mask: _PayMask):
+        self._port = port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    async def pay(
+        self, intent: _PayIntent, *, compliance_result: ComplianceResult = ComplianceResult.PASS
+    ) -> AgentOutcome:
+        policies = ["ADR-048-process-resolution", "ADR-049-scope-allow-list"]
+        op = "PaymentPort.pay"
+        # 1+2. process_ref + scope
+        if not intent.process_ref.resolved or op not in self._mask.scope:
+            return await self._emit(
+                intent,
+                ConfirmationDecision.BLOCK,
+                "HALT_PROCESS_OR_SCOPE",
+                "Unresolved process_ref or out-of-scope op.",
+                policies,
+                ComplianceResult.NA,
+                executed=False,
+                escalated_to=None,
+            )
+        # 3. band
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(intent.confidence_score)
+        if band is not ConfirmationDecision.AUTO:
+            return await self._emit(
+                intent,
+                band,
+                "HOLD_FOR_REVIEW",
+                "Below AUTO band; HITL required.",
+                policies,
+                compliance_result,
+                executed=False,
+                escalated_to=None,
+            )
+        # 4. cost cap
+        policies.append("ADR-047-cost-cap")
+        cap = self._mask.cost_cap
+        if (
+            intent.request_cost.tokens > cap.max_request_tokens
+            or intent.request_cost.cost > cap.max_request_cost
+        ):
+            return await self._emit(
+                intent,
+                ConfirmationDecision.BLOCK,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach.",
+                policies,
+                ComplianceResult.NA,
+                executed=False,
+                escalated_to=None,
+                breach=BudgetBreach.BREACH,
+            )
+        # 5. compliance gate (the producer-supplied verdict — never default-PASS)
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            return await self._emit(
+                intent,
+                ConfirmationDecision.BLOCK,
+                "HALT_COMPLIANCE_BLOCK",
+                f"AML overlay returned {compliance_result}; blocked + escalated.",
+                policies,
+                compliance_result,
+                executed=False,
+                escalated_to=self._mask.aml_role,
+            )
+        # 6. commit
+        await self._port.pay(intent.amount, intent.currency, intent.recipient_ref)
+        self._window.add(intent.request_cost)
+        return await self._emit(
+            intent,
+            band,
+            "APPROVE_PAYMENT",
+            "All §D2 gates satisfied; committing.",
+            policies,
+            compliance_result,
+            executed=True,
+            escalated_to=None,
+        )
+
+    async def _emit(
+        self,
+        intent,
+        decision,
+        action,
+        reasoning,
+        policies,
+        compliance_result,
+        *,
+        executed,
+        escalated_to,
+        breach=BudgetBreach.NONE,
+    ) -> AgentOutcome:
+        from datetime import UTC, datetime
+        import uuid
+
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=f"pay:{intent.recipient_ref}",
+            intent=intent.intent_text,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=intent.confidence_score,
+            action_taken=action,
+            human_reviewed_by=None,
+            correlation_id=intent.correlation_id,
+            cost_tokens=intent.request_cost.tokens,
+            cost_amount=intent.request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return AgentOutcome(
+            decision=decision, executed=executed, record=record, escalated_to=escalated_to
+        )
+
+
+# ── Dispatcher wiring (handler + sanctions stub + composition builder) ────────
+
+
+def _payments_handler(request: DispatchRequest, outputs, recorder: DecisionRecorder):
+    pr = request.process_refs[0]
+    agent = _PaymentsTestAgent(
+        port=_StubPaymentPort(),
+        recorder=recorder,
+        mask=_PayMask(cost_cap=DEFAULT_COST_CAP),
+    )
+    intent = _PayIntent(
+        intent_text=request.resolved_intent.raw_text,
+        process_ref=LineageProcessRef(process_id=pr.process_id, version=pr.version),
+        amount=Decimal("10.00"),
+        currency="GBP",
+        recipient_ref=f"rcpt-{request.correlation_id}",
+        correlation_id=request.correlation_id,
+        confidence_score=outputs.confidence_score,
+        request_cost=outputs.request_cost,
+    )
+    return agent.pay(intent, compliance_result=outputs.compliance_result)
+
+
+class _SanctionsFail:
+    """A sanctions check that FAILs when the upstream structured signal flags a hit
+    (proves the produced verdict is REAL, not the agents' default-PASS)."""
+
+    def check(self, request: ComplianceCheckRequest) -> CheckOutcome:
+        if request.is_sanctions_hit:
+            return CheckOutcome(
+                result=ComplianceResult.FAIL,
+                ref="sanctions:hit",
+                reason_codes=("SANCTIONS_CONFIRMED",),
+            )
+        return CheckOutcome(result=ComplianceResult.PASS, ref="sanctions:clear")
+
+
+def _sanctions_check_builder(request: DispatchRequest) -> ComplianceCheckRequest:
+    """Represents the upstream structured sanctions signal (NOT free-text parsing)."""
+    return ComplianceCheckRequest(
+        action=request.resolved_intent.matched_intent or request.capability,
+        correlation_id=request.correlation_id,
+        subject_ref=f"subj-{request.correlation_id}",
+        is_sanctions_hit=True,
+    )
+
+
+class _CountingDispatcher:
+    """Wraps a dispatcher to assert (iii) does NOT dispatch."""
+
+    def __init__(self, inner: CapabilityDispatcher) -> None:
+        self._inner = inner
+        self.calls = 0
+
+    def dispatch(self, request: DispatchRequest):
+        self.calls += 1
+        return self._inner.dispatch(request)
+
+
+def _benign_producers() -> ProducerBundle:
+    return ProducerBundle.null()  # Null L3 ports → PASS
+
+
+def _sanctions_producers() -> ProducerBundle:
+    return ProducerBundle(
+        compliance=ComplianceProducer(sanctions=_SanctionsFail()),
+        confidence=ConfidenceScorer(),
+        cost=CostEstimator(cost_cap=DEFAULT_COST_CAP),
+    )
+
+
+def _build_chain(catalog, *, handlers, producers, check_builder=None):
+    recorder = InMemoryDecisionRecorder()
+    inner = CapabilityDispatcher(
+        handlers=handlers,
+        producers=producers,
+        recorder=recorder,
+        check_request_builder=check_builder,
+    )
+    dispatcher = _CountingDispatcher(inner)
+    classifier = IntentClassifier(catalog, enabled=True)
+    router = IntentRouter(dispatcher, enabled=True)
+    return classifier, router, recorder, dispatcher
+
+
+# ── (i) pay → Payments mask → PASS record ────────────────────────────────────
+
+
+def test_pay_intent_flows_chat_to_lineage(catalog):
+    classifier, router, recorder, dispatcher = _build_chain(
+        catalog, handlers={"Payments": _payments_handler}, producers=_benign_producers()
+    )
+
+    resolved = classifier.classify("pay", correlation_id="corr-pay-1")
+    assert resolved.status is IntentStatus.RESOLVED
+    assert resolved.capability == "Payments"
+
+    disposition = router.route(resolved)
+    assert disposition.kind is DispositionKind.DISPATCHED
+    assert dispatcher.calls == 1
+
+    record = recorder.get_by_correlation("corr-pay-1")
+    assert record is not None
+    # (i) record carries action + compliance + process_ref-derived lineage
+    assert record.action_taken == "APPROVE_PAYMENT"
+    assert record.compliance_result is ComplianceResult.PASS
+    assert "ADR-048-process-resolution" in record.policies_evaluated
+    assert record.agent_id == "payments_agent"
+    assert record.correlation_id == "corr-pay-1"
+
+
+# ── (ii) sanctions-hit → FAIL/ESCALATE record (producers REAL) ────────────────
+
+
+def test_sanctions_hit_yields_fail_escalate_record(catalog):
+    classifier, router, recorder, _ = _build_chain(
+        catalog,
+        handlers={"Payments": _payments_handler},
+        producers=_sanctions_producers(),
+        check_builder=_sanctions_check_builder,
+    )
+
+    resolved = classifier.classify("send money", correlation_id="corr-sanction-1")
+    disposition = router.route(resolved)
+    assert disposition.kind is DispositionKind.DISPATCHED
+
+    record = recorder.get_by_correlation("corr-sanction-1")
+    assert record is not None
+    # The verdict was PRODUCED (real ComplianceProducer + sanctions FAIL), not default-PASS.
+    assert record.compliance_result in (ComplianceResult.FAIL, ComplianceResult.ESCALATE)
+    assert record.action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert record.escalated_to == "AML"
+    assert disposition.receipt is not None
+    assert disposition.receipt.metadata["executed"] == "false"
+
+
+# ── (iii) UNRESOLVED → governance event, NO dispatch ─────────────────────────
+
+
+def test_unresolved_intent_yields_governance_event_no_dispatch(catalog):
+    classifier, router, recorder, dispatcher = _build_chain(
+        catalog, handlers={"Payments": _payments_handler}, producers=_benign_producers()
+    )
+
+    resolved = classifier.classify("flibbertigibbet quux", correlation_id="corr-unresolved-1")
+    assert resolved.status is IntentStatus.UNRESOLVED
+
+    disposition = router.route(resolved)
+    assert disposition.kind is DispositionKind.GOVERNANCE_EVENT
+    assert dispatcher.calls == 0  # NO dispatch
+    assert recorder.records == []  # NO lineage record emitted
+    assert disposition.reason is not None
+
+
+# ── (iv) a REAL NotificationAgent mask flows through the SAME dispatcher ──────
+
+
+def test_real_notification_mask_flows_through_dispatcher(catalog):
+    from api.routers.intent import _notifications_handler  # the real-mask handler
+
+    classifier, router, recorder, dispatcher = _build_chain(
+        catalog,
+        handlers={"Notifications": _notifications_handler},
+        producers=_benign_producers(),
+    )
+
+    resolved = classifier.classify("notifications", correlation_id="corr-notif-1")
+    assert resolved.capability == "Notifications"
+
+    disposition = router.route(resolved)
+    assert disposition.kind is DispositionKind.DISPATCHED
+    record = recorder.get_by_correlation("corr-notif-1")
+    assert record is not None
+    assert record.agent_id == "notification_agent"
+    assert record.action_taken == "CHECK_CHANNEL_AVAILABLE"
+    assert record.compliance_result is ComplianceResult.PASS
+
+
+# ── record shape validity (matches the agent_decision_record schema fields) ───
+
+_REQUIRED_RECORD_FIELDS = (
+    "record_id",
+    "timestamp",
+    "agent_id",
+    "triggering_event",
+    "intent",
+    "policies_evaluated",
+    "compliance_result",
+    "reasoning_summary",
+    "confidence_score",
+    "action_taken",
+    "human_reviewed_by",
+    "correlation_id",
+    "cost_tokens",
+    "cost_amount",
+    "budget_window_ref",
+    "budget_breach_flag",
+)
+
+
+@pytest.mark.parametrize("text,cid", [("pay", "corr-shape-1")])
+def test_emitted_record_is_schema_shape_valid(catalog, text, cid):
+    classifier, router, recorder, _ = _build_chain(
+        catalog, handlers={"Payments": _payments_handler}, producers=_benign_producers()
+    )
+    router.route(classifier.classify(text, correlation_id=cid))
+    record = recorder.get_by_correlation(cid)
+
+    for field_name in _REQUIRED_RECORD_FIELDS:
+        assert hasattr(record, field_name), f"record missing required field {field_name}"
+    # I-05: money is Decimal, never float.
+    assert isinstance(record.cost_amount, Decimal)
+    assert isinstance(record.compliance_result, ComplianceResult)
+    assert 0.0 <= record.confidence_score <= 1.0


### PR DESCRIPTION
## S8 (final): chat-first convergence — backend wiring

Wires the existing layers end-to-end (no new layer): **L1 Intent Layer (S5.1) → L2 client-facing masks → port → ADR-046 lineage**, exposes the first HTTP surface, and proves the chain in-memory.

### What's here
- **`api/routers/intent.py`** — `POST /v1/intent` (classify → route → dispatch) and `GET /v1/intent/decision/{correlation_id}` (lineage retrieval). Gated behind `INTENT_LAYER_ENABLED` (off → `NOT_ENABLED`, no dispatch — safe pre-activation). Sync handler so the async masks run via the composition's async→sync bridge with no nested event loop.
- **`services/intent_layer/composition.py`** — the composition root: `InMemoryDecisionRecorder` (ADR-046 sink) + `CapabilityDispatcher` (`AgentDispatchPort`) that runs the **S5.2 `ProducerBundle`** (compliance/confidence/cost — **replacing the agents' default-PASS**) and dispatches to the in-process L2 mask by capability, capturing the emitted record.
- **`services/intent_layer/catalog_snapshot.py`** — self-contained intent→process catalogue (live S3 files when `INTENT_PROCESS_MAP_PATH`/`INTENT_PROCESS_REGISTRY_PATH` are set, else an embedded snapshot mirroring the canonical map; all versions `1.0.0`).
- **Notifications** wired to the **real `NotificationAgent` mask** (channel-availability read) → a genuine in-process chat→L1→L2→port→lineage flow over HTTP. **Payments/FX/Wallet** are owned by banxe-payment-core → honest **"unrouted"** receipt (cross-repo dispatch is the operator runtime step).

### Acceptance proof (in-memory, no live infra)
`tests/test_intent_layer/test_e2e_chat_to_lineage.py`:
- **(i)** `"pay"` → classify → route → Payments mask → **PASS** record with action + compliance + process_ref;
- **(ii)** sanctions-hit → **FAIL/ESCALATE** record from a **real `ComplianceProducer`** (+ a sanctions check that FAILs) — not default-PASS;
- **(iii)** UNRESOLVED → **governance event, NO dispatch** (dispatcher untouched, no record emitted).
- Plus: a real `NotificationAgent` mask flowing through the same dispatcher, and a record-shape check (agent_decision_record fields, `cost_amount` Decimal).

`tests/test_api_intent.py` covers the HTTP gate (disabled/enabled), real-mask dispatch, governance event, unrouted Payments, and GET retrieval/404.

### Operator runtime step (NOT fabricated here)
S1 LLM gateway + `INTENT_LAYER_ENABLED=true` + real L3 adapters (`services/producers/adapters.py`) + the ClickHouse decision sink in place of the in-memory recorder.

### Quality
- Money is `Decimal` throughout (I-05); no float on any cost/amount.
- `ruff check` + `ruff format` clean; `semgrep --config .semgrep/banxe-rules.yml` 0 findings.
- New modules ~97–99% covered; 65 intent tests + 355-test regression sweep (producers/agents/intent_layer/api) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added Intent Layer API (`POST /v1/intent`) to submit free-form intents and receive dispatched decisions or governance events for unresolved intents
- Added decision record retrieval endpoint (`GET /v1/intent/decision/{correlation_id}`)
- Intent routing dispatches requests to appropriate handlers with decision tracking and lineage recording

## Chores
- Intent Layer functionality is configurable and can be toggled via environment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->