### PR TITLE
feat(cfo-agents): TreasuryAgent + ForecastAgent + treasury/forecast ports (sprint-46 / ADR-078 / IL-172)

### DIFF
--- a/services/agents/forecast_agent.py
+++ b/services/agents/forecast_agent.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import datetime
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.treasury.liquidity_forecast_port import (
+    LiquidityForecastPort,
+    LiquidityForecastPortError,
+)
+
+
+@dataclass(frozen=True)
+class ForecastMask:
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    lineage_obligation: bool = True
+    agent_id: str = "forecast_agent"
+    scope: tuple[str, ...] = (
+        "LiquidityForecastPort.get_forecast_inputs",
+        "LiquidityForecastPort.get_current_position",
+    )
+    compliance_gate: tuple[str, ...] = ("FINANCIAL_DATA",)
+    review_role: str = "HEAD_OF_FPA"
+
+
+@dataclass(frozen=True)
+class BuildLiquidityForecastIntent:
+    intent_text: str
+    process_ref: ProcessRef
+    horizon_days: int
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass(frozen=True)
+class GetLiquidityPositionIntent:
+    intent_text: str
+    process_ref: ProcessRef
+    as_of: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass(frozen=True)
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies_evaluated: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+@dataclass
+class _ActionContext:
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+    human_reviewed_by: str | None
+
+
+class ForecastAgent:
+    """L2 Review agent for liquidity forecast inputs and current position reads.
+
+    Band thresholds: AUTO >= 0.90; REVIEW 0.70–0.90; BLOCK < 0.70.
+    REVIEW band with no reviewer → HOLD_FOR_REVIEW escalated to HEAD_OF_FPA.
+    soul: forecast-agent — read-only inputs only; no modelling or distribution.
+    """
+
+    def __init__(
+        self,
+        port: LiquidityForecastPort,
+        recorder: DecisionRecorder,
+        mask: ForecastMask,
+        window: CostWindow | None = None,
+    ) -> None:
+        self._port = port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = window if window is not None else CostWindow()
+
+    # ------------------------------------------------------------------ public
+
+    async def build_liquidity_forecast(
+        self,
+        intent: BuildLiquidityForecastIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"build_liquidity_forecast:{intent.horizon_days}",
+            success_action="BUILD_LIQUIDITY_FORECAST",
+            op="LiquidityForecastPort.get_forecast_inputs",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=human_reviewed_by,
+        )
+        return await self._run_action(
+            ctx, lambda: self._port.get_forecast_inputs(intent.horizon_days)
+        )
+
+    async def get_liquidity_position(
+        self,
+        intent: GetLiquidityPositionIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_liquidity_position:{intent.as_of}",
+            success_action="GET_LIQUIDITY_POSITION",
+            op="LiquidityForecastPort.get_current_position",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=human_reviewed_by,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_current_position(intent.as_of))
+
+    # ---------------------------------------------------------------- internals
+
+    def _band(self, score: float) -> ConfirmationDecision:
+        if score >= self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if score >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        if cost.tokens > cap.max_request_tokens:
+            return True
+        if cost.cost > cap.max_request_cost:
+            return True
+        if self._window.used_tokens + cost.tokens > cap.max_window_tokens:
+            return True
+        if self._window.used_cost + cost.cost > cap.max_window_cost:
+            return True
+        return False
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:  # noqa: PLR0911
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError(f"confidence_score {ctx.confidence_score!r} must be in [0.0, 1.0]")
+        policies: list[str] = ["ADR-048-process-resolution"]
+
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op!r} not on forecast scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70; human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+
+        if band is ConfirmationDecision.REVIEW and ctx.human_reviewed_by is None:
+            return _Evaluation(
+                band,
+                False,
+                "HOLD_FOR_REVIEW",
+                f"Forecast action in REVIEW band; HITL hold — escalated to {self._mask.review_role}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="hitl_review_required",
+                requires_hitl=True,
+                escalated_to=self._mask.review_role,
+            )
+
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Per-request or per-window cost-cap breach; action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"FINANCIAL_DATA overlay {ctx.compliance_result}; "
+                f"blocked, escalated to {self._mask.review_role}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=self._mask.review_role,
+            )
+
+        note = f" (reviewed by {ctx.human_reviewed_by})" if ctx.human_reviewed_by else ""
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All forecast gates satisfied at {band.value} confidence{note}.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.datetime.utcnow().isoformat(),
+            agent_id=self._mask.agent_id,
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies_evaluated=list(ev.policies_evaluated),
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=ctx.human_reviewed_by,
+            correlation_id=ctx.correlation_id,
+            cost_tokens=ctx.request_cost.tokens,
+            cost_amount=ctx.request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except LiquidityForecastPortError as exc:
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=ev.compliance_result,
+                        reasoning=f"Port raised {type(exc).__name__}: {exc}",
+                        escalated_to=ev.escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_step_up=ev.requires_step_up,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )

