### PR TITLE
feat(cto-agent): DataQualityAgent + DataQualityPort (L1 read-only) — sprint-48 / ADR-080 / IL-174

### DIFF
--- a/services/agents/data_quality_agent.py
+++ b/services/agents/data_quality_agent.py
@@ -1,0 +1,618 @@
+"""DataQualityAgent — L1-Auto CTO data quality & drift detection agent
+(ADR-080 / ORG-STRUCTURE §2.7.1).
+
+WHY: ORG-STRUCTURE §2.7.1 defines the CTO data-quality agent as the governed surface
+through which a resolved data-quality read intent becomes a bounded DataQualityPort
+read action. This module implements the agent *logic* and *governance enforcement* of
+the data quality mask in front of the DataQualityPort CONTRACT.
+
+The CTO data-quality agent provides drift score detection, quality reports, dataset
+discovery, and freshness reads for the CTO data oversight dashboard. It operates
+READ-ONLY over the data quality layer and NEVER modifies source data, NEVER triggers
+pipeline runs, NEVER updates or retrains models, and NEVER makes autonomous data
+decisions.
+
+INVARIANT (CRITICAL — enforced in code):
+    DataQualityAgent is detection/reporting only. It MUST NEVER trigger retraining,
+    pipeline runs, or data writes. Enforced by three independent mechanisms:
+      (1) the mask scope allow-list contains ONLY the 4 read ops:
+          get_drift_score, get_quality_report, list_datasets, get_freshness;
+      (2) DataQualityPort has NO mutate/trigger/retrain method — calling one would
+          require a method that does not exist on the port;
+      (3) every ``success_action`` in this module is a DETECT/REPORT verb
+          (DETECT_DRIFT_SCORE, REPORT_QUALITY, DETECT_DATASETS, REPORT_FRESHNESS) —
+          the strings RETRAIN, TRIGGER, WRITE, UPDATE do not appear as success actions.
+
+    I-27 (CLAUDE.md): Feedback is supervised — this agent PROPOSES findings, never
+    applies model updates or triggers retraining autonomously.
+
+GOVERNANCE (ADR-049 §D2 gate-chain, fixed order):
+    process_ref → scope → band → cost_cap → compliance(DATA_QUALITY) → port call
+
+* ``scope``              — DataQualityPort READ ops only (allow-list:
+                           get_drift_score / get_quality_report /
+                           list_datasets / get_freshness).
+                           Off-list ops are refused outright (ADR-054 §D1 pattern).
+* ``autonomy_level``     — L1-Auto: every read is AUTO-eligible within cap. NO
+                           REVIEW HITL hold, NO biometric step-up. A read below
+                           the AUTO band halts for a re-check (HALT_REVIEW_DEFERRED,
+                           requires_hitl=True); there is no HITL hold path.
+* ``confirmation_policy``— AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70
+                           (ADR-047 thresholds). REVIEW band → HALT_REVIEW_DEFERRED.
+* ``cost_cap``           — per-request AND per-window hard caps in both token and
+                           monetary (Decimal) dimensions (ADR-047 §D2).
+* ``lineage_obligation`` — one ``AgentDecisionRecord`` per action on every exit
+                           path (ADR-046), non-optional.
+* ``compliance_gate``    — DATA_QUALITY overlay: the L3 check MUST PASS before a
+                           port call; a non-PASS verdict halts (BLOCK) and
+                           escalates to the CTO (config-as-data on the mask).
+
+Any one of {unresolved process_ref, out-of-scope op, below-band confidence,
+cost-cap breach, compliance(DATA_QUALITY) fail} halts the action (ADR-049 §D4).
+The port's own validation is defense-in-depth: if the port raises
+DataQualityPortError, lineage is emitted (executed=False) and the error is
+re-raised. Mask values are config-as-data, carried on :class:`DataQualityMask`.
+
+R-SEC (R-SEC-NEW-01, ADR-021): no raw metric value, drift score, null rate, or PII
+ever enters a lineage record. triggering_event is keyed on opaque labels only (dataset
+name + op prefix) — never metric values. The port's return value (DriftSignal /
+DataQualityReport / list[str] / int) rides on ``AgentOutcome.result`` ONLY — NEVER
+on the recorded ``AgentDecisionRecord``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.data_quality.data_quality_port import DataQualityPort, DataQualityPortError
+
+# ---------------------------------------------------------------------------
+# Mask (config-as-data)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DataQualityMask:
+    """Config-as-data CTO data quality oversight (ORG-STRUCTURE §2.7.1) mask.
+
+    All gate values are governed config, not hardcoded flow logic. The
+    AUTO/REVIEW/BLOCK scale is ADR-047 canon. The scope is the exclusive
+    read-only allow-list — no retrain/trigger/write op is present
+    (INVARIANT: see module docstring).
+    """
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    lineage_obligation: bool = True
+    agent_id: str = "data_quality_agent"
+    # The mask scope (allow-list): ONLY the 4 DataQualityPort READ ops.
+    # INVARIANT: no retrain / trigger / write / update op is present in this tuple.
+    # Any attempt to call one is REJECT_OUT_OF_SCOPE.
+    scope: tuple[str, ...] = (
+        "DataQualityPort.get_drift_score",
+        "DataQualityPort.get_quality_report",
+        "DataQualityPort.list_datasets",
+        "DataQualityPort.get_freshness",
+    )
+    # L3 compliance contour required before any port call.
+    compliance_gate: tuple[str, ...] = ("DATA_QUALITY",)
+    # Escalation role for a compliance non-PASS verdict (config-as-data).
+    cto_role: str = "CTO"
+
+
+# ---------------------------------------------------------------------------
+# Intent vocabulary
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GetDriftScoreIntent:
+    """A resolved drift-score detection intent
+    (``DataQualityPort.get_drift_score``) — the primary data drift read op
+    (ADR-080 / ORG-STRUCTURE §2.7.1). A read below the AUTO band halts for a
+    re-check, not a HITL hold. The DATA_QUALITY compliance overlay MUST PASS;
+    a non-PASS verdict blocks and escalates to the CTO. The DriftSignal rides
+    on ``AgentOutcome.result`` ONLY (R-SEC).
+    """
+
+    dataset: str
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class GetQualityReportIntent:
+    """A resolved quality-report read intent
+    (``DataQualityPort.get_quality_report``) — full data quality report for
+    the CTO dashboard (ADR-080). A read below the AUTO band halts for a
+    re-check. The DATA_QUALITY overlay MUST PASS; non-PASS escalates to CTO.
+    The DataQualityReport rides on ``AgentOutcome.result`` ONLY (R-SEC).
+    """
+
+    dataset: str
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class ListDatasetsIntent:
+    """A resolved dataset-discovery intent
+    (``DataQualityPort.list_datasets``) — enumerates monitored datasets
+    (ADR-080). A read below the AUTO band halts for a re-check. The
+    DATA_QUALITY overlay MUST PASS; non-PASS escalates to CTO. The dataset
+    list rides on ``AgentOutcome.result`` ONLY (R-SEC).
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class GetFreshnessIntent:
+    """A resolved freshness-report intent
+    (``DataQualityPort.get_freshness``) — seconds since last data update
+    (ADR-080). A read below the AUTO band halts for a re-check. The
+    DATA_QUALITY overlay MUST PASS; non-PASS escalates to CTO. The freshness
+    value rides on ``AgentOutcome.result`` ONLY (R-SEC).
+    """
+
+    dataset: str
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    """All inputs a single masked data quality action evaluates against."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class DataQualityAgent:
+    """L1-Auto CTO data quality & drift detection agent enforcing ADR-049 §D2 gate chain.
+
+    The :class:`~services.data_quality.data_quality_port.DataQualityPort` and the
+    lineage recorder are injected as interfaces (constructor injection); the agent
+    contains pure governance logic and is unit-testable without any live infra.
+
+    INVARIANT: DETECTION/REPORTING ONLY. This agent MUST NEVER trigger retraining,
+    pipeline runs, or data writes. See module docstring for the three independent
+    enforcement mechanisms. I-27: PROPOSES findings only, never applies autonomously.
+    """
+
+    def __init__(
+        self,
+        *,
+        data_quality_port: DataQualityPort,
+        recorder: DecisionRecorder,
+        mask: DataQualityMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._port = data_quality_port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def get_drift_score(
+        self,
+        intent: GetDriftScoreIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Drift score detection via ``DataQualityPort.get_drift_score`` (ADR-080).
+
+        AUTO-eligible within cap. DATA_QUALITY overlay (``compliance_result``) MUST PASS;
+        a non-PASS verdict blocks and escalates to the CTO. A read below the AUTO band
+        halts for a re-check (L1-Auto). DriftSignal rides on ``AgentOutcome.result``
+        ONLY (R-SEC — no drift score in lineage)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_drift_score:{intent.dataset}",
+            success_action="DETECT_DRIFT_SCORE",
+            op="DataQualityPort.get_drift_score",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_drift_score(intent.dataset))
+
+    async def get_quality_report(
+        self,
+        intent: GetQualityReportIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Quality report read via ``DataQualityPort.get_quality_report`` (ADR-080).
+
+        AUTO-eligible within cap. DATA_QUALITY overlay MUST PASS; non-PASS blocks and
+        escalates to CTO. A read below the AUTO band halts for a re-check (L1-Auto).
+        DataQualityReport rides on ``AgentOutcome.result`` ONLY (R-SEC — no null-rate
+        or schema-conformance value in lineage)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_quality_report:{intent.dataset}",
+            success_action="REPORT_QUALITY",
+            op="DataQualityPort.get_quality_report",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_quality_report(intent.dataset))
+
+    async def list_datasets(
+        self,
+        intent: ListDatasetsIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Dataset discovery via ``DataQualityPort.list_datasets`` (ADR-080).
+
+        AUTO-eligible within cap. DATA_QUALITY overlay MUST PASS; non-PASS blocks and
+        escalates to CTO. A read below the AUTO band halts for a re-check (L1-Auto).
+        Dataset list rides on ``AgentOutcome.result`` ONLY (R-SEC)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event="list_datasets",
+            success_action="DETECT_DATASETS",
+            op="DataQualityPort.list_datasets",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.list_datasets())
+
+    async def get_freshness(
+        self,
+        intent: GetFreshnessIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Freshness report via ``DataQualityPort.get_freshness`` (ADR-080).
+
+        AUTO-eligible within cap. DATA_QUALITY overlay MUST PASS; non-PASS blocks and
+        escalates to CTO. A read below the AUTO band halts for a re-check (L1-Auto).
+        Freshness value rides on ``AgentOutcome.result`` ONLY (R-SEC — no freshness
+        seconds value in lineage)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_freshness:{intent.dataset}",
+            success_action="REPORT_FRESHNESS",
+            op="DataQualityPort.get_freshness",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_freshness(intent.dataset))
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be in [0.0, 1.0]")
+        policies = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no port call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. Scope allow-list — an off-list op is refused outright.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op} is not on the data quality mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band. REVIEW → HALT_REVIEW_DEFERRED: reads are
+        #    AUTO-only (L1-Auto); there is no HITL hold path in this agent.
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+        if band is ConfirmationDecision.REVIEW:
+            return _Evaluation(
+                band,
+                False,
+                "HALT_REVIEW_DEFERRED",
+                "Read intent below AUTO band; reads are AUTO-only, no HITL hold (L1-Auto).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="review_deferred",
+                requires_hitl=True,
+            )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window tokens/cost); action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. DATA_QUALITY compliance gate. A non-PASS verdict halts AND escalates to CTO.
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            escalated = self._mask.cto_role
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"DATA_QUALITY overlay returned {ctx.compliance_result}; "
+                f"action blocked and escalated to {escalated}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=escalated,
+            )
+
+        # All gates satisfied — clear to commit the read.
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All data quality mask gates satisfied at {band.value} confidence; committing within scope.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except DataQualityPortError as exc:
+                    # Defense-in-depth: the port's own data guard fired. Emit one
+                    # lineage record (executed=False) then re-raise — no raw metric
+                    # value, drift score, null rate, or PII recorded.
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=ev.compliance_result,
+                        reasoning=f"Port rejected the action: {exc}",
+                        escalated_to=ev.escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        return await self._record(
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies=ev.policies,
+            compliance_result=compliance_result,
+            reasoning=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            correlation_id=ctx.correlation_id,
+            request_cost=ctx.request_cost,
+            budget_breach=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+
+    async def _record(
+        self,
+        *,
+        triggering_event: str,
+        intent: str,
+        policies: list[str],
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        confidence_score: float,
+        action_taken: str,
+        correlation_id: str,
+        request_cost: RequestCost,
+        budget_breach: BudgetBreach,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        """Build, persist, and return exactly one ADR-046 lineage record (the single
+        producer→sink seam used by every exit path). R-SEC: triggering_event uses
+        opaque dataset/op labels only — never drift scores, null rates, metric values,
+        freshness values, or PII. Port return values ride on AgentOutcome.result,
+        never on this record."""
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=triggering_event,
+            intent=intent,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=None,
+            correlation_id=correlation_id,
+            cost_tokens=request_cost.tokens,
+            cost_amount=request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "BudgetBreach",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DataQualityAgent",
+    "DataQualityMask",
+    "DataQualityPortError",
+    "DecisionRecorder",
+    "GetDriftScoreIntent",
+    "GetFreshnessIntent",
+    "GetQualityReportIntent",
+    "ListDatasetsIntent",
+    "ProcessRef",
+    "RequestCost",
+]

--- a/services/data_quality/__init__.py
+++ b/services/data_quality/__init__.py
@@ -1,0 +1,1 @@
+# services/data_quality — CTO data quality & drift detection domain (ADR-080).

--- a/services/data_quality/data_quality_port.py
+++ b/services/data_quality/data_quality_port.py
@@ -1,0 +1,256 @@
+"""services/data_quality/data_quality_port.py — DataQualityPort: governed READ-ONLY
+data quality & drift CONTRACT (ADR-080, CTO DataQualityAgent).
+
+EXPLICIT BOUNDARY: READ ONLY — detection and reporting of data-quality and drift
+signals only. This port does NOT mutate data, trigger pipeline runs, update models,
+or retrain models. There are NO mutate/trigger/retrain methods on this port at all
+(I-10: no fake integrations, I-27: no autonomous model updates).
+
+WHY: ADR-080 defines the CTO data-quality agent as the governed surface through
+which the Chief Technology Officer accesses drift scores, quality reports, dataset
+freshness, and dataset discovery. The DataQualityPort is the CONTRACT boundary the
+DataQualityAgent mask ``scope`` allow-lists (ADR-049 §D1). The read-only constraint
+is an invariant: the port has no mutating methods so the agent cannot accidentally
+call one.
+
+Governance contract (ADR-049 §D1 — canonical):
+  reads: get_drift_score, get_quality_report, list_datasets, get_freshness
+
+PII / R-SEC (R-SEC-NEW-01, ADR-021):
+  All value types carry only aggregated / non-personal data. No method accepts or
+  returns raw PII. Dataset identifiers are opaque handles, not customer references.
+
+I-01 (CLAUDE.md): numeric quality metrics (drift_score, null_rate, schema_conformance)
+are Decimal, never float.
+"""
+
+from __future__ import annotations
+
+import abc
+from abc import abstractmethod
+from dataclasses import dataclass
+from decimal import Decimal
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class DataQualityPortError(Exception):
+    """Base error for DataQualityPort read failures.
+
+    Adapters raise this (or a subclass) when a data-quality fetch fails.
+    DataQualityAgent catches it, emits one lineage record (executed=False),
+    then re-raises — defense-in-depth (ADR-046 / ADR-027). Correlate failures
+    via ``AgentDecisionRecord.correlation_id``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Value types (frozen=True — immutable after construction, I-01 Decimal)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DriftSignal:
+    """A single dataset drift signal snapshot (READ-ONLY).
+
+    I-01: drift_score is Decimal, never float.
+
+    Required fields:
+      dataset     — dataset identifier (non-PII opaque handle).
+      drift_score — drift magnitude as Decimal (range: [0.0, 1.0]).
+      as_of       — ISO-8601 date/datetime string of the snapshot.
+    """
+
+    dataset: str
+    drift_score: Decimal
+    as_of: str
+
+
+@dataclass(frozen=True)
+class DataQualityReport:
+    """Full data quality report for a dataset (READ-ONLY).
+
+    I-01: all numeric quality metric fields are Decimal, never float.
+
+    Required fields:
+      dataset             — dataset identifier (non-PII opaque handle).
+      null_rate           — fraction of null values as Decimal [0.0, 1.0].
+      schema_conformance  — fraction of schema-conformant records as Decimal [0.0, 1.0].
+      freshness_seconds   — integer seconds since last data update.
+      drift_score         — drift magnitude as Decimal [0.0, 1.0].
+      as_of               — ISO-8601 date/datetime string of the report.
+    """
+
+    dataset: str
+    null_rate: Decimal
+    schema_conformance: Decimal
+    freshness_seconds: int
+    drift_score: Decimal
+    as_of: str
+
+
+# ---------------------------------------------------------------------------
+# Abstract port (READ-ONLY CONTRACT, ADR-080)
+# ---------------------------------------------------------------------------
+
+
+class DataQualityPort(abc.ABC):
+    """Abstract CONTRACT for governed READ-ONLY data quality & drift metrics (ADR-080).
+
+    INVARIANT: Every method on this port is a pure read. There are NO methods
+    for triggering pipeline runs, retraining models, updating data, or mutating
+    any state. The absence of mutating methods is the primary enforcement mechanism
+    for the DataQualityAgent read-only invariant (I-27).
+
+    Conformance rules:
+      Read-only (ADR-080 §D1): NO operation mutates state, triggers pipelines,
+      or retrains models. The four reads MUST NOT trigger any state change.
+
+      I-01: all numeric quality metric fields are Decimal, never float.
+    """
+
+    @abstractmethod
+    async def get_drift_score(self, dataset: str) -> DriftSignal:
+        """Return the current drift signal for a dataset (read-only).
+
+        Read-only; MUST NOT trigger any state change. I-01: drift_score is Decimal.
+
+        Returns:
+            DriftSignal with Decimal drift_score and an as_of timestamp.
+
+        Raises:
+            DataQualityPortError: if the dataset is unknown or the read fails.
+        """
+        ...  # pragma: no cover
+
+    @abstractmethod
+    async def get_quality_report(self, dataset: str) -> DataQualityReport:
+        """Return the full quality report for a dataset (read-only).
+
+        Read-only; MUST NOT trigger any state change. I-01: all numeric fields Decimal.
+
+        Returns:
+            DataQualityReport with Decimal quality metrics.
+
+        Raises:
+            DataQualityPortError: if the dataset is unknown or the read fails.
+        """
+        ...  # pragma: no cover
+
+    @abstractmethod
+    async def list_datasets(self) -> list[str]:
+        """Return the list of known dataset identifiers (read-only).
+
+        Read-only; MUST NOT trigger any state change.
+
+        Returns:
+            A list of dataset identifier strings (possibly empty).
+
+        Raises:
+            DataQualityPortError: if the read fails.
+        """
+        ...  # pragma: no cover
+
+    @abstractmethod
+    async def get_freshness(self, dataset: str) -> int:
+        """Return freshness_seconds for a dataset (read-only).
+
+        Read-only; MUST NOT trigger any state change.
+
+        Returns:
+            Integer seconds since last data update.
+
+        Raises:
+            DataQualityPortError: if the dataset is unknown or the read fails.
+        """
+        ...  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# InMemory implementation (for unit tests)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryDataQualityPort(DataQualityPort):
+    """Configurable in-memory stub for unit tests.
+
+    Seed data is provided at construction time. Pass ``fail_on_call=True`` to
+    make every method raise :class:`DataQualityPortError` — exercises the agent
+    HALT_PROVIDER_ERROR branch. Raises DataQualityPortError for unknown datasets.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_on_call: bool = False,
+        signals: dict[str, DriftSignal] | None = None,
+        reports: dict[str, DataQualityReport] | None = None,
+    ) -> None:
+        self._fail = fail_on_call
+        self._signals: dict[str, DriftSignal] = signals or {
+            "payments": DriftSignal(
+                dataset="payments",
+                drift_score=Decimal("0.05"),
+                as_of="2026-06-11",
+            ),
+            "customers": DriftSignal(
+                dataset="customers",
+                drift_score=Decimal("0.02"),
+                as_of="2026-06-11",
+            ),
+        }
+        self._reports: dict[str, DataQualityReport] = reports or {
+            "payments": DataQualityReport(
+                dataset="payments",
+                null_rate=Decimal("0.01"),
+                schema_conformance=Decimal("0.99"),
+                freshness_seconds=300,
+                drift_score=Decimal("0.05"),
+                as_of="2026-06-11",
+            ),
+            "customers": DataQualityReport(
+                dataset="customers",
+                null_rate=Decimal("0.00"),
+                schema_conformance=Decimal("1.00"),
+                freshness_seconds=600,
+                drift_score=Decimal("0.02"),
+                as_of="2026-06-11",
+            ),
+        }
+
+    def _check_fail(self) -> None:
+        if self._fail:
+            raise DataQualityPortError("InMemoryDataQualityPort configured to fail")
+
+    async def get_drift_score(self, dataset: str) -> DriftSignal:
+        self._check_fail()
+        if dataset not in self._signals:
+            raise DataQualityPortError(f"Unknown dataset: {dataset!r}")
+        return self._signals[dataset]
+
+    async def get_quality_report(self, dataset: str) -> DataQualityReport:
+        self._check_fail()
+        if dataset not in self._reports:
+            raise DataQualityPortError(f"Unknown dataset: {dataset!r}")
+        return self._reports[dataset]
+
+    async def list_datasets(self) -> list[str]:
+        self._check_fail()
+        return list(self._signals.keys())
+
+    async def get_freshness(self, dataset: str) -> int:
+        self._check_fail()
+        if dataset not in self._reports:
+            raise DataQualityPortError(f"Unknown dataset: {dataset!r}")
+        return self._reports[dataset].freshness_seconds
+
+
+__all__ = [
+    "DataQualityPort",
+    "DataQualityPortError",
+    "DataQualityReport",
+    "DriftSignal",
+    "InMemoryDataQualityPort",
+]

--- a/tests/agents/test_data_quality_agent.py
+++ b/tests/agents/test_data_quality_agent.py
@@ -1,0 +1,806 @@
+"""DataQualityAgent test suite — 100% coverage over services/agents/data_quality_agent.py.
+
+Validates: ADR-049 §D2 gate-chain branches (process-ref resolution, scope allow-list,
+confidence band, cost-cap per-request and per-window, compliance gate, successful port
+call, port DataQualityPortError path), ADR-046 lineage invariants (one record per action
+on every exit path), R-SEC-NEW-01 (no raw metric value / drift score / null-rate in any
+lineage record — result rides on AgentOutcome.result only), and the DETECTION/REPORTING
+INVARIANT (mask scope has no retrain / trigger / write / update op; all success_actions
+use DETECT_ or REPORT_ prefix).
+
+asyncio_mode = "auto" (pyproject.toml): every ``async def test_*`` is auto-collected
+without @pytest.mark.asyncio.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.agents.data_quality_agent import (
+    DataQualityAgent,
+    DataQualityMask,
+    GetDriftScoreIntent,
+    GetFreshnessIntent,
+    GetQualityReportIntent,
+    ListDatasetsIntent,
+)
+from services.data_quality.data_quality_port import (
+    DataQualityPortError,
+    DataQualityReport,
+    DriftSignal,
+    InMemoryDataQualityPort,
+)
+
+# ---------------------------------------------------------------------------
+# In-test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeRecorder(DecisionRecorder):
+    """In-memory DecisionRecorder that collects records for assertion."""
+
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CAP = CostCap(
+    max_request_tokens=1_000,
+    max_request_cost=Decimal("1.00"),
+    max_window_tokens=10_000,
+    max_window_cost=Decimal("10.00"),
+)
+
+
+def make_mask(**overrides: object) -> DataQualityMask:
+    base: dict[str, object] = {"cost_cap": _DEFAULT_CAP}
+    base.update(overrides)
+    return DataQualityMask(**base)  # type: ignore[arg-type]
+
+
+def make_agent(
+    mask: DataQualityMask | None = None,
+    port: InMemoryDataQualityPort | None = None,
+    recorder: FakeRecorder | None = None,
+    window: CostWindow | None = None,
+) -> tuple[DataQualityAgent, InMemoryDataQualityPort, FakeRecorder]:
+    p = port or InMemoryDataQualityPort()
+    r = recorder or FakeRecorder()
+    m = mask or make_mask()
+    return DataQualityAgent(data_quality_port=p, recorder=r, mask=m, cost_window=window), p, r
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    pid = "proc-dq-001" if resolved else ""
+    return ProcessRef(process_id=pid, version="1.0")
+
+
+def _cost(tokens: int = 10, cost: str = "0.01") -> RequestCost:
+    return RequestCost(tokens=tokens, cost=Decimal(cost))
+
+
+def make_drift_intent(
+    *,
+    dataset: str = "payments",
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> GetDriftScoreIntent:
+    return GetDriftScoreIntent(
+        dataset=dataset,
+        intent_text="detect drift score for payments dataset",
+        process_ref=_ref(resolved),
+        correlation_id="corr-drift-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+def make_report_intent(
+    *,
+    dataset: str = "payments",
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> GetQualityReportIntent:
+    return GetQualityReportIntent(
+        dataset=dataset,
+        intent_text="report quality for payments dataset",
+        process_ref=_ref(resolved),
+        correlation_id="corr-report-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+def make_list_intent(
+    *,
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> ListDatasetsIntent:
+    return ListDatasetsIntent(
+        intent_text="detect datasets available for quality monitoring",
+        process_ref=_ref(resolved),
+        correlation_id="corr-list-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+def make_freshness_intent(
+    *,
+    dataset: str = "payments",
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> GetFreshnessIntent:
+    return GetFreshnessIntent(
+        dataset=dataset,
+        intent_text="report freshness for payments dataset",
+        process_ref=_ref(resolved),
+        correlation_id="corr-freshness-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. AUTO happy path — get_drift_score
+# ---------------------------------------------------------------------------
+
+
+async def test_get_drift_score_auto_read_executes() -> None:
+    """Confidence 0.95 > 0.90 → AUTO band; port called; exactly one lineage record."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_drift_score(make_drift_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.halt_reason is None
+    assert outcome.requires_hitl is False
+    assert outcome.escalated_to is None
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.action_taken == "DETECT_DRIFT_SCORE"
+    assert rec.agent_id == "data_quality_agent"
+    assert rec.compliance_result is ComplianceResult.PASS
+    assert rec.budget_breach_flag is BudgetBreach.NONE
+    # DriftSignal rides on outcome.result ONLY — not on the record (R-SEC).
+    assert isinstance(outcome.result, DriftSignal)
+    assert outcome.record is rec
+
+
+# ---------------------------------------------------------------------------
+# 2. AUTO happy path — get_quality_report
+# ---------------------------------------------------------------------------
+
+
+async def test_get_quality_report_auto_read_executes() -> None:
+    """Confidence 0.95 → AUTO; port called; result is DataQualityReport."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_quality_report(make_report_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, DataQualityReport)
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "REPORT_QUALITY"
+
+
+# ---------------------------------------------------------------------------
+# 3. AUTO happy path — list_datasets
+# ---------------------------------------------------------------------------
+
+
+async def test_list_datasets_auto_read_executes() -> None:
+    """Confidence 0.95 → AUTO; port called; result is list[str]."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.list_datasets(make_list_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, list)
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "DETECT_DATASETS"
+
+
+# ---------------------------------------------------------------------------
+# 4. AUTO happy path — get_freshness
+# ---------------------------------------------------------------------------
+
+
+async def test_get_freshness_auto_read_executes() -> None:
+    """Confidence 0.95 → AUTO; port called; result is int."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_freshness(make_freshness_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, int)
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "REPORT_FRESHNESS"
+
+
+# ---------------------------------------------------------------------------
+# 5. Unresolved process_ref → HALT_UNRESOLVED_PROCESS
+# ---------------------------------------------------------------------------
+
+
+async def test_unresolved_process_ref_blocks() -> None:
+    """Empty process_id → unresolved; port NOT called; one lineage record."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_drift_score(make_drift_intent(resolved=False))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert outcome.requires_hitl is True
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+# ---------------------------------------------------------------------------
+# 6. Out-of-scope op → REJECT_OUT_OF_SCOPE (INVARIANT: trigger_retrain refused)
+# ---------------------------------------------------------------------------
+
+
+async def test_out_of_scope_op_refused() -> None:
+    """Scope restricted to trigger_retrain (a mutate op); get_drift_score is off-list → REJECT.
+
+    This is the INVARIANT test: DataQualityPort.trigger_retrain is never in the default
+    allow-list. When a scope containing only a mutate op is configured, the standard read
+    ops are REJECT_OUT_OF_SCOPE — demonstrating that trigger_retrain cannot be reached via
+    the normal agent flow (the port also has no such method).
+    """
+    scoped_mask = make_mask(scope=("DataQualityPort.trigger_retrain",))
+    agent, _, recorder = make_agent(mask=scoped_mask)
+    outcome = await agent.get_drift_score(make_drift_intent())
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "out_of_scope"
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+# ---------------------------------------------------------------------------
+# 7. Below-AUTO band (REVIEW) → HALT_REVIEW_DEFERRED, port NOT called
+# ---------------------------------------------------------------------------
+
+
+async def test_below_auto_band_read_halts_review_deferred() -> None:
+    """Confidence 0.80 is in REVIEW band (0.70–0.90); reads are AUTO-only (L1-Auto)."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_drift_score(make_drift_intent(confidence=0.80))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+# ---------------------------------------------------------------------------
+# 8. Low confidence (<0.70) → BLOCK_LOW_CONFIDENCE
+# ---------------------------------------------------------------------------
+
+
+async def test_block_low_confidence() -> None:
+    """Confidence 0.50 < 0.70 → BLOCK; port NOT called."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_drift_score(make_drift_intent(confidence=0.50))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+# ---------------------------------------------------------------------------
+# 9. Band boundaries: exactly at threshold values
+# ---------------------------------------------------------------------------
+
+
+async def test_band_boundary_exactly_auto_threshold_is_review() -> None:
+    """confidence=0.90 is NOT > 0.90 → falls to REVIEW band → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.get_drift_score(make_drift_intent(confidence=0.90))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+async def test_band_boundary_exactly_review_floor_is_review() -> None:
+    """confidence=0.70 is >= 0.70 → REVIEW band → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.get_drift_score(make_drift_intent(confidence=0.70))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+# ---------------------------------------------------------------------------
+# 10. Per-request token cost-cap breach → HALT_COST_CAP_BREACH
+# ---------------------------------------------------------------------------
+
+
+async def test_per_request_cost_cap_tokens_breach() -> None:
+    """tokens=100 > max_request_tokens=5 → breach; port NOT called."""
+    tight_cap = CostCap(
+        max_request_tokens=5,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.get_drift_score(make_drift_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert len(recorder.records) == 1
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+# ---------------------------------------------------------------------------
+# 11. Per-request monetary cost-cap breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_request_cost_cap_monetary_breach() -> None:
+    """cost=0.10 > max_request_cost=0.001 → breach; port NOT called."""
+    tight_cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("0.001"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.get_drift_score(make_drift_intent(cost="0.10"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+# ---------------------------------------------------------------------------
+# 12. Per-window token cost-cap breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_window_cost_cap_tokens_breach() -> None:
+    """Window nearly full on tokens; next request overflows → breach."""
+    window = CostWindow(
+        used_tokens=9990, used_cost=Decimal("0.00"), window_ref="data_quality_agent:test"
+    )
+    agent, _, recorder = make_agent(window=window)
+    outcome = await agent.get_drift_score(make_drift_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert len(recorder.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# 13. Per-window monetary cost-cap breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_window_monetary_cost_cap_breach() -> None:
+    """Window nearly full on cost; next request overflows → breach."""
+    window = CostWindow(
+        used_tokens=0, used_cost=Decimal("9.99"), window_ref="data_quality_agent:test"
+    )
+    cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=1_000_000,
+        max_window_cost=Decimal("10.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.get_drift_score(make_drift_intent(tokens=1, cost="0.02"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+# ---------------------------------------------------------------------------
+# 14. Compliance FAIL → HALT_COMPLIANCE_BLOCK, escalated to CTO
+# ---------------------------------------------------------------------------
+
+
+async def test_compliance_fail_blocks_escalates_to_cto() -> None:
+    """DATA_QUALITY FAIL → HALT_COMPLIANCE_BLOCK; escalated_to = CTO."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_drift_score(
+        make_drift_intent(),
+        compliance_result=ComplianceResult.FAIL,
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CTO"
+    assert outcome.requires_hitl is True
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.escalated_to == "CTO"
+    assert rec.action_taken == "HALT_COMPLIANCE_BLOCK"
+
+
+# ---------------------------------------------------------------------------
+# 15. Compliance ESCALATE → HALT_COMPLIANCE_BLOCK, escalated to CTO
+# ---------------------------------------------------------------------------
+
+
+async def test_compliance_escalate_blocks_escalates_to_cto() -> None:
+    """DATA_QUALITY ESCALATE also halts and escalates to CTO."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_quality_report(
+        make_report_intent(),
+        compliance_result=ComplianceResult.ESCALATE,
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CTO"
+    assert len(recorder.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# 16. Port raises DataQualityPortError → lineage emitted (executed=False), re-raised
+# ---------------------------------------------------------------------------
+
+
+async def test_port_error_emits_lineage_then_reraises() -> None:
+    """DataQualityPortError: one lineage record with HALT_PROVIDER_ERROR; error re-raised."""
+    port = InMemoryDataQualityPort(fail_on_call=True)
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(DataQualityPortError):
+        await agent.get_drift_score(make_drift_intent())
+
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert "HALT_PROVIDER_ERROR" in rec.action_taken
+    assert "DataQualityPortError" in rec.action_taken
+
+
+# ---------------------------------------------------------------------------
+# 17. Port error on each action type
+# ---------------------------------------------------------------------------
+
+
+async def test_port_error_on_get_quality_report_reraises() -> None:
+    """DataQualityPortError on get_quality_report: lineage emitted, error re-raised."""
+    port = InMemoryDataQualityPort(fail_on_call=True)
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(DataQualityPortError):
+        await agent.get_quality_report(make_report_intent())
+
+    assert len(recorder.records) == 1
+    assert "HALT_PROVIDER_ERROR" in recorder.records[0].action_taken
+
+
+async def test_port_error_on_list_datasets_reraises() -> None:
+    """DataQualityPortError on list_datasets: lineage emitted, error re-raised."""
+    port = InMemoryDataQualityPort(fail_on_call=True)
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(DataQualityPortError):
+        await agent.list_datasets(make_list_intent())
+
+    assert len(recorder.records) == 1
+    assert "HALT_PROVIDER_ERROR" in recorder.records[0].action_taken
+
+
+async def test_port_error_on_get_freshness_reraises() -> None:
+    """DataQualityPortError on get_freshness: lineage emitted, error re-raised."""
+    port = InMemoryDataQualityPort(fail_on_call=True)
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(DataQualityPortError):
+        await agent.get_freshness(make_freshness_intent())
+
+    assert len(recorder.records) == 1
+    assert "HALT_PROVIDER_ERROR" in recorder.records[0].action_taken
+
+
+# ---------------------------------------------------------------------------
+# 18. Confidence out of [0, 1] → ValueError, NO lineage record
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_confidence_above_range_raises_no_record() -> None:
+    """confidence=1.1 → ValueError; _evaluate raises before any lineage record."""
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_drift_score(make_drift_intent(confidence=1.1))
+    assert len(recorder.records) == 0
+
+
+async def test_invalid_confidence_below_range_raises_no_record() -> None:
+    """confidence=-0.01 → ValueError; no lineage record."""
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_drift_score(make_drift_intent(confidence=-0.01))
+    assert len(recorder.records) == 0
+
+
+# ---------------------------------------------------------------------------
+# 19. R-SEC: no raw metric value / drift score in any lineage record field
+# ---------------------------------------------------------------------------
+
+
+async def test_no_raw_drift_score_in_lineage_record() -> None:
+    """DriftSignal.drift_score sentinel MUST NOT appear in any AgentDecisionRecord field."""
+    sentinel = Decimal("0.87654321")
+    signal = DriftSignal(dataset="payments", drift_score=sentinel, as_of="2026-06-11")
+    port = InMemoryDataQualityPort(signals={"payments": signal})
+    agent, _, recorder = make_agent(port=port)
+
+    outcome = await agent.get_drift_score(make_drift_intent())
+
+    # DriftSignal rides on AgentOutcome.result — confirmed it's there.
+    assert isinstance(outcome.result, DriftSignal)
+    assert outcome.result.drift_score == sentinel  # type: ignore[union-attr]
+
+    rec = recorder.records[0]
+    sentinel_str = str(sentinel)
+    # No raw metric value in any record string field (R-SEC-NEW-01).
+    assert sentinel_str not in rec.triggering_event
+    assert sentinel_str not in rec.intent
+    assert sentinel_str not in rec.reasoning_summary
+    assert sentinel_str not in rec.action_taken
+    assert all(sentinel_str not in p for p in rec.policies_evaluated)
+    # cost_amount is the REQUEST cost (e.g. "0.01"), never the metric value.
+    assert rec.cost_amount != sentinel
+
+
+async def test_no_raw_null_rate_in_lineage_record() -> None:
+    """DataQualityReport.null_rate sentinel MUST NOT appear in any AgentDecisionRecord field."""
+    sentinel = Decimal("0.99876543")
+    report = DataQualityReport(
+        dataset="payments",
+        null_rate=sentinel,
+        schema_conformance=Decimal("0.01"),
+        freshness_seconds=100,
+        drift_score=Decimal("0.05"),
+        as_of="2026-06-11",
+    )
+    port = InMemoryDataQualityPort(reports={"payments": report})
+    agent, _, recorder = make_agent(port=port)
+
+    outcome = await agent.get_quality_report(make_report_intent())
+
+    assert isinstance(outcome.result, DataQualityReport)
+    assert outcome.result.null_rate == sentinel  # type: ignore[union-attr]
+
+    rec = recorder.records[0]
+    sentinel_str = str(sentinel)
+    assert sentinel_str not in rec.triggering_event
+    assert sentinel_str not in rec.intent
+    assert sentinel_str not in rec.reasoning_summary
+    assert sentinel_str not in rec.action_taken
+
+
+# ---------------------------------------------------------------------------
+# 20. ADR-046 lineage-per-action: exactly 1 record per call on every exit path
+# ---------------------------------------------------------------------------
+
+
+async def test_lineage_one_record_per_call_adr046() -> None:
+    """Every action call (succeed or halt) emits exactly 1 record; total increments by 1."""
+    agent, _, recorder = make_agent()
+
+    assert len(recorder.records) == 0
+    await agent.get_drift_score(make_drift_intent())
+    assert len(recorder.records) == 1
+
+    await agent.get_quality_report(make_report_intent())
+    assert len(recorder.records) == 2
+
+    await agent.list_datasets(make_list_intent())
+    assert len(recorder.records) == 3
+
+    await agent.get_freshness(make_freshness_intent())
+    assert len(recorder.records) == 4
+
+    # Halted path also emits exactly 1 record.
+    await agent.get_drift_score(make_drift_intent(resolved=False))
+    assert len(recorder.records) == 5
+
+
+# ---------------------------------------------------------------------------
+# 21. Window accumulates only on successful reads
+# ---------------------------------------------------------------------------
+
+
+async def test_window_accumulates_on_successful_reads() -> None:
+    """Window.used_tokens / used_cost increment per successful port call."""
+    window = CostWindow(window_ref="data_quality_agent:test")
+    agent, _, _ = make_agent(window=window)
+
+    assert window.used_tokens == 0
+    assert window.used_cost == Decimal("0")
+    await agent.get_drift_score(make_drift_intent(tokens=50, cost="0.05"))
+    assert window.used_tokens == 50
+    assert window.used_cost == Decimal("0.05")
+
+    await agent.get_quality_report(make_report_intent(tokens=30, cost="0.03"))
+    assert window.used_tokens == 80
+    assert window.used_cost == Decimal("0.08")
+
+
+async def test_window_not_accumulated_on_halt() -> None:
+    """A halted call (e.g., unresolved ref) MUST NOT advance the window."""
+    window = CostWindow(window_ref="data_quality_agent:test")
+    agent, _, _ = make_agent(window=window)
+
+    await agent.get_drift_score(make_drift_intent(resolved=False))
+    assert window.used_tokens == 0
+    assert window.used_cost == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# 22. Default window_ref is set from mask.agent_id
+# ---------------------------------------------------------------------------
+
+
+async def test_default_window_ref_uses_agent_id() -> None:
+    """When no cost_window is injected, window_ref defaults to '{agent_id}:default'."""
+    agent, _, _ = make_agent()
+    assert agent._window.window_ref == "data_quality_agent:default"
+
+
+# ---------------------------------------------------------------------------
+# 23. INVARIANT: default mask scope has ONLY the 4 read ops (no retrain/trigger/write)
+# ---------------------------------------------------------------------------
+
+
+async def test_invariant_scope_is_detect_report_only() -> None:
+    """Default mask scope MUST NOT contain retrain/trigger/write/update ops.
+
+    INVARIANT (ADR-080): DataQualityAgent is detection/reporting only. The scope
+    allow-list enforces this at the governance layer: any op not in the allow-list
+    is REJECT_OUT_OF_SCOPE before the port is ever called.
+    """
+    mask = make_mask()
+    scope_lower = " ".join(mask.scope).lower()
+
+    assert "retrain" not in scope_lower
+    assert "trigger" not in scope_lower
+    assert "write" not in scope_lower
+    assert "update" not in scope_lower
+
+    # Every op in the default scope must be one of the 4 read ops.
+    read_ops = {
+        "DataQualityPort.get_drift_score",
+        "DataQualityPort.get_quality_report",
+        "DataQualityPort.list_datasets",
+        "DataQualityPort.get_freshness",
+    }
+    for op in mask.scope:
+        assert op in read_ops, f"Non-read op found in mask scope: {op}"
+
+    # Verify the scope has exactly 4 ops.
+    assert len(mask.scope) == 4
+
+
+async def test_invariant_trigger_retrain_always_out_of_scope() -> None:
+    """Proves that trigger_retrain is REJECT_OUT_OF_SCOPE — it is never in the allow-list.
+
+    The default scope only includes the 4 read ops. When scope is restricted to
+    trigger_retrain, the read ops are off-list → REJECT, proving that a retrain op
+    is unreachable through the standard agent flow.
+    """
+    scoped_mask = make_mask(scope=("DataQualityPort.trigger_retrain",))
+    agent, _, _ = make_agent(mask=scoped_mask)
+
+    outcome = await agent.get_drift_score(make_drift_intent())
+    # op="DataQualityPort.get_drift_score" is not in this scope → REJECT.
+    assert outcome.halt_reason == "out_of_scope"
+
+
+# ---------------------------------------------------------------------------
+# 24. INVARIANT: every public action's success_action is a DETECT/REPORT verb
+# ---------------------------------------------------------------------------
+
+
+async def test_invariant_all_success_actions_are_detect_report_verbs() -> None:
+    """Every public action's success_action must use DETECT_ or REPORT_ prefix.
+
+    INVARIANT: the strings RETRAIN, TRIGGER, WRITE, UPDATE must not appear
+    in any success_action — enforced at the agent code level and verified here.
+    """
+    agent, _, recorder = make_agent()
+
+    await agent.get_drift_score(make_drift_intent())
+    await agent.get_quality_report(make_report_intent())
+    await agent.list_datasets(make_list_intent())
+    await agent.get_freshness(make_freshness_intent())
+
+    success_actions = [rec.action_taken for rec in recorder.records]
+    detect_report_prefixes = ("DETECT_", "REPORT_")
+
+    for action in success_actions:
+        assert any(action.startswith(prefix) for prefix in detect_report_prefixes), (
+            f"success_action {action!r} is not a DETECT/REPORT verb — invariant violated"
+        )
+
+    all_actions_str = " ".join(success_actions)
+    assert "RETRAIN" not in all_actions_str
+    assert "TRIGGER" not in all_actions_str
+    assert "WRITE" not in all_actions_str
+    assert "UPDATE" not in all_actions_str
+
+
+# ---------------------------------------------------------------------------
+# 25. In-memory e2e full flow (real mask, InMemoryDataQualityPort, FakeRecorder)
+# ---------------------------------------------------------------------------
+
+
+async def test_in_memory_e2e_get_drift_score() -> None:
+    """Full e2e: real DataQualityMask + InMemoryDataQualityPort → AUTO read with lineage."""
+    recorder = FakeRecorder()
+    mask = DataQualityMask(
+        cost_cap=CostCap(
+            max_request_tokens=500,
+            max_request_cost=Decimal("0.50"),
+            max_window_tokens=50_000,
+            max_window_cost=Decimal("50.00"),
+        ),
+        agent_id="data_quality_agent",
+        cto_role="CTO",
+    )
+    port = InMemoryDataQualityPort()
+    agent = DataQualityAgent(data_quality_port=port, recorder=recorder, mask=mask)
+    intent = GetDriftScoreIntent(
+        dataset="payments",
+        intent_text="CTO daily drift check Q2-2026",
+        process_ref=ProcessRef(process_id="proc-e2e-dq-001", version="1.0"),
+        correlation_id="e2e-corr-dq-001",
+        confidence_score=0.97,
+        request_cost=RequestCost(tokens=100, cost=Decimal("0.10")),
+    )
+    outcome = await agent.get_drift_score(intent)
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, DriftSignal)
+    assert outcome.halt_reason is None
+    assert outcome.requires_hitl is False
+    assert outcome.escalated_to is None
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.agent_id == "data_quality_agent"
+    assert rec.correlation_id == "e2e-corr-dq-001"
+    assert rec.compliance_result is ComplianceResult.PASS
+    assert rec.budget_breach_flag is BudgetBreach.NONE
+    assert rec.triggering_event == "get_drift_score:payments"
+    assert rec.human_reviewed_by is None  # L1-Auto: never a reviewer

--- a/tests/test_data_quality/test_data_quality_port.py
+++ b/tests/test_data_quality/test_data_quality_port.py
@@ -1,0 +1,273 @@
+"""InMemoryDataQualityPort unit tests — 100% coverage over services/data_quality/data_quality_port.py.
+
+Validates: happy-path reads for all 4 methods, failure paths (fail_on_call=True),
+unknown dataset raises DataQualityPortError, custom seed data injection, value type
+invariants (I-01: Decimal for numeric metrics, frozen=True on DTOs), and port
+abstractness.
+
+asyncio_mode = "auto" (pyproject.toml): every ``async def test_*`` is auto-collected
+without @pytest.mark.asyncio.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from decimal import Decimal
+
+import pytest
+
+from services.data_quality.data_quality_port import (
+    DataQualityPort,
+    DataQualityPortError,
+    DataQualityReport,
+    DriftSignal,
+    InMemoryDataQualityPort,
+)
+
+# ---------------------------------------------------------------------------
+# Happy path — default seed data
+# ---------------------------------------------------------------------------
+
+
+async def test_get_drift_score_returns_correct_type() -> None:
+    """Default seed returns DriftSignal with Decimal drift_score (I-01)."""
+    port = InMemoryDataQualityPort()
+    result = await port.get_drift_score("payments")
+
+    assert isinstance(result, DriftSignal)
+    assert isinstance(result.drift_score, Decimal)
+    assert result.dataset == "payments"
+    assert isinstance(result.as_of, str)
+    assert len(result.as_of) > 0
+
+
+async def test_get_quality_report_returns_correct_type() -> None:
+    """Default seed returns DataQualityReport with Decimal numeric fields (I-01)."""
+    port = InMemoryDataQualityPort()
+    result = await port.get_quality_report("payments")
+
+    assert isinstance(result, DataQualityReport)
+    assert isinstance(result.null_rate, Decimal)
+    assert isinstance(result.schema_conformance, Decimal)
+    assert isinstance(result.drift_score, Decimal)
+    assert isinstance(result.freshness_seconds, int)
+    assert result.dataset == "payments"
+    assert isinstance(result.as_of, str)
+
+
+async def test_list_datasets_returns_nonempty_list() -> None:
+    """Default seed returns a non-empty list of dataset name strings."""
+    port = InMemoryDataQualityPort()
+    result = await port.list_datasets()
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    assert all(isinstance(name, str) for name in result)
+
+
+async def test_get_freshness_returns_int() -> None:
+    """Default seed returns an integer freshness_seconds."""
+    port = InMemoryDataQualityPort()
+    result = await port.get_freshness("payments")
+
+    assert isinstance(result, int)
+    assert result >= 0
+
+
+async def test_second_dataset_readable() -> None:
+    """Default seed exposes at least two datasets (payments + customers)."""
+    port = InMemoryDataQualityPort()
+    signal = await port.get_drift_score("customers")
+    report = await port.get_quality_report("customers")
+    freshness = await port.get_freshness("customers")
+
+    assert signal.dataset == "customers"
+    assert isinstance(signal.drift_score, Decimal)
+    assert report.dataset == "customers"
+    assert isinstance(freshness, int)
+
+
+# ---------------------------------------------------------------------------
+# Custom seed data
+# ---------------------------------------------------------------------------
+
+
+async def test_custom_signal_seed_returned_unchanged() -> None:
+    """Custom DriftSignal seed is returned exactly as injected."""
+    custom = DriftSignal(dataset="trades", drift_score=Decimal("0.15"), as_of="2026-01-01")
+    port = InMemoryDataQualityPort(signals={"trades": custom})
+    result = await port.get_drift_score("trades")
+    assert result is custom
+
+
+async def test_custom_report_seed_returned_unchanged() -> None:
+    """Custom DataQualityReport seed is returned exactly as injected."""
+    custom = DataQualityReport(
+        dataset="trades",
+        null_rate=Decimal("0.02"),
+        schema_conformance=Decimal("0.98"),
+        freshness_seconds=120,
+        drift_score=Decimal("0.15"),
+        as_of="2026-01-01",
+    )
+    port = InMemoryDataQualityPort(reports={"trades": custom})
+    result = await port.get_quality_report("trades")
+    assert result is custom
+
+
+async def test_list_datasets_reflects_signals_keys() -> None:
+    """list_datasets returns the keys from the injected signals dict."""
+    signals = {
+        "ds_alpha": DriftSignal(
+            dataset="ds_alpha", drift_score=Decimal("0.01"), as_of="2026-01-01"
+        ),
+        "ds_beta": DriftSignal(dataset="ds_beta", drift_score=Decimal("0.02"), as_of="2026-01-01"),
+    }
+    port = InMemoryDataQualityPort(signals=signals)
+    result = await port.list_datasets()
+    assert set(result) == {"ds_alpha", "ds_beta"}
+
+
+async def test_list_datasets_returns_defensive_copy() -> None:
+    """list_datasets returns a new list each time — mutations don't affect the port."""
+    port = InMemoryDataQualityPort()
+    r1 = await port.list_datasets()
+    r2 = await port.list_datasets()
+    assert r1 == r2
+    r1.clear()
+    r3 = await port.list_datasets()
+    assert len(r3) > 0
+
+
+async def test_get_freshness_returns_value_from_report_seed() -> None:
+    """get_freshness reads freshness_seconds from the corresponding report seed."""
+    report = DataQualityReport(
+        dataset="trades",
+        null_rate=Decimal("0.00"),
+        schema_conformance=Decimal("1.00"),
+        freshness_seconds=999,
+        drift_score=Decimal("0.00"),
+        as_of="2026-01-01",
+    )
+    port = InMemoryDataQualityPort(reports={"trades": report})
+    result = await port.get_freshness("trades")
+    assert result == 999
+
+
+# ---------------------------------------------------------------------------
+# Failure paths — fail_on_call=True
+# ---------------------------------------------------------------------------
+
+
+async def test_fail_on_get_drift_score() -> None:
+    """fail_on_call=True raises DataQualityPortError on get_drift_score."""
+    port = InMemoryDataQualityPort(fail_on_call=True)
+    with pytest.raises(DataQualityPortError):
+        await port.get_drift_score("payments")
+
+
+async def test_fail_on_get_quality_report() -> None:
+    """fail_on_call=True raises DataQualityPortError on get_quality_report."""
+    port = InMemoryDataQualityPort(fail_on_call=True)
+    with pytest.raises(DataQualityPortError):
+        await port.get_quality_report("payments")
+
+
+async def test_fail_on_list_datasets() -> None:
+    """fail_on_call=True raises DataQualityPortError on list_datasets."""
+    port = InMemoryDataQualityPort(fail_on_call=True)
+    with pytest.raises(DataQualityPortError):
+        await port.list_datasets()
+
+
+async def test_fail_on_get_freshness() -> None:
+    """fail_on_call=True raises DataQualityPortError on get_freshness."""
+    port = InMemoryDataQualityPort(fail_on_call=True)
+    with pytest.raises(DataQualityPortError):
+        await port.get_freshness("payments")
+
+
+# ---------------------------------------------------------------------------
+# Unknown dataset paths
+# ---------------------------------------------------------------------------
+
+
+async def test_unknown_dataset_get_drift_score_raises() -> None:
+    """Unknown dataset raises DataQualityPortError on get_drift_score."""
+    port = InMemoryDataQualityPort()
+    with pytest.raises(DataQualityPortError):
+        await port.get_drift_score("no_such_dataset")
+
+
+async def test_unknown_dataset_get_quality_report_raises() -> None:
+    """Unknown dataset raises DataQualityPortError on get_quality_report."""
+    port = InMemoryDataQualityPort()
+    with pytest.raises(DataQualityPortError):
+        await port.get_quality_report("no_such_dataset")
+
+
+async def test_unknown_dataset_get_freshness_raises() -> None:
+    """Unknown dataset raises DataQualityPortError on get_freshness."""
+    port = InMemoryDataQualityPort()
+    with pytest.raises(DataQualityPortError):
+        await port.get_freshness("no_such_dataset")
+
+
+# ---------------------------------------------------------------------------
+# Value type invariants (frozen=True, I-01 Decimal)
+# ---------------------------------------------------------------------------
+
+
+def test_drift_signal_is_frozen() -> None:
+    """DriftSignal is a frozen dataclass — mutation raises FrozenInstanceError."""
+    signal = DriftSignal(dataset="x", drift_score=Decimal("0.1"), as_of="2026-01-01")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        signal.drift_score = Decimal("0.9")  # type: ignore[misc]
+
+
+def test_data_quality_report_is_frozen() -> None:
+    """DataQualityReport is a frozen dataclass — mutation raises FrozenInstanceError."""
+    report = DataQualityReport(
+        dataset="x",
+        null_rate=Decimal("0.01"),
+        schema_conformance=Decimal("0.99"),
+        freshness_seconds=60,
+        drift_score=Decimal("0.05"),
+        as_of="2026-01-01",
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        report.null_rate = Decimal("0.99")  # type: ignore[misc]
+
+
+def test_drift_signal_drift_score_is_decimal_not_float() -> None:
+    """I-01: drift_score must be Decimal — float would violate the invariant."""
+    signal = DriftSignal(dataset="x", drift_score=Decimal("0.05"), as_of="2026-01-01")
+    assert isinstance(signal.drift_score, Decimal)
+    assert not isinstance(signal.drift_score, float)
+
+
+def test_data_quality_report_numeric_fields_are_decimal() -> None:
+    """I-01: null_rate, schema_conformance, drift_score must all be Decimal."""
+    report = DataQualityReport(
+        dataset="y",
+        null_rate=Decimal("0.02"),
+        schema_conformance=Decimal("0.98"),
+        freshness_seconds=100,
+        drift_score=Decimal("0.10"),
+        as_of="2026-01-01",
+    )
+    assert isinstance(report.null_rate, Decimal)
+    assert isinstance(report.schema_conformance, Decimal)
+    assert isinstance(report.drift_score, Decimal)
+    assert isinstance(report.freshness_seconds, int)
+
+
+# ---------------------------------------------------------------------------
+# Port is abstract
+# ---------------------------------------------------------------------------
+
+
+def test_data_quality_port_cannot_be_instantiated() -> None:
+    """DataQualityPort is abstract — direct instantiation raises TypeError."""
+    with pytest.raises(TypeError):
+        DataQualityPort()  # type: ignore[abstract]


### PR DESCRIPTION
## CTO DataQualityAgent — sprint-48 / ADR-080 (port-first)

Implements ORG §2.7.1 CTO (SMF26) `DataQualityAgent` — *Data drift detection*, **L1 Auto, no gate**.

**Scope note:** ONLY DataQualityAgent this sprint. `MLPipelineAgent` (§2.7.1, L3/I-27) and `DeployAgent` (§2.7.2, L2/L3) remain `(PROPOSED)` — deferred.

### ETAP A — `DataQualityPort` (`services/data_quality/`, read-only)
abc.ABC + `InMemoryDataQualityPort` + `DataQualityPortError`. Reads: drift score, quality report (null-rate / schema-conformance / freshness / drift), dataset list, freshness. Decimal (I-01). **No mutate/trigger/retrain method exists** — detection/reporting surface only; live integrations out of scope (I-10, I-27).

### ETAP B — `DataQualityAgent` (`services/agents/`, L1 Auto)
Detect + report data drift/quality via the port. Full ADR-049 §D2 chain (process_ref → scope → band → cost_cap → compliance(DATA_QUALITY) → port), one ADR-046 `AgentDecisionRecord` per action, port + DecisionRecorder injected. **R-SEC:** only opaque handles (dataset names) in lineage — never metric values/PII.

**⭐ INVARIANT (enforced + tested):** the agent **never** triggers retraining, pipeline runs, or data writes — detection/reporting only; any such op is out-of-scope and refused (`test_invariant_trigger_retrain_always_out_of_scope`, `test_invariant_scope_is_detect_report_only`). Preserves the I-27 boundary (no autonomous model updates).

**Files (6, scope-locked):** `services/data_quality/{__init__,data_quality_port}.py` + `services/agents/data_quality_agent.py` + 3 test files.

**Gates:** ruff ✅ · semgrep banxe-rules ✅ · pytest **54 tests, 100% coverage** on both new modules ✅ · full suite **10614 passed / 0 failed** ✅

Paired banxe-architecture PR (ADR-080 + ORG §2.7.1 + IL-174) lands separately. PR-only — no merge.