### PR TITLE
feat(cro-agent): RiskOversightAgent + RiskMetricsPort (L1 read-only) — sprint-47 / ADR-079 / IL-173

### DIFF
--- a/services/agents/risk_oversight_agent.py
+++ b/services/agents/risk_oversight_agent.py
@@ -1,0 +1,616 @@
+"""RiskOversightAgent — L1-Auto CRO risk dashboard read agent
+(ADR-079 / ORG-STRUCTURE §2.2).
+
+WHY: ORG-STRUCTURE §2.2 defines the CRO risk-oversight agent as the governed surface
+through which a resolved risk-data read intent becomes a bounded RiskMetricsPort
+read action. This module is the emi-stack CRO sibling of
+``services/agents/bi_agent.py`` and ``services/agents/fpa_agent.py`` — it implements
+the agent *logic* and *governance enforcement* of the risk oversight mask in front
+of the RiskMetricsPort CONTRACT.
+
+The CRO risk oversight agent provides aggregate exposure, monitoring counters,
+and Consumer Duty signal reads for the CRO dashboard. It operates READ-ONLY
+over the risk metrics layer and NEVER modifies source data, NEVER approves models,
+NEVER changes risk thresholds, and NEVER makes risk decisions.
+
+INVARIANT (CRITICAL — enforced in code):
+    RiskOversightAgent is READ-ONLY DASHBOARD. It MUST NEVER emit an approve /
+    threshold-change / model-approval / risk-decision action. Enforced by three
+    independent mechanisms:
+      (1) the mask scope allow-list contains ONLY the 4 read ops:
+          get_risk_dashboard, get_aggregate_exposure, get_monitoring_counters,
+          get_consumer_duty_signals;
+      (2) RiskMetricsPort has NO mutating / approve / threshold method — calling
+          one would require a method that does not exist on the port;
+      (3) every ``success_action`` in this module is a DASHBOARD/READ verb
+          (GET_RISK_DASHBOARD, GET_AGGREGATE_EXPOSURE, GET_MONITORING_COUNTERS,
+          GET_CONSUMER_DUTY_SIGNALS) — the strings APPROVE, THRESHOLD, DECISION,
+          MODEL_APPROVAL do not appear as success actions here.
+
+GOVERNANCE (ADR-049 §D2 gate-chain, fixed order):
+    process_ref → scope → band → cost_cap → compliance(RISK_DATA) → port call
+
+* ``scope``              — RiskMetricsPort READ ops only (allow-list:
+                           get_risk_dashboard / get_aggregate_exposure /
+                           get_monitoring_counters / get_consumer_duty_signals).
+                           Off-list ops are refused outright (ADR-054 §D1 pattern).
+* ``autonomy_level``     — L1-Auto: every read is AUTO-eligible within cap. NO
+                           REVIEW HITL hold, NO biometric step-up (no money
+                           movement). A read below the AUTO band halts for a
+                           re-check (HALT_REVIEW_DEFERRED, requires_hitl=True);
+                           there is no HITL hold path in this agent.
+* ``confirmation_policy``— AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70
+                           (ADR-047 thresholds). REVIEW band → HALT_REVIEW_DEFERRED
+                           (re-check required, not a hold): reads are AUTO-only.
+* ``cost_cap``           — per-request AND per-window hard caps in both token and
+                           monetary (Decimal) dimensions (ADR-047 §D2).
+* ``lineage_obligation`` — one ``AgentDecisionRecord`` per action on every exit
+                           path (ADR-046), non-optional.
+* ``compliance_gate``    — RISK_DATA overlay: the L3 check MUST PASS before a
+                           port call; a non-PASS verdict halts (BLOCK) and
+                           escalates to the CRO (config-as-data on the mask).
+
+Any one of {unresolved process_ref, out-of-scope op, below-band confidence,
+cost-cap breach, compliance(RISK_DATA) fail} halts the action (ADR-049 §D4).
+The port's own validation is defense-in-depth: if the port raises
+RiskMetricsPortError, lineage is emitted (executed=False) and the error is
+re-raised. Mask values are config-as-data, carried on :class:`RiskOversightMask`.
+
+R-SEC (R-SEC-NEW-01, ADR-021): no raw metric value, exposure amount, alert
+counter, or PII ever enters a lineage record. triggering_event is keyed on
+static op labels only — never metric values or amounts. The port's return value
+(RiskDashboard / AggregateExposure / MonitoringCounters / list[ConsumerDutySignal])
+rides on ``AgentOutcome.result`` ONLY — NEVER on the recorded
+``AgentDecisionRecord``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.risk.risk_metrics_port import RiskMetricsPort, RiskMetricsPortError
+
+# ---------------------------------------------------------------------------
+# Mask (config-as-data)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RiskOversightMask:
+    """Config-as-data CRO risk oversight (ORG-STRUCTURE §2.2) mask.
+
+    All gate values are governed config, not hardcoded flow logic. The
+    AUTO/REVIEW/BLOCK scale is ADR-047 canon. The scope is the exclusive
+    read-only allow-list — no approve / threshold / decision op is present
+    (INVARIANT: see module docstring).
+    """
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    lineage_obligation: bool = True
+    agent_id: str = "risk_oversight_agent"
+    # The mask scope (allow-list): ONLY the 4 RiskMetricsPort READ ops.
+    # INVARIANT: no approve / threshold / model-approval / risk-decision op
+    # is present in this tuple. Any attempt to call one is REJECT_OUT_OF_SCOPE.
+    scope: tuple[str, ...] = (
+        "RiskMetricsPort.get_risk_dashboard",
+        "RiskMetricsPort.get_aggregate_exposure",
+        "RiskMetricsPort.get_monitoring_counters",
+        "RiskMetricsPort.get_consumer_duty_signals",
+    )
+    # L3 compliance contour required before any port call.
+    compliance_gate: tuple[str, ...] = ("RISK_DATA",)
+    # Escalation role for a compliance non-PASS verdict (config-as-data).
+    cro_role: str = "CRO"
+
+
+# ---------------------------------------------------------------------------
+# Intent vocabulary
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GetRiskDashboardIntent:
+    """A resolved risk-dashboard read intent
+    (``RiskMetricsPort.get_risk_dashboard``) — the primary CRO read op
+    (ADR-079 / ORG-STRUCTURE §2.2). A read below the AUTO band halts for a
+    re-check, not a HITL hold. The RISK_DATA compliance overlay MUST PASS;
+    a non-PASS verdict blocks and escalates to the CRO. The dashboard rides
+    on ``AgentOutcome.result`` ONLY (R-SEC).
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class GetAggregateExposureIntent:
+    """A resolved aggregate-exposure read intent
+    (``RiskMetricsPort.get_aggregate_exposure``) — the EMI-wide exposure
+    leg of CRO oversight (ADR-079). A read below the AUTO band halts for a
+    re-check. The RISK_DATA overlay MUST PASS; non-PASS escalates to CRO.
+    The AggregateExposure rides on ``AgentOutcome.result`` ONLY (R-SEC).
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class GetMonitoringCountersIntent:
+    """A resolved monitoring-counters read intent
+    (``RiskMetricsPort.get_monitoring_counters``) — fraud/AML alert counts
+    for CRO situational awareness (ADR-079). A read below the AUTO band halts
+    for a re-check. The RISK_DATA overlay MUST PASS; non-PASS escalates to CRO.
+    The MonitoringCounters rides on ``AgentOutcome.result`` ONLY (R-SEC).
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class GetConsumerDutySignalsIntent:
+    """A resolved Consumer Duty signals read intent
+    (``RiskMetricsPort.get_consumer_duty_signals``) — outcome metric signals
+    for CRO Consumer Duty oversight (ADR-079). A read below the AUTO band halts
+    for a re-check. The RISK_DATA overlay MUST PASS; non-PASS escalates to CRO.
+    The signal list rides on ``AgentOutcome.result`` ONLY (R-SEC).
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    """All inputs a single masked risk oversight action evaluates against."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class RiskOversightAgent:
+    """L1-Auto CRO risk dashboard read agent enforcing the ADR-049 §D2 gate chain.
+
+    The :class:`~services.risk.risk_metrics_port.RiskMetricsPort` and the lineage
+    recorder are injected as interfaces (constructor injection); the agent contains
+    pure governance logic and is unit-testable without any live infra.
+
+    INVARIANT: READ-ONLY DASHBOARD. This agent MUST NEVER emit an approve /
+    threshold-change / model-approval / risk-decision action. See module docstring
+    for the three independent enforcement mechanisms.
+    """
+
+    def __init__(
+        self,
+        *,
+        risk_metrics_port: RiskMetricsPort,
+        recorder: DecisionRecorder,
+        mask: RiskOversightMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._port = risk_metrics_port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def get_risk_dashboard(
+        self,
+        intent: GetRiskDashboardIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """CRO dashboard read via ``RiskMetricsPort.get_risk_dashboard`` — the
+        primary risk oversight op (ADR-079 / ORG-STRUCTURE §2.2). AUTO-eligible
+        within cap. The RISK_DATA overlay (``compliance_result``) must PASS before
+        the dashboard is returned; a non-PASS verdict blocks and escalates to the
+        CRO. A read below the AUTO band halts for a re-check, not a HITL hold
+        (L1-Auto). Dashboard rides on ``AgentOutcome.result`` ONLY (R-SEC)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event="get_risk_dashboard",
+            success_action="GET_RISK_DASHBOARD",
+            op="RiskMetricsPort.get_risk_dashboard",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_risk_dashboard())
+
+    async def get_aggregate_exposure(
+        self,
+        intent: GetAggregateExposureIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Aggregate exposure read via ``RiskMetricsPort.get_aggregate_exposure``
+        (ADR-079). AUTO-eligible within cap. The RISK_DATA overlay must PASS;
+        non-PASS blocks and escalates to CRO. A read below the AUTO band halts
+        for a re-check (L1-Auto). Result rides on ``AgentOutcome.result`` ONLY
+        (R-SEC — never expose total_gbp in a lineage record)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event="get_aggregate_exposure",
+            success_action="GET_AGGREGATE_EXPOSURE",
+            op="RiskMetricsPort.get_aggregate_exposure",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_aggregate_exposure())
+
+    async def get_monitoring_counters(
+        self,
+        intent: GetMonitoringCountersIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Monitoring counters read via ``RiskMetricsPort.get_monitoring_counters``
+        (ADR-079). AUTO-eligible within cap. The RISK_DATA overlay must PASS;
+        non-PASS blocks and escalates to CRO. A read below the AUTO band halts
+        for a re-check (L1-Auto). Result rides on ``AgentOutcome.result`` ONLY
+        (R-SEC — never expose counter values in a lineage record)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event="get_monitoring_counters",
+            success_action="GET_MONITORING_COUNTERS",
+            op="RiskMetricsPort.get_monitoring_counters",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_monitoring_counters())
+
+    async def get_consumer_duty_signals(
+        self,
+        intent: GetConsumerDutySignalsIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Consumer Duty signals read via ``RiskMetricsPort.get_consumer_duty_signals``
+        (ADR-079). AUTO-eligible within cap. The RISK_DATA overlay must PASS;
+        non-PASS blocks and escalates to CRO. A read below the AUTO band halts
+        for a re-check (L1-Auto). Result rides on ``AgentOutcome.result`` ONLY
+        (R-SEC)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event="get_consumer_duty_signals",
+            success_action="GET_CONSUMER_DUTY_SIGNALS",
+            op="RiskMetricsPort.get_consumer_duty_signals",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_consumer_duty_signals())
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be in [0.0, 1.0]")
+        policies = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no port call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. Scope allow-list — an off-list op is refused outright.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op} is not on the risk oversight mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band. REVIEW → HALT_REVIEW_DEFERRED: reads are
+        #    AUTO-only (L1-Auto); there is no HITL hold path in this agent.
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+        if band is ConfirmationDecision.REVIEW:
+            return _Evaluation(
+                band,
+                False,
+                "HALT_REVIEW_DEFERRED",
+                "Read intent below AUTO band; reads are AUTO-only, no HITL hold (L1-Auto).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="review_deferred",
+                requires_hitl=True,
+            )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window tokens/cost); action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. RISK_DATA compliance gate. A non-PASS verdict halts AND escalates to CRO.
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            escalated = self._mask.cro_role
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"RISK_DATA overlay returned {ctx.compliance_result}; "
+                f"action blocked and escalated to {escalated}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=escalated,
+            )
+
+        # All gates satisfied — clear to commit the read.
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All risk oversight mask gates satisfied at {band.value} confidence; committing within scope.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except RiskMetricsPortError as exc:
+                    # Defense-in-depth: the port's own data guard fired. Emit one
+                    # lineage record (executed=False) then re-raise — no raw metric
+                    # value, exposure amount, or PII recorded.
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=ev.compliance_result,
+                        reasoning=f"Port rejected the action: {exc}",
+                        escalated_to=ev.escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        return await self._record(
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies=ev.policies,
+            compliance_result=compliance_result,
+            reasoning=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            correlation_id=ctx.correlation_id,
+            request_cost=ctx.request_cost,
+            budget_breach=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+
+    async def _record(
+        self,
+        *,
+        triggering_event: str,
+        intent: str,
+        policies: list[str],
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        confidence_score: float,
+        action_taken: str,
+        correlation_id: str,
+        request_cost: RequestCost,
+        budget_breach: BudgetBreach,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        """Build, persist, and return exactly one ADR-046 lineage record (the single
+        producer→sink seam used by every exit path). R-SEC: triggering_event uses
+        static op labels only — never metric values, exposure amounts, alert counters,
+        or PII. Port return values ride on AgentOutcome.result, never on this record."""
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=triggering_event,
+            intent=intent,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=None,
+            correlation_id=correlation_id,
+            cost_tokens=request_cost.tokens,
+            cost_amount=request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "BudgetBreach",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "GetAggregateExposureIntent",
+    "GetConsumerDutySignalsIntent",
+    "GetMonitoringCountersIntent",
+    "GetRiskDashboardIntent",
+    "ProcessRef",
+    "RequestCost",
+    "RiskMetricsPortError",
+    "RiskOversightAgent",
+    "RiskOversightMask",
+]

--- a/services/risk/__init__.py
+++ b/services/risk/__init__.py
@@ -1,0 +1,1 @@
+# services/risk — CRO risk oversight domain (ADR-079).

--- a/services/risk/risk_metrics_port.py
+++ b/services/risk/risk_metrics_port.py
@@ -1,0 +1,286 @@
+"""services/risk/risk_metrics_port.py — RiskMetricsPort: governed READ-ONLY risk
+metrics CONTRACT (ADR-079, CRO dashboard).
+
+EXPLICIT BOUNDARY: READ ONLY — fetch risk metrics for the CRO dashboard.
+This port does NOT change thresholds, approve models, make risk decisions,
+or write anything. There are NO mutating / approve / threshold methods on
+this port at all.
+
+WHY: ADR-079 defines the CRO risk-oversight agent as the governed surface through
+which the Chief Risk Officer accesses aggregate exposure, monitoring counters, and
+Consumer Duty signals. The RiskMetricsPort is the CONTRACT boundary the
+RiskOversightAgent mask ``scope`` allow-lists (ADR-049 §D1). The read-only
+constraint is an invariant: the port has no mutating methods so the agent cannot
+accidentally call one.
+
+Governance contract (ADR-049 §D1 — canonical):
+  reads: get_aggregate_exposure, get_monitoring_counters,
+         get_consumer_duty_signals, get_risk_dashboard
+
+PII / R-SEC (R-SEC-NEW-01, ADR-021):
+  All value types carry only aggregated / non-personal data. No method accepts or
+  returns raw PII (no customer IDs, names, IBANs, or personal transaction details).
+  ``total_gbp`` is the EMI-wide aggregate exposure, not a per-customer balance.
+
+I-01 (CLAUDE.md): monetary fields (``AggregateExposure.total_gbp``) are Decimal,
+never float.
+"""
+
+from __future__ import annotations
+
+import abc
+from abc import abstractmethod
+from dataclasses import dataclass
+from decimal import Decimal
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class RiskMetricsPortError(Exception):
+    """Base error for RiskMetricsPort read failures.
+
+    Adapters raise this (or a subclass) when a risk-data fetch fails.
+    RiskOversightAgent catches it, emits one lineage record (executed=False),
+    then re-raises — defense-in-depth (ADR-046 / ADR-027). Correlate failures
+    via ``AgentDecisionRecord.correlation_id``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Value types (frozen=True — immutable after construction, I-01 Decimal)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AggregateExposure:
+    """EMI-wide aggregate client-fund exposure snapshot (READ-ONLY).
+
+    ``total_gbp`` is the sum of all safeguarded client funds in GBP-equivalent
+    at the time of the snapshot. I-01: Decimal, never float.
+
+    Required fields:
+      total_gbp — aggregate exposure in GBP (Decimal).
+      as_of     — ISO-8601 date/datetime string of the snapshot.
+    """
+
+    total_gbp: Decimal
+    as_of: str
+
+
+@dataclass(frozen=True)
+class MonitoringCounters:
+    """Operational monitoring counters for the CRO dashboard (READ-ONLY).
+
+    Integer counts only — no raw transaction data or PII.
+
+    Required fields:
+      fraud_alerts — open fraud alerts at snapshot time.
+      aml_alerts   — open AML alerts at snapshot time.
+      as_of        — ISO-8601 date/datetime string of the snapshot.
+    """
+
+    fraud_alerts: int
+    aml_alerts: int
+    as_of: str
+
+
+@dataclass(frozen=True)
+class ConsumerDutySignal:
+    """A single Consumer Duty outcome metric signal (READ-ONLY).
+
+    Carries the metric name and its outcome label (e.g., WITHIN_TOLERANCE /
+    REQUIRES_REVIEW). No raw customer data or PII.
+
+    Required fields:
+      metric  — non-PII metric identifier (e.g., "complaints_rate").
+      outcome — outcome label (e.g., "WITHIN_TOLERANCE").
+      as_of   — ISO-8601 date/datetime string of the signal.
+    """
+
+    metric: str
+    outcome: str
+    as_of: str
+
+
+@dataclass(frozen=True)
+class RiskDashboard:
+    """Aggregated CRO risk dashboard snapshot (READ-ONLY).
+
+    Combines all three risk metric categories into a single response object.
+    Intended as the primary read surface for the CRO agent.
+
+    Required fields:
+      aggregate    — EMI-wide aggregate exposure (AggregateExposure).
+      counters     — monitoring counters (MonitoringCounters).
+      consumer_duty — list of Consumer Duty signals (may be empty).
+      as_of        — ISO-8601 date/datetime string of the dashboard snapshot.
+    """
+
+    aggregate: AggregateExposure
+    counters: MonitoringCounters
+    consumer_duty: list[ConsumerDutySignal]
+    as_of: str
+
+
+# ---------------------------------------------------------------------------
+# Abstract port (READ-ONLY CONTRACT, ADR-079)
+# ---------------------------------------------------------------------------
+
+
+class RiskMetricsPort(abc.ABC):
+    """Abstract CONTRACT for governed READ-ONLY risk metrics (ADR-079 CRO mask).
+
+    INVARIANT: Every method on this port is a pure read. There are NO methods
+    for approving models, changing thresholds, filing risk decisions, or
+    mutating any state. The absence of mutating methods is the primary
+    enforcement mechanism for the RiskOversightAgent read-only invariant.
+
+    Conformance rules:
+      Read-only (ADR-079 §D1): NO operation mutates state, changes thresholds,
+      or moves money. The four reads MUST NOT trigger any state change.
+
+      PII (ADR-021): All entity references are aggregate/non-personal. No method
+      returns raw PII or per-customer transaction data.
+
+      I-01: ``total_gbp`` in AggregateExposure is Decimal.
+    """
+
+    @abstractmethod
+    async def get_aggregate_exposure(self) -> AggregateExposure:
+        """Return the EMI-wide aggregate client-fund exposure snapshot (read-only).
+
+        Read-only; MUST NOT trigger any state change. I-01: total_gbp is Decimal.
+
+        Returns:
+            AggregateExposure with Decimal total_gbp and an as_of timestamp.
+
+        Raises:
+            RiskMetricsPortError: if the read fails.
+        """
+        ...  # pragma: no cover
+
+    @abstractmethod
+    async def get_monitoring_counters(self) -> MonitoringCounters:
+        """Return current operational monitoring counters (read-only).
+
+        Read-only; MUST NOT trigger any state change.
+
+        Returns:
+            MonitoringCounters with fraud_alerts and aml_alerts integer counts.
+
+        Raises:
+            RiskMetricsPortError: if the read fails.
+        """
+        ...  # pragma: no cover
+
+    @abstractmethod
+    async def get_consumer_duty_signals(self) -> list[ConsumerDutySignal]:
+        """Return the current Consumer Duty outcome signals (read-only).
+
+        Read-only; MUST NOT trigger any state change.
+
+        Returns:
+            A list of ConsumerDutySignal (possibly empty).
+
+        Raises:
+            RiskMetricsPortError: if the read fails.
+        """
+        ...  # pragma: no cover
+
+    @abstractmethod
+    async def get_risk_dashboard(self) -> RiskDashboard:
+        """Return the full aggregated CRO risk dashboard snapshot (read-only).
+
+        Aggregates get_aggregate_exposure, get_monitoring_counters, and
+        get_consumer_duty_signals into a single RiskDashboard. Read-only;
+        MUST NOT trigger any state change.
+
+        Returns:
+            RiskDashboard combining all three metric categories.
+
+        Raises:
+            RiskMetricsPortError: if the read fails.
+        """
+        ...  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# InMemory implementation (for unit tests)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryRiskMetricsPort(RiskMetricsPort):
+    """Configurable in-memory stub for unit tests.
+
+    Seed data is provided at construction time. Pass ``fail_on_call=True`` to
+    make every method raise :class:`RiskMetricsPortError` — exercises the agent
+    HALT_PROVIDER_ERROR branch.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_on_call: bool = False,
+        exposure: AggregateExposure | None = None,
+        counters: MonitoringCounters | None = None,
+        signals: list[ConsumerDutySignal] | None = None,
+    ) -> None:
+        self._fail = fail_on_call
+        self._exposure: AggregateExposure = exposure or AggregateExposure(
+            total_gbp=Decimal("1_000_000.00"),
+            as_of="2026-06-11",
+        )
+        self._counters: MonitoringCounters = counters or MonitoringCounters(
+            fraud_alerts=5,
+            aml_alerts=3,
+            as_of="2026-06-11",
+        )
+        self._signals: list[ConsumerDutySignal] = (
+            signals
+            if signals is not None
+            else [
+                ConsumerDutySignal(
+                    metric="complaints_rate",
+                    outcome="WITHIN_TOLERANCE",
+                    as_of="2026-06-11",
+                )
+            ]
+        )
+
+    def _check_fail(self) -> None:
+        if self._fail:
+            raise RiskMetricsPortError("InMemoryRiskMetricsPort configured to fail")
+
+    async def get_aggregate_exposure(self) -> AggregateExposure:
+        self._check_fail()
+        return self._exposure
+
+    async def get_monitoring_counters(self) -> MonitoringCounters:
+        self._check_fail()
+        return self._counters
+
+    async def get_consumer_duty_signals(self) -> list[ConsumerDutySignal]:
+        self._check_fail()
+        return list(self._signals)
+
+    async def get_risk_dashboard(self) -> RiskDashboard:
+        self._check_fail()
+        return RiskDashboard(
+            aggregate=self._exposure,
+            counters=self._counters,
+            consumer_duty=list(self._signals),
+            as_of=self._exposure.as_of,
+        )
+
+
+__all__ = [
+    "AggregateExposure",
+    "ConsumerDutySignal",
+    "InMemoryRiskMetricsPort",
+    "MonitoringCounters",
+    "RiskDashboard",
+    "RiskMetricsPort",
+    "RiskMetricsPortError",
+]

--- a/tests/agents/test_risk_oversight_agent.py
+++ b/tests/agents/test_risk_oversight_agent.py
@@ -1,0 +1,674 @@
+"""RiskOversightAgent test suite — 100% coverage over services/agents/risk_oversight_agent.py.
+
+Validates: ADR-049 §D2 gate-chain branches (process-ref resolution, scope allow-list,
+confidence band, cost-cap per-request and per-window, compliance gate, successful port
+call, port RiskMetricsPortError path), ADR-046 lineage invariants (one record per action
+on every exit path), R-SEC-NEW-01 (no raw metric value / exposure amount / alert counter
+in any lineage record — result rides on AgentOutcome.result only), and the
+READ-ONLY INVARIANT (mask scope has no approve / threshold / decision / model-approval op).
+
+asyncio_mode = "auto" (pyproject.toml): every ``async def test_*`` is auto-collected
+without @pytest.mark.asyncio.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.agents.risk_oversight_agent import (
+    GetAggregateExposureIntent,
+    GetConsumerDutySignalsIntent,
+    GetMonitoringCountersIntent,
+    GetRiskDashboardIntent,
+    RiskOversightAgent,
+    RiskOversightMask,
+)
+from services.risk.risk_metrics_port import (
+    AggregateExposure,
+    InMemoryRiskMetricsPort,
+    MonitoringCounters,
+    RiskDashboard,
+    RiskMetricsPortError,
+)
+
+# ---------------------------------------------------------------------------
+# In-test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeRecorder(DecisionRecorder):
+    """In-memory DecisionRecorder that collects records for assertion."""
+
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CAP = CostCap(
+    max_request_tokens=1_000,
+    max_request_cost=Decimal("1.00"),
+    max_window_tokens=10_000,
+    max_window_cost=Decimal("10.00"),
+)
+
+
+def make_mask(**overrides: object) -> RiskOversightMask:
+    base: dict[str, object] = {"cost_cap": _DEFAULT_CAP}
+    base.update(overrides)
+    return RiskOversightMask(**base)  # type: ignore[arg-type]
+
+
+def make_agent(
+    mask: RiskOversightMask | None = None,
+    port: InMemoryRiskMetricsPort | None = None,
+    recorder: FakeRecorder | None = None,
+    window: CostWindow | None = None,
+) -> tuple[RiskOversightAgent, InMemoryRiskMetricsPort, FakeRecorder]:
+    p = port or InMemoryRiskMetricsPort()
+    r = recorder or FakeRecorder()
+    m = mask or make_mask()
+    return RiskOversightAgent(risk_metrics_port=p, recorder=r, mask=m, cost_window=window), p, r
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    pid = "proc-risk-001" if resolved else ""
+    return ProcessRef(process_id=pid, version="1.0")
+
+
+def _cost(tokens: int = 10, cost: str = "0.01") -> RequestCost:
+    return RequestCost(tokens=tokens, cost=Decimal(cost))
+
+
+def make_dashboard_intent(
+    *,
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> GetRiskDashboardIntent:
+    return GetRiskDashboardIntent(
+        intent_text="get CRO risk dashboard",
+        process_ref=_ref(resolved),
+        correlation_id="corr-dashboard-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+def make_exposure_intent(
+    *,
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> GetAggregateExposureIntent:
+    return GetAggregateExposureIntent(
+        intent_text="get aggregate exposure for CRO",
+        process_ref=_ref(resolved),
+        correlation_id="corr-exposure-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+def make_counters_intent(
+    *,
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> GetMonitoringCountersIntent:
+    return GetMonitoringCountersIntent(
+        intent_text="get monitoring counters for CRO",
+        process_ref=_ref(resolved),
+        correlation_id="corr-counters-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+def make_signals_intent(
+    *,
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> GetConsumerDutySignalsIntent:
+    return GetConsumerDutySignalsIntent(
+        intent_text="get consumer duty signals for CRO",
+        process_ref=_ref(resolved),
+        correlation_id="corr-signals-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. AUTO happy path — get_risk_dashboard
+# ---------------------------------------------------------------------------
+
+
+async def test_get_risk_dashboard_auto_read_executes() -> None:
+    """Confidence 0.95 > 0.90 → AUTO band; port called; exactly one lineage record."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.halt_reason is None
+    assert outcome.requires_hitl is False
+    assert outcome.escalated_to is None
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.action_taken == "GET_RISK_DASHBOARD"
+    assert rec.agent_id == "risk_oversight_agent"
+    assert rec.compliance_result is ComplianceResult.PASS
+    assert rec.budget_breach_flag is BudgetBreach.NONE
+    # Dashboard rides on outcome.result ONLY — not on the record (R-SEC).
+    assert isinstance(outcome.result, RiskDashboard)
+    assert outcome.record is rec
+
+
+# ---------------------------------------------------------------------------
+# 2. AUTO happy path — get_aggregate_exposure
+# ---------------------------------------------------------------------------
+
+
+async def test_get_aggregate_exposure_auto_read_executes() -> None:
+    """Confidence 0.95 → AUTO; port called; result is AggregateExposure."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_aggregate_exposure(make_exposure_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, AggregateExposure)
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "GET_AGGREGATE_EXPOSURE"
+
+
+# ---------------------------------------------------------------------------
+# 3. AUTO happy path — get_monitoring_counters
+# ---------------------------------------------------------------------------
+
+
+async def test_get_monitoring_counters_auto_read_executes() -> None:
+    """Confidence 0.95 → AUTO; port called; result is MonitoringCounters."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_monitoring_counters(make_counters_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, MonitoringCounters)
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "GET_MONITORING_COUNTERS"
+
+
+# ---------------------------------------------------------------------------
+# 4. AUTO happy path — get_consumer_duty_signals
+# ---------------------------------------------------------------------------
+
+
+async def test_get_consumer_duty_signals_auto_read_executes() -> None:
+    """Confidence 0.95 → AUTO; port called; result is list[ConsumerDutySignal]."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_consumer_duty_signals(make_signals_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, list)
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "GET_CONSUMER_DUTY_SIGNALS"
+
+
+# ---------------------------------------------------------------------------
+# 5. Unresolved process_ref → HALT_UNRESOLVED_PROCESS
+# ---------------------------------------------------------------------------
+
+
+async def test_unresolved_process_ref_blocks() -> None:
+    """Empty process_id → unresolved; port NOT called; one lineage record."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent(resolved=False))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert outcome.requires_hitl is True
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+# ---------------------------------------------------------------------------
+# 6. Out-of-scope op → REJECT_OUT_OF_SCOPE
+# ---------------------------------------------------------------------------
+
+
+async def test_out_of_scope_op_refused() -> None:
+    """Scope limited to approve_threshold; get_risk_dashboard is off-list → REJECT."""
+    scoped_mask = make_mask(scope=("RiskMetricsPort.approve_threshold",))
+    agent, _, recorder = make_agent(mask=scoped_mask)
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent())
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "out_of_scope"
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+# ---------------------------------------------------------------------------
+# 7. Below-AUTO band (REVIEW) → HALT_REVIEW_DEFERRED, port NOT called
+# ---------------------------------------------------------------------------
+
+
+async def test_below_auto_band_read_halts_review_deferred() -> None:
+    """Confidence 0.80 is in REVIEW band (0.70–0.90); reads are AUTO-only (L1-Auto)."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent(confidence=0.80))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+# ---------------------------------------------------------------------------
+# 8. Low confidence (<0.70) → BLOCK_LOW_CONFIDENCE
+# ---------------------------------------------------------------------------
+
+
+async def test_block_low_confidence() -> None:
+    """Confidence 0.50 < 0.70 → BLOCK; port NOT called."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent(confidence=0.50))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+# ---------------------------------------------------------------------------
+# 9. Band boundaries: exactly at threshold values
+# ---------------------------------------------------------------------------
+
+
+async def test_band_boundary_exactly_auto_threshold_is_review() -> None:
+    """confidence=0.90 is NOT > 0.90 → falls to REVIEW band → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent(confidence=0.90))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+async def test_band_boundary_exactly_review_floor_is_review() -> None:
+    """confidence=0.70 is >= 0.70 → REVIEW band → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent(confidence=0.70))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+# ---------------------------------------------------------------------------
+# 10. Per-request token cost-cap breach → HALT_COST_CAP_BREACH
+# ---------------------------------------------------------------------------
+
+
+async def test_per_request_cost_cap_tokens_breach() -> None:
+    """tokens=100 > max_request_tokens=5 → breach; port NOT called."""
+    tight_cap = CostCap(
+        max_request_tokens=5,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert len(recorder.records) == 1
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+# ---------------------------------------------------------------------------
+# 11. Per-request monetary cost-cap breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_request_cost_cap_monetary_breach() -> None:
+    """cost=0.10 > max_request_cost=0.001 → breach; port NOT called."""
+    tight_cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("0.001"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent(cost="0.10"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+# ---------------------------------------------------------------------------
+# 12. Per-window token cost-cap breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_window_cost_cap_tokens_breach() -> None:
+    """Window nearly full on tokens; next request overflows → breach."""
+    window = CostWindow(
+        used_tokens=9990, used_cost=Decimal("0.00"), window_ref="risk_oversight_agent:test"
+    )
+    agent, _, recorder = make_agent(window=window)
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert len(recorder.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# 13. Per-window monetary cost-cap breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_window_monetary_cost_cap_breach() -> None:
+    """Window nearly full on cost; next request overflows → breach."""
+    window = CostWindow(
+        used_tokens=0, used_cost=Decimal("9.99"), window_ref="risk_oversight_agent:test"
+    )
+    cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=1_000_000,
+        max_window_cost=Decimal("10.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent(tokens=1, cost="0.02"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+# ---------------------------------------------------------------------------
+# 14. Compliance FAIL → HALT_COMPLIANCE_BLOCK, escalated to CRO
+# ---------------------------------------------------------------------------
+
+
+async def test_compliance_fail_blocks_escalates_to_cro() -> None:
+    """RISK_DATA FAIL → HALT_COMPLIANCE_BLOCK; escalated_to = CRO."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_risk_dashboard(
+        make_dashboard_intent(),
+        compliance_result=ComplianceResult.FAIL,
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CRO"
+    assert outcome.requires_hitl is True
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.escalated_to == "CRO"
+    assert rec.action_taken == "HALT_COMPLIANCE_BLOCK"
+
+
+# ---------------------------------------------------------------------------
+# 15. Compliance ESCALATE → HALT_COMPLIANCE_BLOCK, escalated to CRO
+# ---------------------------------------------------------------------------
+
+
+async def test_compliance_escalate_blocks_escalates_to_cro() -> None:
+    """RISK_DATA ESCALATE also halts and escalates to CRO."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_aggregate_exposure(
+        make_exposure_intent(),
+        compliance_result=ComplianceResult.ESCALATE,
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CRO"
+    assert len(recorder.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# 16. Port raises RiskMetricsPortError → lineage emitted (executed=False), re-raised
+# ---------------------------------------------------------------------------
+
+
+async def test_port_error_emits_lineage_then_reraises() -> None:
+    """RiskMetricsPortError: one lineage record with HALT_PROVIDER_ERROR; error re-raised."""
+    port = InMemoryRiskMetricsPort(fail_on_call=True)
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(RiskMetricsPortError):
+        await agent.get_risk_dashboard(make_dashboard_intent())
+
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert "HALT_PROVIDER_ERROR" in rec.action_taken
+    assert "RiskMetricsPortError" in rec.action_taken
+
+
+# ---------------------------------------------------------------------------
+# 17. Confidence out of [0, 1] → ValueError, NO lineage record
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_confidence_above_range_raises_no_record() -> None:
+    """confidence=1.1 → ValueError; _evaluate raises before any lineage record."""
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_risk_dashboard(make_dashboard_intent(confidence=1.1))
+    assert len(recorder.records) == 0
+
+
+async def test_invalid_confidence_below_range_raises_no_record() -> None:
+    """confidence=-0.01 → ValueError; no lineage record."""
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_risk_dashboard(make_dashboard_intent(confidence=-0.01))
+    assert len(recorder.records) == 0
+
+
+# ---------------------------------------------------------------------------
+# 18. R-SEC: no raw metric value / exposure amount in any lineage record field
+# ---------------------------------------------------------------------------
+
+
+async def test_no_raw_exposure_in_lineage_record() -> None:
+    """AggregateExposure.total_gbp sentinel MUST NOT appear in any AgentDecisionRecord field."""
+    sentinel = Decimal("87654321.99")
+    port = InMemoryRiskMetricsPort(
+        exposure=AggregateExposure(total_gbp=sentinel, as_of="2026-06-11")
+    )
+    agent, _, recorder = make_agent(port=port)
+
+    outcome = await agent.get_aggregate_exposure(make_exposure_intent())
+
+    # Exposure rides on AgentOutcome.result — confirmed it's there.
+    assert isinstance(outcome.result, AggregateExposure)
+    assert outcome.result.total_gbp == sentinel  # type: ignore[union-attr]
+
+    rec = recorder.records[0]
+    sentinel_str = str(sentinel)
+    # No raw metric value in any record string field (R-SEC-NEW-01).
+    assert sentinel_str not in rec.triggering_event
+    assert sentinel_str not in rec.intent
+    assert sentinel_str not in rec.reasoning_summary
+    assert sentinel_str not in rec.action_taken
+    assert all(sentinel_str not in p for p in rec.policies_evaluated)
+    # cost_amount is the REQUEST cost (e.g. "0.01"), never the exposure amount.
+    assert rec.cost_amount != sentinel
+
+
+# ---------------------------------------------------------------------------
+# 19. ADR-046 lineage-per-action: exactly 1 record per call on every exit path
+# ---------------------------------------------------------------------------
+
+
+async def test_lineage_one_record_per_call_adr046() -> None:
+    """Every action call (succeed or halt) emits exactly 1 record; total increments by 1."""
+    agent, _, recorder = make_agent()
+
+    assert len(recorder.records) == 0
+    await agent.get_risk_dashboard(make_dashboard_intent())
+    assert len(recorder.records) == 1
+
+    await agent.get_aggregate_exposure(make_exposure_intent())
+    assert len(recorder.records) == 2
+
+    await agent.get_monitoring_counters(make_counters_intent())
+    assert len(recorder.records) == 3
+
+    await agent.get_consumer_duty_signals(make_signals_intent())
+    assert len(recorder.records) == 4
+
+    # Halted path also emits exactly 1 record.
+    await agent.get_risk_dashboard(make_dashboard_intent(resolved=False))
+    assert len(recorder.records) == 5
+
+
+# ---------------------------------------------------------------------------
+# 20. Window accumulates only on successful reads
+# ---------------------------------------------------------------------------
+
+
+async def test_window_accumulates_on_successful_reads() -> None:
+    """Window.used_tokens / used_cost increment per successful port call."""
+    window = CostWindow(window_ref="risk_oversight_agent:test")
+    agent, _, _ = make_agent(window=window)
+
+    assert window.used_tokens == 0
+    assert window.used_cost == Decimal("0")
+    await agent.get_risk_dashboard(make_dashboard_intent(tokens=50, cost="0.05"))
+    assert window.used_tokens == 50
+    assert window.used_cost == Decimal("0.05")
+
+    await agent.get_aggregate_exposure(make_exposure_intent(tokens=30, cost="0.03"))
+    assert window.used_tokens == 80
+    assert window.used_cost == Decimal("0.08")
+
+
+async def test_window_not_accumulated_on_halt() -> None:
+    """A halted call (e.g., unresolved ref) MUST NOT advance the window."""
+    window = CostWindow(window_ref="risk_oversight_agent:test")
+    agent, _, _ = make_agent(window=window)
+
+    await agent.get_risk_dashboard(make_dashboard_intent(resolved=False))
+    assert window.used_tokens == 0
+    assert window.used_cost == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# 21. INVARIANT: default mask scope has only READ ops
+# ---------------------------------------------------------------------------
+
+
+async def test_invariant_scope_is_read_only() -> None:
+    """Default mask scope MUST NOT contain approve / threshold / decision / model_approval."""
+    mask = make_mask()
+    scope_lower = " ".join(mask.scope).lower()
+
+    assert "approve" not in scope_lower
+    assert "threshold" not in scope_lower
+    assert "decision" not in scope_lower
+    assert "model_approval" not in scope_lower
+
+    # Every op in scope must be one of the 4 read verbs.
+    read_ops = {
+        "RiskMetricsPort.get_risk_dashboard",
+        "RiskMetricsPort.get_aggregate_exposure",
+        "RiskMetricsPort.get_monitoring_counters",
+        "RiskMetricsPort.get_consumer_duty_signals",
+    }
+    for op in mask.scope:
+        assert op in read_ops, f"Non-read op found in mask scope: {op}"
+
+
+async def test_invariant_approve_op_always_out_of_scope() -> None:
+    """Proves an approve_threshold op is REJECT_OUT_OF_SCOPE — it is never in the allow-list.
+
+    This is the READ-ONLY INVARIANT test: even if the scope were manually overridden to
+    contain approve_threshold, the real read ops (get_risk_dashboard) would be off-list,
+    demonstrating that approve_threshold is never reachable through the standard agent flow.
+    """
+    scoped_mask = make_mask(scope=("RiskMetricsPort.approve_threshold",))
+    agent, _, _ = make_agent(mask=scoped_mask)
+
+    outcome = await agent.get_risk_dashboard(make_dashboard_intent())
+    # op="RiskMetricsPort.get_risk_dashboard" is not in this scope → REJECT.
+    assert outcome.halt_reason == "out_of_scope"
+
+
+# ---------------------------------------------------------------------------
+# 22. In-memory e2e full flow (real mask, InMemoryRiskMetricsPort, FakeRecorder)
+# ---------------------------------------------------------------------------
+
+
+async def test_in_memory_e2e_get_risk_dashboard() -> None:
+    """Full e2e: real RiskOversightMask + InMemoryRiskMetricsPort → AUTO read with lineage."""
+    recorder = FakeRecorder()
+    mask = RiskOversightMask(
+        cost_cap=CostCap(
+            max_request_tokens=500,
+            max_request_cost=Decimal("0.50"),
+            max_window_tokens=50_000,
+            max_window_cost=Decimal("50.00"),
+        ),
+        agent_id="risk_oversight_agent",
+        cro_role="CRO",
+    )
+    port = InMemoryRiskMetricsPort()
+    agent = RiskOversightAgent(risk_metrics_port=port, recorder=recorder, mask=mask)
+    intent = GetRiskDashboardIntent(
+        intent_text="CRO daily risk dashboard Q2-2026",
+        process_ref=ProcessRef(process_id="proc-e2e-risk-001", version="1.0"),
+        correlation_id="e2e-corr-risk-001",
+        confidence_score=0.97,
+        request_cost=RequestCost(tokens=100, cost=Decimal("0.10")),
+    )
+    outcome = await agent.get_risk_dashboard(intent)
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, RiskDashboard)
+    assert outcome.halt_reason is None
+    assert outcome.requires_hitl is False
+    assert outcome.escalated_to is None
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.agent_id == "risk_oversight_agent"
+    assert rec.correlation_id == "e2e-corr-risk-001"
+    assert rec.compliance_result is ComplianceResult.PASS
+    assert rec.budget_breach_flag is BudgetBreach.NONE
+    assert rec.triggering_event == "get_risk_dashboard"
+    assert rec.human_reviewed_by is None  # L1-Auto: never a reviewer

--- a/tests/test_risk/test_risk_metrics_port.py
+++ b/tests/test_risk/test_risk_metrics_port.py
@@ -1,0 +1,175 @@
+"""InMemoryRiskMetricsPort unit tests — 100% coverage over services/risk/risk_metrics_port.py.
+
+Validates the InMemoryRiskMetricsPort implementation: happy-path reads for all 4 methods,
+failure paths (fail_on_call=True), custom seed data injection, value type invariants
+(I-01: Decimal for total_gbp), and dashboard consistency with individual reads.
+
+asyncio_mode = "auto" (pyproject.toml): every ``async def test_*`` is auto-collected
+without @pytest.mark.asyncio.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.risk.risk_metrics_port import (
+    AggregateExposure,
+    ConsumerDutySignal,
+    InMemoryRiskMetricsPort,
+    MonitoringCounters,
+    RiskDashboard,
+    RiskMetricsPortError,
+)
+
+# ---------------------------------------------------------------------------
+# Happy path — default seed data
+# ---------------------------------------------------------------------------
+
+
+async def test_get_aggregate_exposure_returns_correct_type() -> None:
+    """Default seed returns AggregateExposure with Decimal total_gbp (I-01)."""
+    port = InMemoryRiskMetricsPort()
+    result = await port.get_aggregate_exposure()
+
+    assert isinstance(result, AggregateExposure)
+    assert isinstance(result.total_gbp, Decimal)
+    assert result.total_gbp > Decimal("0")
+    assert isinstance(result.as_of, str)
+
+
+async def test_get_monitoring_counters_returns_correct_type() -> None:
+    """Default seed returns MonitoringCounters with int alert fields."""
+    port = InMemoryRiskMetricsPort()
+    result = await port.get_monitoring_counters()
+
+    assert isinstance(result, MonitoringCounters)
+    assert isinstance(result.fraud_alerts, int)
+    assert isinstance(result.aml_alerts, int)
+    assert isinstance(result.as_of, str)
+
+
+async def test_get_consumer_duty_signals_returns_nonempty_list() -> None:
+    """Default seed returns a non-empty list of ConsumerDutySignal."""
+    port = InMemoryRiskMetricsPort()
+    result = await port.get_consumer_duty_signals()
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    assert isinstance(result[0], ConsumerDutySignal)
+    assert isinstance(result[0].metric, str)
+    assert isinstance(result[0].outcome, str)
+
+
+async def test_get_risk_dashboard_returns_correct_type() -> None:
+    """Default seed returns RiskDashboard aggregating all three metric categories."""
+    port = InMemoryRiskMetricsPort()
+    result = await port.get_risk_dashboard()
+
+    assert isinstance(result, RiskDashboard)
+    assert isinstance(result.aggregate, AggregateExposure)
+    assert isinstance(result.counters, MonitoringCounters)
+    assert isinstance(result.consumer_duty, list)
+    assert isinstance(result.as_of, str)
+
+
+# ---------------------------------------------------------------------------
+# Custom seed data
+# ---------------------------------------------------------------------------
+
+
+async def test_custom_exposure_seed_returned_unchanged() -> None:
+    """Custom AggregateExposure seed is returned exactly as injected."""
+    custom = AggregateExposure(total_gbp=Decimal("5_000_000.00"), as_of="2026-01-01")
+    port = InMemoryRiskMetricsPort(exposure=custom)
+    result = await port.get_aggregate_exposure()
+    assert result is custom
+
+
+async def test_custom_counters_seed_returned_unchanged() -> None:
+    """Custom MonitoringCounters seed is returned exactly as injected."""
+    custom = MonitoringCounters(fraud_alerts=99, aml_alerts=42, as_of="2026-01-01")
+    port = InMemoryRiskMetricsPort(counters=custom)
+    result = await port.get_monitoring_counters()
+    assert result is custom
+
+
+async def test_custom_signals_seed_returned_as_copy() -> None:
+    """Custom signals seed returns a list copy with the same elements (defensive copy)."""
+    custom = [ConsumerDutySignal(metric="m1", outcome="OK", as_of="2026-01-01")]
+    port = InMemoryRiskMetricsPort(signals=custom)
+    result = await port.get_consumer_duty_signals()
+
+    assert result == custom
+    # Returned list is a copy, not the same object.
+    assert result is not custom
+
+
+async def test_empty_signals_seed_returns_empty_list() -> None:
+    """Empty signals seed returns an empty list (not None)."""
+    port = InMemoryRiskMetricsPort(signals=[])
+    result = await port.get_consumer_duty_signals()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Failure paths (fail_on_call=True)
+# ---------------------------------------------------------------------------
+
+
+async def test_fail_on_get_aggregate_exposure() -> None:
+    """fail_on_call=True raises RiskMetricsPortError on get_aggregate_exposure."""
+    port = InMemoryRiskMetricsPort(fail_on_call=True)
+    with pytest.raises(RiskMetricsPortError):
+        await port.get_aggregate_exposure()
+
+
+async def test_fail_on_get_monitoring_counters() -> None:
+    """fail_on_call=True raises RiskMetricsPortError on get_monitoring_counters."""
+    port = InMemoryRiskMetricsPort(fail_on_call=True)
+    with pytest.raises(RiskMetricsPortError):
+        await port.get_monitoring_counters()
+
+
+async def test_fail_on_get_consumer_duty_signals() -> None:
+    """fail_on_call=True raises RiskMetricsPortError on get_consumer_duty_signals."""
+    port = InMemoryRiskMetricsPort(fail_on_call=True)
+    with pytest.raises(RiskMetricsPortError):
+        await port.get_consumer_duty_signals()
+
+
+async def test_fail_on_get_risk_dashboard() -> None:
+    """fail_on_call=True raises RiskMetricsPortError on get_risk_dashboard."""
+    port = InMemoryRiskMetricsPort(fail_on_call=True)
+    with pytest.raises(RiskMetricsPortError):
+        await port.get_risk_dashboard()
+
+
+# ---------------------------------------------------------------------------
+# Dashboard consistency: same seed data appears in all legs
+# ---------------------------------------------------------------------------
+
+
+async def test_risk_dashboard_consistent_with_individual_reads() -> None:
+    """RiskDashboard fields are consistent with the individual method return values."""
+    custom_exposure = AggregateExposure(total_gbp=Decimal("2_500_000.00"), as_of="2026-06-11")
+    custom_counters = MonitoringCounters(fraud_alerts=7, aml_alerts=2, as_of="2026-06-11")
+    custom_signals = [
+        ConsumerDutySignal(metric="complaints_rate", outcome="WITHIN_TOLERANCE", as_of="2026-06-11")
+    ]
+
+    port = InMemoryRiskMetricsPort(
+        exposure=custom_exposure,
+        counters=custom_counters,
+        signals=custom_signals,
+    )
+
+    dashboard = await port.get_risk_dashboard()
+    exposure = await port.get_aggregate_exposure()
+    counters = await port.get_monitoring_counters()
+    signals = await port.get_consumer_duty_signals()
+
+    assert dashboard.aggregate == exposure
+    assert dashboard.counters == counters
+    assert dashboard.consumer_duty == signals


### PR DESCRIPTION
## CRO RiskOversightAgent — sprint-47 / ADR-079 (port-first)

Implements ORG §2.2 CRO (SMF4) `RiskOversightAgent`, resolving the section's **L1-vs-L3 contradiction**: the header says `Autonomy: L3 / RED` but the agent-table row says `RiskOversightAgent | Risk dashboard | L1 Auto | No`. **Resolution (ADR-079):** the L3-RED posture is the **CRO function** (model risk assessment, fraud/AML threshold approval, Board escalation — stay L3/human, EU AI Act Art.14); the **dashboard agent is L1-Auto read-only**.

### ETAP A — `RiskMetricsPort` (`services/risk/`, read-only)
abc.ABC + `InMemoryRiskMetricsPort` + `RiskMetricsPortError`. Reads: aggregate exposure, fraud/AML monitoring counters, Consumer Duty PS22/9 signals, dashboard. Decimal (I-01). **No mutate/approve/threshold method exists** — read-only surface; live integrations out of scope (I-10).

### ETAP B — `RiskOversightAgent` (`services/agents/`, L1 Auto)
Read-only dashboard via the port. Full ADR-049 §D2 chain (process_ref → scope → band → cost_cap → compliance(RISK_DATA) → port), one ADR-046 `AgentDecisionRecord` per action, port + DecisionRecorder injected. **R-SEC:** only opaque handles in lineage — never metric values/PII.

**⭐ INVARIANT (enforced + tested):** the agent **never** emits an approve/threshold/decision action — only dashboard reads; any approve/threshold op is out-of-scope and refused (`test_invariant_scope_is_read_only`, `test_invariant_approve_op_always_out_of_scope`). This is the code-level enforcement of the §2.2 L1-read-only resolution.

**Files (6, scope-locked):** `services/risk/{__init__,risk_metrics_port}.py` + `services/agents/risk_oversight_agent.py` + 3 test files.

**Gates:** ruff ✅ · semgrep banxe-rules ✅ · pytest **39 tests, 100% coverage** on both new modules ✅ · full suite **10560 passed / 0 failed** ✅

Paired banxe-architecture PR (ADR-079 + ORG §2.2 + IL-173) lands separately. PR-only — no merge.