--- a/services/agents/treasury_agent.py
+++ b/services/agents/treasury_agent.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import datetime
+from decimal import Decimal
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.treasury.fx_exposure_port import (
+    FXExposurePort,
+    FXExposurePortError,
+)
+from services.treasury.nostro_recon_port import (
+    NOSTROReconPort,
+    NostroReconPortError,
+)
+
+_TREASURY_PORT_ERRORS = (FXExposurePortError, NostroReconPortError)
+
+
+@dataclass(frozen=True)
+class TreasuryMask:
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    lineage_obligation: bool = True
+    agent_id: str = "treasury_agent"
+    scope: tuple[str, ...] = (
+        "FXExposurePort.get_exposure",
+        "FXExposurePort.get_total_exposure",
+        "NOSTROReconPort.reconcile",
+    )
+    compliance_gate: tuple[str, ...] = ("FINANCIAL_DATA",)
+    cfo_role: str = "CFO"
+    cfo_signoff_threshold_gbp: Decimal = Decimal("100000")
+
+
+@dataclass(frozen=True)
+class GetFXExposureIntent:
+    intent_text: str
+    process_ref: ProcessRef
+    currency_pair: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    amount_gbp: Decimal
+
+
+@dataclass(frozen=True)
+class GetTotalFXExposureIntent:
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    amount_gbp: Decimal
+
+
+@dataclass(frozen=True)
+class ReconcileNostroIntent:
+    intent_text: str
+    process_ref: ProcessRef
+    account_id: str
+    as_of: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    amount_gbp: Decimal
+
+
+@dataclass(frozen=True)
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies_evaluated: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+@dataclass
+class _ActionContext:
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+    human_reviewed_by: str | None
+    force_review: bool = False
+    review_escalate_to: str | None = None
+
+
+class TreasuryAgent:
+    """L2 Review agent for FX exposure reads and NOSTRO reconciliation.
+
+    Band thresholds: AUTO >= 0.90; REVIEW 0.70–0.90; BLOCK < 0.70.
+    CFO step-up: amount_gbp >= cfo_signoff_threshold_gbp forces REVIEW regardless of band.
+    soul: fx-exposure-agent / cash-position — read-only; no trades; no transfers.
+    """
+
+    def __init__(
+        self,
+        fx_port: FXExposurePort,
+        nostro_port: NOSTROReconPort,
+        recorder: DecisionRecorder,
+        mask: TreasuryMask,
+        window: CostWindow | None = None,
+    ) -> None:
+        self._fx_port = fx_port
+        self._nostro_port = nostro_port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = window if window is not None else CostWindow()
+
+    # ------------------------------------------------------------------ public
+
+    async def get_fx_exposure(
+        self,
+        intent: GetFXExposureIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        exceeds = intent.amount_gbp >= self._mask.cfo_signoff_threshold_gbp
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_fx_exposure:{intent.currency_pair}",
+            success_action="GET_FX_EXPOSURE",
+            op="FXExposurePort.get_exposure",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=human_reviewed_by,
+            force_review=exceeds,
+            review_escalate_to=self._mask.cfo_role if exceeds else None,
+        )
+        return await self._run_action(ctx, lambda: self._fx_port.get_exposure(intent.currency_pair))
+
+    async def get_total_fx_exposure(
+        self,
+        intent: GetTotalFXExposureIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        exceeds = intent.amount_gbp >= self._mask.cfo_signoff_threshold_gbp
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event="get_total_fx_exposure",
+            success_action="GET_TOTAL_FX_EXPOSURE",
+            op="FXExposurePort.get_total_exposure",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=human_reviewed_by,
+            force_review=exceeds,
+            review_escalate_to=self._mask.cfo_role if exceeds else None,
+        )
+        return await self._run_action(ctx, lambda: self._fx_port.get_total_exposure())
+
+    async def reconcile_nostro(
+        self,
+        intent: ReconcileNostroIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+        human_reviewed_by: str | None = None,
+    ) -> AgentOutcome:
+        exceeds = intent.amount_gbp >= self._mask.cfo_signoff_threshold_gbp
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"reconcile_nostro:{intent.account_id}",
+            success_action="RECONCILE_NOSTRO",
+            op="NOSTROReconPort.reconcile",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=human_reviewed_by,
+            force_review=exceeds,
+            review_escalate_to=self._mask.cfo_role if exceeds else None,
+        )
+        return await self._run_action(
+            ctx, lambda: self._nostro_port.reconcile(intent.account_id, intent.as_of)
+        )
+
+    # ---------------------------------------------------------------- internals
+
+    def _band(self, score: float) -> ConfirmationDecision:
+        if score >= self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if score >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        if cost.tokens > cap.max_request_tokens:
+            return True
+        if cost.cost > cap.max_request_cost:
+            return True
+        if self._window.used_tokens + cost.tokens > cap.max_window_tokens:
+            return True
+        if self._window.used_cost + cost.cost > cap.max_window_cost:
+            return True
+        return False
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:  # noqa: PLR0911
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError(f"confidence_score {ctx.confidence_score!r} must be in [0.0, 1.0]")
+        policies: list[str] = ["ADR-048-process-resolution"]
+
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op!r} not on treasury scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+        if ctx.force_review and band is ConfirmationDecision.AUTO:
+            policies.append("ADR-078-CFO-step-up")
+            band = ConfirmationDecision.REVIEW
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70; human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+
+        if band is ConfirmationDecision.REVIEW and ctx.human_reviewed_by is None:
+            reason = (
+                f"Material amount >= £{self._mask.cfo_signoff_threshold_gbp}: "
+                "CFO sign-off required (ADR-078)."
+                if ctx.force_review
+                else "Treasury action in REVIEW band; HITL hold (ADR-049 §D4)."
+            )
+            return _Evaluation(
+                band,
+                False,
+                "HOLD_FOR_REVIEW",
+                reason,
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="hitl_review_required",
+                requires_hitl=True,
+                escalated_to=ctx.review_escalate_to,
+            )
+
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Per-request or per-window cost-cap breach; action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"FINANCIAL_DATA overlay {ctx.compliance_result}; "
+                f"blocked, escalated to {self._mask.cfo_role}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=self._mask.cfo_role,
+            )
+
+        note = f" (reviewed by {ctx.human_reviewed_by})" if ctx.human_reviewed_by else ""
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All treasury gates satisfied at {band.value} confidence{note}.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.datetime.utcnow().isoformat(),
+            agent_id=self._mask.agent_id,
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies_evaluated=list(ev.policies_evaluated),
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=ctx.human_reviewed_by,
+            correlation_id=ctx.correlation_id,
+            cost_tokens=ctx.request_cost.tokens,
+            cost_amount=ctx.request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except _TREASURY_PORT_ERRORS as exc:
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=ev.compliance_result,
+                        reasoning=f"Port raised {type(exc).__name__}: {exc}",
+                        escalated_to=ev.escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_step_up=ev.requires_step_up,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )

--- a/services/treasury/fx_exposure_port.py
+++ b/services/treasury/fx_exposure_port.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+class FXExposurePortError(Exception):
+    """Raised when FXExposurePort cannot fulfil a request."""
+
+
+@dataclass(frozen=True)
+class FXPosition:
+    currency_pair: str
+    net_exposure_gbp: Decimal
+    as_of: str
+
+
+@dataclass(frozen=True)
+class FXExposureView:
+    positions: list[FXPosition]
+    total_exposure_gbp: Decimal
+    as_of: str
+
+
+class FXExposurePort(abc.ABC):
+    """Read net FX exposure per currency pair and aggregate total.
+
+    DOES: read net FX positions; aggregate total exposure.
+    DOES NOT: execute FX trades or hedges.
+    soul: fx-exposure-agent — NEVER execute hedge trades.
+    """
+
+    @abc.abstractmethod
+    async def get_exposure(self, currency_pair: str) -> FXPosition:
+        """Return net GBP exposure for the given currency pair."""
+        ...  # pragma: no cover
+
+    @abc.abstractmethod
+    async def get_total_exposure(self) -> FXExposureView:
+        """Return aggregated FX exposure across all open positions."""
+        ...  # pragma: no cover
+
+
+class InMemoryFXExposurePort(FXExposurePort):
+    """Configurable in-memory stub for unit tests."""
+
+    def __init__(self, positions: list[FXPosition] | None = None) -> None:
+        self._positions: dict[str, FXPosition] = {}
+        for p in positions or []:
+            self._positions[p.currency_pair] = p
+
+    async def get_exposure(self, currency_pair: str) -> FXPosition:
+        if currency_pair not in self._positions:
+            raise FXExposurePortError(f"Unknown currency pair: {currency_pair!r}")
+        return self._positions[currency_pair]
+
+    async def get_total_exposure(self) -> FXExposureView:
+        positions = list(self._positions.values())
+        total = sum((p.net_exposure_gbp for p in positions), Decimal("0"))
+        as_of = positions[0].as_of if positions else "1970-01-01"
+        return FXExposureView(
+            positions=positions,
+            total_exposure_gbp=total,
+            as_of=as_of,
+        )

--- a/services/treasury/liquidity_forecast_port.py
+++ b/services/treasury/liquidity_forecast_port.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+class LiquidityForecastPortError(Exception):
+    """Raised when LiquidityForecastPort cannot fulfil a request."""
+
+
+@dataclass(frozen=True)
+class LiquidityForecastInputs:
+    as_of: str
+    horizon_days: int
+    opening_balance_gbp: Decimal
+    projected_inflows_gbp: Decimal
+    projected_outflows_gbp: Decimal
+
+
+class LiquidityForecastPort(abc.ABC):
+    """Supply read-only inputs for a rolling liquidity forecast.
+
+    DOES: provide opening balance, projected inflows/outflows, current position.
+    DOES NOT: execute forecasting models or distribute forecast packs.
+    soul: forecast-agent — modelling and distribution are out of scope.
+    """
+
+    @abc.abstractmethod
+    async def get_forecast_inputs(self, horizon_days: int) -> LiquidityForecastInputs:
+        """Return forecast inputs for the requested horizon."""
+        ...  # pragma: no cover
+
+    @abc.abstractmethod
+    async def get_current_position(self, as_of: str) -> Decimal:
+        """Return current GBP liquidity position as of a date."""
+        ...  # pragma: no cover
+
+
+class InMemoryLiquidityForecastPort(LiquidityForecastPort):
+    """Configurable in-memory stub for unit tests."""
+
+    def __init__(
+        self,
+        inputs: LiquidityForecastInputs | None = None,
+        current_position: Decimal = Decimal("0"),
+        inputs_raises: Exception | None = None,
+        position_raises: Exception | None = None,
+    ) -> None:
+        self._inputs = inputs
+        self._current_position = current_position
+        self._inputs_raises = inputs_raises
+        self._position_raises = position_raises
+
+    async def get_forecast_inputs(self, horizon_days: int) -> LiquidityForecastInputs:
+        if self._inputs_raises is not None:
+            raise self._inputs_raises
+        if self._inputs is None:
+            raise LiquidityForecastPortError("No forecast inputs configured")
+        return self._inputs
+
+    async def get_current_position(self, as_of: str) -> Decimal:
+        if self._position_raises is not None:
+            raise self._position_raises
+        return self._current_position

--- a/services/treasury/nostro_recon_port.py
+++ b/services/treasury/nostro_recon_port.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+class NostroReconPortError(Exception):
+    """Raised when NOSTROReconPort cannot fulfil a request."""
+
+
+@dataclass(frozen=True)
+class NostroBalance:
+    account_id: str
+    internal_gbp: Decimal
+    external_gbp: Decimal
+    as_of: str
+
+
+@dataclass(frozen=True)
+class NostroReconResult:
+    account_id: str
+    internal_gbp: Decimal
+    external_gbp: Decimal
+    difference_gbp: Decimal
+    matched: bool
+    as_of: str
+
+
+class NOSTROReconPort(abc.ABC):
+    """Read and compare internal vs external NOSTRO balances.
+
+    DOES: read balances; surface discrepancies.
+    DOES NOT: mutate balances or initiate bank transfers.
+    soul: cash-position — NEVER initiate any bank transfers.
+    """
+
+    @abc.abstractmethod
+    async def get_nostro_balances(self, account_id: str, as_of: str) -> NostroBalance:
+        """Return internal and external NOSTRO balances for an account."""
+        ...  # pragma: no cover
+
+    @abc.abstractmethod
+    async def reconcile(self, account_id: str, as_of: str) -> NostroReconResult:
+        """Compare internal vs external; matched = abs(difference_gbp) <= £0.01."""
+        ...  # pragma: no cover
+
+
+class InMemoryNOSTROReconPort(NOSTROReconPort):
+    """Configurable in-memory stub for unit tests."""
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, NostroBalance] = {}
+
+    def seed(self, balance: NostroBalance) -> None:
+        self._accounts[balance.account_id] = balance
+
+    async def get_nostro_balances(self, account_id: str, as_of: str) -> NostroBalance:
+        if account_id not in self._accounts:
+            raise NostroReconPortError(f"Unknown NOSTRO account: {account_id!r}")
+        return self._accounts[account_id]
+
+    async def reconcile(self, account_id: str, as_of: str) -> NostroReconResult:
+        balance = await self.get_nostro_balances(account_id, as_of)
+        diff = balance.internal_gbp - balance.external_gbp
+        return NostroReconResult(
+            account_id=account_id,
+            internal_gbp=balance.internal_gbp,
+            external_gbp=balance.external_gbp,
+            difference_gbp=diff,
+            matched=abs(diff) <= Decimal("0.01"),
+            as_of=balance.as_of,
+        )

--- a/tests/agents/test_forecast_agent.py
+++ b/tests/agents/test_forecast_agent.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.agents.forecast_agent import (
+    BuildLiquidityForecastIntent,
+    ForecastAgent,
+    ForecastMask,
+    GetLiquidityPositionIntent,
+)
+from services.treasury.liquidity_forecast_port import (
+    InMemoryLiquidityForecastPort,
+    LiquidityForecastInputs,
+    LiquidityForecastPortError,
+)
+
+# ------------------------------------------------------------------ fixtures/helpers
+
+_DEFAULT_CAP = CostCap(
+    max_request_tokens=5000,
+    max_request_cost=Decimal("5.00"),
+    max_window_tokens=50000,
+    max_window_cost=Decimal("50.00"),
+)
+_SMALL_COST = RequestCost(tokens=100, cost=Decimal("0.10"))
+_PROC = ProcessRef(process_id="LQ-001", version="v1.0")
+_UNRESOLVED = ProcessRef(process_id="", version="")
+
+
+class FakeRecorder(DecisionRecorder):
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+def make_mask(**overrides: object) -> ForecastMask:
+    base: dict[str, object] = {"cost_cap": _DEFAULT_CAP}
+    base.update(overrides)
+    return ForecastMask(**base)  # type: ignore[arg-type]
+
+
+def _default_inputs(horizon_days: int = 30) -> LiquidityForecastInputs:
+    return LiquidityForecastInputs(
+        as_of="2026-06-09",
+        horizon_days=horizon_days,
+        opening_balance_gbp=Decimal("500000.00"),
+        projected_inflows_gbp=Decimal("200000.00"),
+        projected_outflows_gbp=Decimal("150000.00"),
+    )
+
+
+def make_agent(
+    *,
+    mask: ForecastMask | None = None,
+    window: CostWindow | None = None,
+    inputs: LiquidityForecastInputs | None = None,
+    inputs_raises: Exception | None = None,
+    position_raises: Exception | None = None,
+    current_position: Decimal | None = None,
+) -> tuple[ForecastAgent, InMemoryLiquidityForecastPort, FakeRecorder]:
+    port = InMemoryLiquidityForecastPort(
+        inputs=inputs or _default_inputs(),
+        current_position=current_position or Decimal("750000.00"),
+        inputs_raises=inputs_raises,
+        position_raises=position_raises,
+    )
+    rec = FakeRecorder()
+    agent = ForecastAgent(
+        port=port,
+        recorder=rec,
+        mask=mask or make_mask(),
+        window=window,
+    )
+    return agent, port, rec
+
+
+def build_intent(
+    confidence: float = 0.95,
+    horizon_days: int = 30,
+    proc: ProcessRef = _PROC,
+) -> BuildLiquidityForecastIntent:
+    return BuildLiquidityForecastIntent(
+        intent_text="build liquidity forecast",
+        process_ref=proc,
+        horizon_days=horizon_days,
+        correlation_id="corr-001",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+    )
+
+
+def position_intent(
+    confidence: float = 0.95,
+    as_of: str = "2026-06-09",
+    proc: ProcessRef = _PROC,
+) -> GetLiquidityPositionIntent:
+    return GetLiquidityPositionIntent(
+        intent_text="get liquidity position",
+        process_ref=proc,
+        as_of=as_of,
+        correlation_id="corr-002",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+    )
+
+
+# ------------------------------------------------------------------ AUTO happy paths
+
+
+async def test_build_liquidity_forecast_auto_proceeds() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.build_liquidity_forecast(build_intent(confidence=0.95))
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.result is not None
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "BUILD_LIQUIDITY_FORECAST"
+
+
+async def test_get_liquidity_position_auto_proceeds() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.get_liquidity_position(position_intent(confidence=0.95))
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "GET_LIQUIDITY_POSITION"
+
+
+# ------------------------------------------------------------------ gate halts
+
+
+async def test_halt_unresolved_process_ref() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.build_liquidity_forecast(build_intent(proc=_UNRESOLVED))
+    assert outcome.executed is False
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert rec.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+async def test_reject_out_of_scope() -> None:
+    mask = make_mask(scope=("OTHER.op",))
+    agent, _, rec = make_agent(mask=mask)
+    outcome = await agent.build_liquidity_forecast(build_intent())
+    assert outcome.halt_reason == "out_of_scope"
+    assert rec.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+async def test_block_low_confidence() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.build_liquidity_forecast(build_intent(confidence=0.50))
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert rec.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+# ------------------------------------------------------------------ REVIEW band
+
+
+async def test_review_band_no_reviewer_holds_escalates_to_head_of_fpa() -> None:
+    agent, port, rec = make_agent()
+    port_calls: list[int] = []
+    original = port.get_forecast_inputs
+
+    async def patched(h: int) -> LiquidityForecastInputs:
+        port_calls.append(h)
+        return await original(h)
+
+    port.get_forecast_inputs = patched  # type: ignore[method-assign]
+    outcome = await agent.build_liquidity_forecast(build_intent(confidence=0.80))
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.requires_hitl is True
+    assert outcome.escalated_to == "HEAD_OF_FPA"
+    assert port_calls == []  # port NOT called
+    assert rec.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert rec.records[0].escalated_to == "HEAD_OF_FPA"
+
+
+async def test_review_band_with_reviewer_proceeds() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.build_liquidity_forecast(
+        build_intent(confidence=0.80), human_reviewed_by="analyst@banxe.com"
+    )
+    assert outcome.executed is True
+    assert rec.records[0].human_reviewed_by == "analyst@banxe.com"
+
+
+async def test_review_position_intent_no_reviewer_holds_escalates() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.get_liquidity_position(position_intent(confidence=0.80))
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.escalated_to == "HEAD_OF_FPA"
+
+
+# ------------------------------------------------------------------ no CFO step-up (intents have no amount_gbp)
+
+
+async def test_no_cfo_stepup_gate_exists_on_forecast_agent() -> None:
+    """ForecastAgent has no amount_gbp → no CFO step-up; AUTO proceeds freely."""
+    agent, _, rec = make_agent()
+    outcome = await agent.build_liquidity_forecast(build_intent(confidence=0.95))
+    assert outcome.executed is True
+    assert outcome.escalated_to is None
+
+
+# ------------------------------------------------------------------ cost-cap breaches
+
+
+async def test_halt_cost_cap_per_request_tokens() -> None:
+    cap = CostCap(
+        max_request_tokens=50,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=5000,
+        max_window_cost=Decimal("100.00"),
+    )
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap))
+    outcome = await agent.build_liquidity_forecast(build_intent())
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert rec.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+async def test_halt_cost_cap_per_request_cost() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("0.05"),
+        max_window_tokens=50000,
+        max_window_cost=Decimal("100.00"),
+    )
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap))
+    outcome = await agent.build_liquidity_forecast(build_intent())
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+async def test_halt_cost_cap_per_window_tokens() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=150,
+        max_window_cost=Decimal("100.00"),
+    )
+    window = CostWindow(used_tokens=100)
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.build_liquidity_forecast(build_intent())
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+async def test_halt_cost_cap_per_window_cost() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=50000,
+        max_window_cost=Decimal("0.15"),
+    )
+    window = CostWindow(used_cost=Decimal("0.10"))
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.build_liquidity_forecast(build_intent())
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+# ------------------------------------------------------------------ compliance gate
+
+
+async def test_halt_compliance_fail_escalates_to_head_of_fpa() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.build_liquidity_forecast(
+        build_intent(), compliance_result=ComplianceResult.FAIL
+    )
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "HEAD_OF_FPA"
+    assert rec.records[0].escalated_to == "HEAD_OF_FPA"
+
+
+async def test_halt_compliance_escalate_escalates_to_head_of_fpa() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.build_liquidity_forecast(
+        build_intent(), compliance_result=ComplianceResult.ESCALATE
+    )
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "HEAD_OF_FPA"
+
+
+# ------------------------------------------------------------------ provider error
+
+
+async def test_provider_error_inputs_emits_record_then_reraises() -> None:
+    err = LiquidityForecastPortError("upstream down")
+    agent, _, rec = make_agent(inputs_raises=err)
+    with pytest.raises(LiquidityForecastPortError):
+        await agent.build_liquidity_forecast(build_intent(confidence=0.95))
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken.startswith("HALT_PROVIDER_ERROR")
+
+
+async def test_provider_error_position_emits_record_then_reraises() -> None:
+    err = LiquidityForecastPortError("position unavailable")
+    agent, _, rec = make_agent(position_raises=err)
+    with pytest.raises(LiquidityForecastPortError):
+        await agent.get_liquidity_position(position_intent(confidence=0.95))
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken.startswith("HALT_PROVIDER_ERROR")
+
+
+# ------------------------------------------------------------------ confidence validation
+
+
+async def test_confidence_above_one_raises_value_error() -> None:
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.build_liquidity_forecast(build_intent(confidence=1.01))
+
+
+async def test_confidence_below_zero_raises_value_error() -> None:
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.build_liquidity_forecast(build_intent(confidence=-0.01))
+
+
+# ------------------------------------------------------------------ band boundaries
+
+
+async def test_band_boundary_exactly_090_is_auto() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.build_liquidity_forecast(build_intent(confidence=0.90))
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+
+
+async def test_band_boundary_exactly_070_is_review() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.build_liquidity_forecast(build_intent(confidence=0.70))
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.decision is ConfirmationDecision.REVIEW
+
+
+# ------------------------------------------------------------------ R-SEC invariant
+
+
+async def test_rsec_triggering_event_uses_opaque_handle_for_build() -> None:
+    agent, _, rec = make_agent()
+    await agent.build_liquidity_forecast(build_intent(horizon_days=30, confidence=0.95))
+    r = rec.records[0]
+    assert r.triggering_event == "build_liquidity_forecast:30"
+    # no balance or position amount in record
+    assert "500000" not in r.triggering_event
+    assert "500000" not in (r.intent or "")
+
+
+async def test_rsec_triggering_event_uses_opaque_handle_for_position() -> None:
+    agent, _, rec = make_agent()
+    await agent.get_liquidity_position(position_intent(as_of="2026-06-09", confidence=0.95))
+    r = rec.records[0]
+    assert r.triggering_event == "get_liquidity_position:2026-06-09"
+
+
+# ------------------------------------------------------------------ window & discipline
+
+
+async def test_window_accumulates_on_success() -> None:
+    agent, _, _ = make_agent()
+    assert agent._window.used_tokens == 0
+    await agent.build_liquidity_forecast(build_intent(confidence=0.95))
+    assert agent._window.used_tokens == 100
+    assert agent._window.used_cost == Decimal("0.10")
+
+
+async def test_window_not_accumulated_on_halt() -> None:
+    agent, _, _ = make_agent()
+    await agent.build_liquidity_forecast(build_intent(proc=_UNRESOLVED))
+    assert agent._window.used_tokens == 0
+
+
+async def test_exactly_one_record_per_action() -> None:
+    agent, _, rec = make_agent()
+    await agent.build_liquidity_forecast(build_intent(confidence=0.95))
+    await agent.build_liquidity_forecast(build_intent(confidence=0.80))  # HOLD
+    await agent.get_liquidity_position(position_intent(confidence=0.95))
+    assert len(rec.records) == 3

--- a/tests/agents/test_treasury_agent.py
+++ b/tests/agents/test_treasury_agent.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.agents.treasury_agent import (
+    GetFXExposureIntent,
+    GetTotalFXExposureIntent,
+    ReconcileNostroIntent,
+    TreasuryAgent,
+    TreasuryMask,
+)
+from services.treasury.fx_exposure_port import (
+    FXExposurePortError,
+    FXPosition,
+    InMemoryFXExposurePort,
+)
+from services.treasury.nostro_recon_port import (
+    InMemoryNOSTROReconPort,
+    NostroBalance,
+    NostroReconPortError,
+)
+
+# ------------------------------------------------------------------ fixtures/helpers
+
+_DEFAULT_CAP = CostCap(
+    max_request_tokens=5000,
+    max_request_cost=Decimal("5.00"),
+    max_window_tokens=50000,
+    max_window_cost=Decimal("50.00"),
+)
+_SMALL_COST = RequestCost(tokens=100, cost=Decimal("0.10"))
+_PROC = ProcessRef(process_id="FX-001", version="v1.0")
+_UNRESOLVED = ProcessRef(process_id="", version="")
+
+
+class FakeRecorder(DecisionRecorder):
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+def make_mask(**overrides: object) -> TreasuryMask:
+    base: dict[str, object] = {"cost_cap": _DEFAULT_CAP}
+    base.update(overrides)
+    return TreasuryMask(**base)  # type: ignore[arg-type]
+
+
+def make_agent(
+    *,
+    mask: TreasuryMask | None = None,
+    window: CostWindow | None = None,
+    fx_positions: list[FXPosition] | None = None,
+) -> tuple[TreasuryAgent, InMemoryFXExposurePort, InMemoryNOSTROReconPort, FakeRecorder]:
+    fx = InMemoryFXExposurePort(
+        fx_positions or [FXPosition("GBP/USD", Decimal("5000.00"), "2026-06-09")]
+    )
+    nostro = InMemoryNOSTROReconPort()
+    nostro.seed(NostroBalance("ACCT-001", Decimal("10000"), Decimal("10000"), "2026-06-09"))
+    rec = FakeRecorder()
+    agent = TreasuryAgent(
+        fx_port=fx,
+        nostro_port=nostro,
+        recorder=rec,
+        mask=mask or make_mask(),
+        window=window,
+    )
+    return agent, fx, nostro, rec
+
+
+def fx_intent(
+    confidence: float = 0.95,
+    amount_gbp: str = "50000.00",
+    pair: str = "GBP/USD",
+    proc: ProcessRef = _PROC,
+) -> GetFXExposureIntent:
+    return GetFXExposureIntent(
+        intent_text="get FX exposure",
+        process_ref=proc,
+        currency_pair=pair,
+        correlation_id="corr-001",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+        amount_gbp=Decimal(amount_gbp),
+    )
+
+
+def total_fx_intent(
+    confidence: float = 0.95,
+    amount_gbp: str = "50000.00",
+) -> GetTotalFXExposureIntent:
+    return GetTotalFXExposureIntent(
+        intent_text="get total FX exposure",
+        process_ref=_PROC,
+        correlation_id="corr-002",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+        amount_gbp=Decimal(amount_gbp),
+    )
+
+
+def nostro_intent(
+    confidence: float = 0.95,
+    amount_gbp: str = "50000.00",
+    account_id: str = "ACCT-001",
+) -> ReconcileNostroIntent:
+    return ReconcileNostroIntent(
+        intent_text="reconcile NOSTRO",
+        process_ref=_PROC,
+        account_id=account_id,
+        as_of="2026-06-09",
+        correlation_id="corr-003",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+        amount_gbp=Decimal(amount_gbp),
+    )
+
+
+# ------------------------------------------------------------------ AUTO happy paths
+
+
+async def test_get_fx_exposure_auto_proceeds_and_returns_result() -> None:
+    agent, fx, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(fx_intent(confidence=0.95))
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.result is not None
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "GET_FX_EXPOSURE"
+
+
+async def test_get_total_fx_exposure_auto_proceeds() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_total_fx_exposure(total_fx_intent(confidence=0.95))
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert len(rec.records) == 1
+
+
+async def test_reconcile_nostro_auto_proceeds() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.reconcile_nostro(nostro_intent(confidence=0.95))
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "RECONCILE_NOSTRO"
+
+
+# ------------------------------------------------------------------ gate halts
+
+
+async def test_halt_unresolved_process_ref() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(fx_intent(proc=_UNRESOLVED))
+    assert outcome.executed is False
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert rec.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+async def test_reject_out_of_scope() -> None:
+    mask = make_mask(scope=("OTHER.op",))
+    agent, _, _, rec = make_agent(mask=mask)
+    outcome = await agent.get_fx_exposure(fx_intent())
+    assert outcome.halt_reason == "out_of_scope"
+    assert rec.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+async def test_block_low_confidence() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(fx_intent(confidence=0.50))
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert rec.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+# ------------------------------------------------------------------ REVIEW band
+
+
+async def test_review_band_no_reviewer_holds_for_hitl() -> None:
+    agent, fx, _, rec = make_agent()
+    fx_calls: list[str] = []
+    original = fx.get_exposure
+
+    async def patched(pair: str) -> FXPosition:
+        fx_calls.append(pair)
+        return await original(pair)
+
+    fx.get_exposure = patched  # type: ignore[method-assign]
+    outcome = await agent.get_fx_exposure(fx_intent(confidence=0.80))
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.requires_hitl is True
+    assert fx_calls == []  # port NOT called
+    assert rec.records[0].action_taken == "HOLD_FOR_REVIEW"
+
+
+async def test_review_band_with_reviewer_proceeds() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(
+        fx_intent(confidence=0.80), human_reviewed_by="alice@banxe.com"
+    )
+    assert outcome.executed is True
+    assert rec.records[0].human_reviewed_by == "alice@banxe.com"
+
+
+# ------------------------------------------------------------------ CFO step-up
+
+
+async def test_cfo_stepup_auto_confidence_large_amount_holds() -> None:
+    agent, _, _, rec = make_agent()
+    # AUTO confidence (0.95) but amount >= £100k → force REVIEW → HOLD
+    outcome = await agent.get_fx_exposure(fx_intent(confidence=0.95, amount_gbp="100000.00"))
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.escalated_to == "CFO"
+    assert rec.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert rec.records[0].escalated_to == "CFO"
+
+
+async def test_cfo_stepup_with_reviewer_proceeds() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(
+        fx_intent(confidence=0.95, amount_gbp="100000.00"),
+        human_reviewed_by="cfo@banxe.com",
+    )
+    assert outcome.executed is True
+    assert rec.records[0].human_reviewed_by == "cfo@banxe.com"
+
+
+async def test_auto_small_amount_no_hold() -> None:
+    agent, _, _, rec = make_agent()
+    # AUTO confidence (0.95) + amount < £100k → no step-up, proceeds freely
+    outcome = await agent.get_fx_exposure(fx_intent(confidence=0.95, amount_gbp="99999.99"))
+    assert outcome.executed is True
+    assert rec.records[0].action_taken == "GET_FX_EXPOSURE"
+
+
+async def test_cfo_stepup_exact_threshold_triggers() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(fx_intent(confidence=0.95, amount_gbp="100000.00"))
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.escalated_to == "CFO"
+
+
+# ------------------------------------------------------------------ cost-cap breaches
+
+
+async def test_halt_cost_cap_per_request_tokens() -> None:
+    cap = CostCap(
+        max_request_tokens=50,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=5000,
+        max_window_cost=Decimal("100.00"),
+    )
+    agent, _, _, rec = make_agent(mask=make_mask(cost_cap=cap))
+    outcome = await agent.get_fx_exposure(fx_intent())  # _SMALL_COST=100 tokens > 50
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert rec.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+async def test_halt_cost_cap_per_request_cost() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("0.05"),
+        max_window_tokens=50000,
+        max_window_cost=Decimal("100.00"),
+    )
+    agent, _, _, rec = make_agent(mask=make_mask(cost_cap=cap))
+    outcome = await agent.get_fx_exposure(fx_intent())  # 0.10 > 0.05
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+async def test_halt_cost_cap_per_window_tokens() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=150,
+        max_window_cost=Decimal("100.00"),
+    )
+    window = CostWindow(used_tokens=100)
+    agent, _, _, rec = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.get_fx_exposure(fx_intent())  # 100+100=200 > 150
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+async def test_halt_cost_cap_per_window_cost() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=50000,
+        max_window_cost=Decimal("0.15"),
+    )
+    window = CostWindow(used_cost=Decimal("0.10"))
+    agent, _, _, rec = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.get_fx_exposure(fx_intent())  # 0.10+0.10=0.20 > 0.15
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+# ------------------------------------------------------------------ compliance gate
+
+
+async def test_halt_compliance_fail_escalates_to_cfo() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(fx_intent(), compliance_result=ComplianceResult.FAIL)
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CFO"
+    assert rec.records[0].escalated_to == "CFO"
+
+
+async def test_halt_compliance_escalate_also_blocks() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(fx_intent(), compliance_result=ComplianceResult.ESCALATE)
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CFO"
+
+
+# ------------------------------------------------------------------ provider errors
+
+
+async def test_provider_error_fx_emits_record_then_reraises() -> None:
+    fx = InMemoryFXExposurePort()  # empty → raises on get_exposure
+    nostro = InMemoryNOSTROReconPort()
+    rec = FakeRecorder()
+    agent = TreasuryAgent(fx_port=fx, nostro_port=nostro, recorder=rec, mask=make_mask())
+    with pytest.raises(FXExposurePortError):
+        await agent.get_fx_exposure(fx_intent(pair="GBP/USD"))
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken.startswith("HALT_PROVIDER_ERROR")
+
+
+async def test_provider_error_nostro_emits_record_then_reraises() -> None:
+    fx = InMemoryFXExposurePort()
+    nostro = InMemoryNOSTROReconPort()  # empty → raises on reconcile
+    rec = FakeRecorder()
+    agent = TreasuryAgent(fx_port=fx, nostro_port=nostro, recorder=rec, mask=make_mask())
+    with pytest.raises(NostroReconPortError):
+        await agent.reconcile_nostro(nostro_intent(account_id="MISSING"))
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken.startswith("HALT_PROVIDER_ERROR")
+
+
+# ------------------------------------------------------------------ confidence validation
+
+
+async def test_confidence_above_one_raises_value_error() -> None:
+    agent, _, _, _ = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_fx_exposure(fx_intent(confidence=1.01))
+
+
+async def test_confidence_below_zero_raises_value_error() -> None:
+    agent, _, _, _ = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_fx_exposure(fx_intent(confidence=-0.01))
+
+
+# ------------------------------------------------------------------ band boundaries
+
+
+async def test_band_boundary_exactly_090_is_auto() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(fx_intent(confidence=0.90))
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+
+
+async def test_band_boundary_exactly_070_is_review() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(fx_intent(confidence=0.70))
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.decision is ConfirmationDecision.REVIEW
+
+
+# ------------------------------------------------------------------ R-SEC invariant
+
+
+async def test_rsec_no_financial_values_in_lineage_record() -> None:
+    agent, _, _, rec = make_agent()
+    await agent.get_fx_exposure(fx_intent(confidence=0.95, amount_gbp="50000.00"))
+    r = rec.records[0]
+    # amount_gbp must NOT appear in triggering_event or intent text
+    assert "50000" not in r.triggering_event
+    assert "50000" not in (r.intent or "")
+    # triggering_event is opaque handle (currency_pair), not a balance
+    assert r.triggering_event == "get_fx_exposure:GBP/USD"
+
+
+async def test_rsec_result_not_in_record() -> None:
+    agent, _, _, rec = make_agent()
+    outcome = await agent.get_fx_exposure(fx_intent(confidence=0.95))
+    # result rides only on AgentOutcome, never serialised into record
+    assert outcome.result is not None
+    # record has no 'result' field — only action_taken, intent, triggering_event
+    assert not hasattr(rec.records[0], "result") or rec.records[0].result is None  # type: ignore[union-attr]
+
+
+# ------------------------------------------------------------------ window & port-call discipline
+
+
+async def test_window_accumulates_on_success() -> None:
+    agent, _, _, _ = make_agent()
+    assert agent._window.used_tokens == 0
+    await agent.get_fx_exposure(fx_intent(confidence=0.95))
+    assert agent._window.used_tokens == 100
+    assert agent._window.used_cost == Decimal("0.10")
+
+
+async def test_window_not_accumulated_on_halt() -> None:
+    agent, _, _, _ = make_agent()
+    await agent.get_fx_exposure(fx_intent(proc=_UNRESOLVED))
+    assert agent._window.used_tokens == 0
+
+
+async def test_exactly_one_record_per_action() -> None:
+    agent, _, _, rec = make_agent()
+    await agent.get_fx_exposure(fx_intent(confidence=0.95))
+    await agent.get_fx_exposure(fx_intent(confidence=0.80))  # HOLD
+    await agent.reconcile_nostro(nostro_intent(confidence=0.95))
+    assert len(rec.records) == 3

--- a/tests/test_treasury/test_fx_exposure_port.py
+++ b/tests/test_treasury/test_fx_exposure_port.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from decimal import Decimal
+
+import pytest
+
+from services.treasury.fx_exposure_port import (
+    FXExposurePortError,
+    FXPosition,
+    InMemoryFXExposurePort,
+)
+
+
+def _pos(pair: str, amount: str = "1000.00", as_of: str = "2026-06-09") -> FXPosition:
+    return FXPosition(currency_pair=pair, net_exposure_gbp=Decimal(amount), as_of=as_of)
+
+
+async def test_get_exposure_known_pair_returns_position() -> None:
+    port = InMemoryFXExposurePort([_pos("GBP/USD", "5000.00")])
+    result = await port.get_exposure("GBP/USD")
+    assert result.currency_pair == "GBP/USD"
+    assert result.net_exposure_gbp == Decimal("5000.00")
+
+
+async def test_get_exposure_unknown_pair_raises() -> None:
+    port = InMemoryFXExposurePort([_pos("GBP/EUR")])
+    with pytest.raises(FXExposurePortError, match="GBP/USD"):
+        await port.get_exposure("GBP/USD")
+
+
+async def test_get_total_exposure_sums_all_positions() -> None:
+    port = InMemoryFXExposurePort(
+        [
+            _pos("GBP/USD", "3000.00"),
+            _pos("GBP/EUR", "2000.00"),
+        ]
+    )
+    view = await port.get_total_exposure()
+    assert view.total_exposure_gbp == Decimal("5000.00")
+    assert len(view.positions) == 2
+
+
+async def test_get_total_exposure_empty_returns_zero() -> None:
+    port = InMemoryFXExposurePort()
+    view = await port.get_total_exposure()
+    assert view.total_exposure_gbp == Decimal("0")
+    assert view.positions == []
+    assert view.as_of == "1970-01-01"
+
+
+async def test_get_total_exposure_single_position_inherits_as_of() -> None:
+    port = InMemoryFXExposurePort([_pos("GBP/JPY", "100.00", as_of="2026-05-01")])
+    view = await port.get_total_exposure()
+    assert view.as_of == "2026-05-01"
+
+
+async def test_positions_are_frozen_value_objects() -> None:
+    p = _pos("GBP/CHF", "999.99")
+    with pytest.raises(FrozenInstanceError):
+        p.net_exposure_gbp = Decimal("1")  # type: ignore[misc]

--- a/tests/test_treasury/test_liquidity_forecast_port.py
+++ b/tests/test_treasury/test_liquidity_forecast_port.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from decimal import Decimal
+
+import pytest
+
+from services.treasury.liquidity_forecast_port import (
+    InMemoryLiquidityForecastPort,
+    LiquidityForecastInputs,
+    LiquidityForecastPortError,
+)
+
+
+def _inputs(horizon_days: int = 30) -> LiquidityForecastInputs:
+    return LiquidityForecastInputs(
+        as_of="2026-06-09",
+        horizon_days=horizon_days,
+        opening_balance_gbp=Decimal("500000.00"),
+        projected_inflows_gbp=Decimal("200000.00"),
+        projected_outflows_gbp=Decimal("150000.00"),
+    )
+
+
+async def test_get_forecast_inputs_returns_configured() -> None:
+    port = InMemoryLiquidityForecastPort(inputs=_inputs(30))
+    result = await port.get_forecast_inputs(30)
+    assert result.horizon_days == 30
+    assert result.opening_balance_gbp == Decimal("500000.00")
+
+
+async def test_get_forecast_inputs_no_inputs_raises() -> None:
+    port = InMemoryLiquidityForecastPort()
+    with pytest.raises(LiquidityForecastPortError, match="No forecast inputs"):
+        await port.get_forecast_inputs(30)
+
+
+async def test_get_forecast_inputs_custom_raises_propagated() -> None:
+    err = LiquidityForecastPortError("upstream error")
+    port = InMemoryLiquidityForecastPort(inputs_raises=err)
+    with pytest.raises(LiquidityForecastPortError, match="upstream error"):
+        await port.get_forecast_inputs(30)
+
+
+async def test_get_current_position_returns_configured() -> None:
+    port = InMemoryLiquidityForecastPort(current_position=Decimal("750000.00"))
+    result = await port.get_current_position("2026-06-09")
+    assert result == Decimal("750000.00")
+
+
+async def test_get_current_position_default_zero() -> None:
+    port = InMemoryLiquidityForecastPort()
+    result = await port.get_current_position("2026-06-09")
+    assert result == Decimal("0")
+
+
+async def test_get_current_position_raises_propagated() -> None:
+    err = LiquidityForecastPortError("position unavailable")
+    port = InMemoryLiquidityForecastPort(position_raises=err)
+    with pytest.raises(LiquidityForecastPortError, match="position unavailable"):
+        await port.get_current_position("2026-06-09")
+
+
+async def test_inputs_frozen_value_object() -> None:
+    inp = _inputs(60)
+    with pytest.raises(FrozenInstanceError):
+        inp.horizon_days = 90  # type: ignore[misc]

--- a/tests/test_treasury/test_nostro_recon_port.py
+++ b/tests/test_treasury/test_nostro_recon_port.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.treasury.nostro_recon_port import (
+    InMemoryNOSTROReconPort,
+    NostroBalance,
+    NostroReconPortError,
+)
+
+
+def _bal(
+    account_id: str = "ACCT-001",
+    internal: str = "10000.00",
+    external: str = "10000.00",
+    as_of: str = "2026-06-09",
+) -> NostroBalance:
+    return NostroBalance(
+        account_id=account_id,
+        internal_gbp=Decimal(internal),
+        external_gbp=Decimal(external),
+        as_of=as_of,
+    )
+
+
+def _port(*balances: NostroBalance) -> InMemoryNOSTROReconPort:
+    p = InMemoryNOSTROReconPort()
+    for b in balances:
+        p.seed(b)
+    return p
+
+
+async def test_get_nostro_balances_known_account() -> None:
+    port = _port(_bal("ACCT-001", "5000.00", "5000.00"))
+    result = await port.get_nostro_balances("ACCT-001", "2026-06-09")
+    assert result.account_id == "ACCT-001"
+    assert result.internal_gbp == Decimal("5000.00")
+
+
+async def test_get_nostro_balances_unknown_raises() -> None:
+    port = _port(_bal("ACCT-001"))
+    with pytest.raises(NostroReconPortError, match="ACCT-999"):
+        await port.get_nostro_balances("ACCT-999", "2026-06-09")
+
+
+async def test_reconcile_matched_zero_difference() -> None:
+    port = _port(_bal("ACCT-001", "10000.00", "10000.00"))
+    result = await port.reconcile("ACCT-001", "2026-06-09")
+    assert result.matched is True
+    assert result.difference_gbp == Decimal("0")
+
+
+async def test_reconcile_matched_within_tolerance() -> None:
+    port = _port(_bal("ACCT-001", "10000.01", "10000.00"))
+    result = await port.reconcile("ACCT-001", "2026-06-09")
+    assert result.difference_gbp == Decimal("0.01")
+    assert result.matched is True
+
+
+async def test_reconcile_unmatched_exceeds_tolerance() -> None:
+    port = _port(_bal("ACCT-001", "10000.02", "10000.00"))
+    result = await port.reconcile("ACCT-001", "2026-06-09")
+    assert result.difference_gbp == Decimal("0.02")
+    assert result.matched is False
+
+
+async def test_reconcile_large_discrepancy_unmatched() -> None:
+    port = _port(_bal("ACCT-001", "15000.00", "10000.00"))
+    result = await port.reconcile("ACCT-001", "2026-06-09")
+    assert result.difference_gbp == Decimal("5000.00")
+    assert result.matched is False
+
+
+async def test_reconcile_negative_difference_matched() -> None:
+    port = _port(_bal("ACCT-001", "9999.99", "10000.00"))
+    result = await port.reconcile("ACCT-001", "2026-06-09")
+    assert result.difference_gbp == Decimal("-0.01")
+    assert result.matched is True
+
+
+async def test_reconcile_unknown_account_raises() -> None:
+    port = InMemoryNOSTROReconPort()
+    with pytest.raises(NostroReconPortError):
+        await port.reconcile("MISSING", "2026-06-09")
+
+
+async def test_result_carries_as_of_from_balance() -> None:
+    port = _port(_bal("ACCT-001", as_of="2026-05-31"))
+    result = await port.reconcile("ACCT-001", "2026-06-09")
+    assert result.as_of == "2026-05-31"


### PR DESCRIPTION
## CFO Office agents — sprint-46 / ADR-078 (the 2 deferred from sprint-45)

Unblocks TreasuryAgent (§2.5.3) + ForecastAgent (§2.5.2) by first defining their **read-only port CONTRACTs** (ADR-078, port-first, no fake integrations).

### ETAP A — 3 read-only ports (`services/treasury/`)
| Port | Does | Does NOT |
|---|---|---|
| `FXExposurePort` | read FX positions/exposure | execute FX trades/hedges |
| `NOSTROReconPort` | read internal-vs-external NOSTRO + compare (£0.01 tol) | initiate transfers / post entries |
| `LiquidityForecastPort` | read-only forecast inputs | run ML/dbt models, mutate source |

Each: `abc.ABC` + `@abstractmethod async`, frozen value types (Decimal, I-01), `InMemory…` impl + `…PortError`.

### ETAP B — 2 L2 agents (`services/agents/`)
- **TreasuryAgent** (L2 Review): FX exposure + NOSTRO recon via the two ports. §D2 step-up = **>£100k → CFO HITL hold** (force REVIEW, escalate CFO, regardless of confidence).
- **ForecastAgent** (L2 Review): rolling liquidity via LiquidityForecastPort; below-AUTO → Head-of-FP&A HITL hold.

Both: full ADR-049 §D2 gate-chain (process_ref → scope → band → cost_cap → compliance → step-up → port), one ADR-046 `AgentDecisionRecord` per action, ports + DecisionRecorder injected. **R-SEC:** only opaque handles (currency_pair/account_id) in lineage — never amounts/balances/PII.

**Naming note (documented, mirrors AnalyticsClientAgent precedent):** `services/agents/treasury_agent.py:TreasuryAgent` (L2 client mask) coexists with the pre-existing `services/treasury/treasury_agent.py` (domain liquidity agent) — distinct packages, no shared import; full suite stays green.

**Files (10, scope-locked):** 3 ports + 2 agents + 5 test files. `services/treasury/__init__.py` left untouched (restored after a tooling slip; ports import by full path).

**Gates:** ruff ✅ · semgrep banxe-rules ✅ · pytest **77 new tests, 100% coverage** on all 5 new modules ✅ · full suite **10521 passed / 0 failed** ✅

Paired banxe-architecture PR (ADR-078 + ORG §2.5 + IL-172) lands separately. PR-only — no merge.