### PR TITLE
feat(coo-agent): ChargebackAgent §D2 mask over dispute_resolution (MASK_ONLY) — sprint-50 / IL-178

### DIFF
--- a/services/agents/chargeback_agent.py
+++ b/services/agents/chargeback_agent.py
@@ -1,0 +1,553 @@
+"""ChargebackAgent — L2 Review mask for dispute chargeback operations.
+
+WHY: ORG §2.6 defines the chargeback agent as the governed surface through
+which a resolved chargeback intent becomes a bounded ChargebackHandle action.
+This module is the emi-stack COO-gated sibling of treasury_agent — it enforces
+the ADR-049 §D2 gate chain in front of the dispute_resolution domain.
+
+The chargeback agent operates over initiate_chargeback (L2, COO gate),
+submit_representment (L2, COO gate), and get_chargeback_status (L1 AUTO read).
+It DELEGATES to the injected ChargebackHandle and NEVER reimplements dispute logic.
+
+GOVERNANCE (ADR-049 §D2 gate-chain, fixed order):
+    process_ref → scope → band [+COO step-up] → cost_cap → compliance(DISPUTE) → handle call
+
+* ``scope``          — ChargebackHandle ops only (3-op allow-list).
+* ``autonomy_level`` — L2 for initiate/submit (force_review=True, COO sign-off);
+                       L1-Auto for get_status (AUTO-only read).
+* ``cost_cap``       — per-request AND per-window hard caps (ADR-047 §D2).
+* ``lineage``        — one AgentDecisionRecord per action, every exit path (ADR-046).
+* ``compliance``     — DISPUTE overlay; non-PASS → BLOCK + escalate to COO.
+
+R-SEC (ADR-021): triggering_event is keyed on opaque handles (dispute_id /
+chargeback_id) ONLY — never amounts, PII, or customer data. The handle's dict
+return rides on AgentOutcome.result ONLY, never on AgentDecisionRecord.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Protocol
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+
+# ---------------------------------------------------------------------------
+# Narrow DI Protocol (typing only — not a new heavy port)
+# ---------------------------------------------------------------------------
+
+
+class ChargebackHandle(Protocol):
+    """Narrow typing Protocol for the injected chargeback domain handle.
+
+    Matches ChargebackBridge's three public method signatures exactly.
+    """
+
+    def initiate_chargeback(
+        self,
+        dispute_id: str,
+        scheme: str,
+        amount: Decimal,
+        reason_code: str,
+    ) -> dict[str, str]: ...
+
+    def submit_representment(
+        self,
+        chargeback_id: str,
+        evidence_hashes: list[str],
+    ) -> dict[str, object]: ...
+
+    def get_chargeback_status(self, chargeback_id: str) -> dict[str, str]: ...
+
+
+# ---------------------------------------------------------------------------
+# Mask (config-as-data)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChargebackMask:
+    """Config-as-data COO-gated chargeback mask (ORG §2.6).
+
+    All gate values are governed config. scope is the exclusive allow-list.
+    """
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    lineage_obligation: bool = True
+    agent_id: str = "chargeback_agent"
+    scope: tuple[str, ...] = (
+        "ChargebackHandle.initiate_chargeback",
+        "ChargebackHandle.submit_representment",
+        "ChargebackHandle.get_chargeback_status",
+    )
+    compliance_gate: tuple[str, ...] = ("DISPUTE",)
+    coo_role: str = "COO"
+
+
+# ---------------------------------------------------------------------------
+# Intent vocabulary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InitiateChargebackIntent:
+    """Resolved initiate-chargeback intent (L2 COO gate).
+
+    R-SEC: amount (Decimal, I-01) is passed to the handle but NEVER recorded
+    in the lineage record. triggering_event uses dispute_id (opaque) only.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    dispute_id: str
+    scheme: str
+    amount: Decimal  # I-01: Decimal for money, never float
+    reason_code: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass(frozen=True)
+class SubmitRepresentmentIntent:
+    """Resolved submit-representment intent (L2 COO gate).
+
+    R-SEC: triggering_event uses chargeback_id (opaque) only.
+    evidence_hashes is a tuple to keep the frozen dataclass hashable.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    chargeback_id: str
+    evidence_hashes: tuple[str, ...]
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass(frozen=True)
+class GetChargebackStatusIntent:
+    """Resolved get-chargeback-status intent (L1 AUTO read).
+
+    A read below the AUTO band halts with HALT_REVIEW_DEFERRED; there is
+    no HITL hold path for status reads. R-SEC: triggering_event uses
+    chargeback_id (opaque) only.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    chargeback_id: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation types (private)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+    human_reviewed_by: str | None
+    force_review: bool = False
+    review_escalate_to: str | None = None
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies_evaluated: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class ChargebackAgent:
+    """L2 Review COO-gated chargeback mask enforcing the ADR-049 §D2 gate chain.
+
+    initiate_chargeback and submit_representment always force REVIEW (COO gate).
+    get_chargeback_status is L1-Auto: AUTO-eligible within cap; REVIEW band →
+    HALT_REVIEW_DEFERRED (no HITL hold for reads).
+
+    The ChargebackHandle and recorder are injected; this class contains pure
+    governance logic and is unit-testable without any live infrastructure.
+    """
+
+    def __init__(
+        self,
+        *,
+        chargeback_handle: ChargebackHandle,
+        recorder: DecisionRecorder,
+        mask: ChargebackMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._handle = chargeback_handle
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def initiate_chargeback(
+        self,
+        intent: InitiateChargebackIntent,
+        *,
+        human_reviewed_by: str | None = None,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Initiate a chargeback via the handle (L2, COO gate).
+
+        force_review=True: AUTO confidence is stepped up to REVIEW.
+        No reviewer → HOLD_FOR_REVIEW (handle NOT called, escalate→COO).
+        With reviewer → delegate to handle.initiate_chargeback(…).
+        R-SEC: triggering_event uses dispute_id only — never amount or PII.
+        """
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"initiate_chargeback:{intent.dispute_id}",
+            success_action="INITIATE_CHARGEBACK",
+            op="ChargebackHandle.initiate_chargeback",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=human_reviewed_by,
+            force_review=True,
+            review_escalate_to=self._mask.coo_role,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._handle.initiate_chargeback(
+                intent.dispute_id, intent.scheme, intent.amount, intent.reason_code
+            ),
+        )
+
+    async def submit_representment(
+        self,
+        intent: SubmitRepresentmentIntent,
+        *,
+        human_reviewed_by: str | None = None,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Submit representment evidence via the handle (L2, COO gate).
+
+        force_review=True: same COO gate as initiate_chargeback.
+        R-SEC: triggering_event uses chargeback_id only.
+        """
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"submit_representment:{intent.chargeback_id}",
+            success_action="SUBMIT_REPRESENTMENT",
+            op="ChargebackHandle.submit_representment",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=human_reviewed_by,
+            force_review=True,
+            review_escalate_to=self._mask.coo_role,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._handle.submit_representment(
+                intent.chargeback_id, list(intent.evidence_hashes)
+            ),
+        )
+
+    async def get_chargeback_status(
+        self,
+        intent: GetChargebackStatusIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Read chargeback status via the handle (L1 AUTO read).
+
+        AUTO-eligible within cap. REVIEW band → HALT_REVIEW_DEFERRED (no HITL hold
+        for reads). DISPUTE overlay must PASS; non-PASS blocks and escalates to COO.
+        R-SEC: result rides on AgentOutcome.result ONLY — never in the lineage record.
+        """
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_chargeback_status:{intent.chargeback_id}",
+            success_action="GET_CHARGEBACK_STATUS",
+            op="ChargebackHandle.get_chargeback_status",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=None,
+            force_review=False,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._handle.get_chargeback_status(intent.chargeback_id),
+        )
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, score: float) -> ConfirmationDecision:
+        if score >= self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if score >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:  # noqa: PLR0911
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError(f"confidence_score {ctx.confidence_score!r} must be in [0.0, 1.0]")
+
+        policies: list[str] = ["ADR-048-process-resolution"]
+
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op!r} not on chargeback scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+        if ctx.force_review and band is ConfirmationDecision.AUTO:
+            policies.append("ADR-046-COO-step-up")
+            band = ConfirmationDecision.REVIEW
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence below 0.70; human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+
+        if band is ConfirmationDecision.REVIEW:
+            if ctx.force_review:
+                # L2 write path: COO sign-off required.
+                if ctx.human_reviewed_by is None:
+                    return _Evaluation(
+                        band,
+                        False,
+                        "HOLD_FOR_REVIEW",
+                        "Consequential chargeback op: COO sign-off required (ADR-046).",
+                        policies,
+                        ctx.compliance_result,
+                        BudgetBreach.NONE,
+                        halt_reason="hitl_review_required",
+                        requires_hitl=True,
+                        escalated_to=ctx.review_escalate_to,
+                    )
+                # reviewer present → fall through to cost/compliance gates
+            else:
+                # L1 read path: reads are AUTO-only; no HITL hold.
+                return _Evaluation(
+                    band,
+                    False,
+                    "HALT_REVIEW_DEFERRED",
+                    "Status read below AUTO band; reads are AUTO-only, no HITL hold.",
+                    policies,
+                    ctx.compliance_result,
+                    BudgetBreach.NONE,
+                    halt_reason="review_deferred",
+                    requires_hitl=True,
+                )
+
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Per-request or per-window cost-cap breach; action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"DISPUTE overlay {ctx.compliance_result!r}; blocked, escalated to {self._mask.coo_role}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=self._mask.coo_role,
+            )
+
+        note = f" (reviewed by {ctx.human_reviewed_by})" if ctx.human_reviewed_by else ""
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All chargeback gates satisfied at {band.value} confidence{note}.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,  # noqa: ARG002
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies_evaluated=list(ev.policies_evaluated),
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=ctx.human_reviewed_by,
+            correlation_id=ctx.correlation_id,
+            cost_tokens=ctx.request_cost.tokens,
+            cost_amount=ctx.request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], object],
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            try:
+                result = port_call()
+            except ValueError as exc:
+                # Domain raises ValueError for unknown scheme / non-positive amount / not-found.
+                action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                await self._emit(
+                    ctx,
+                    ev,
+                    action_taken,
+                    executed=False,
+                    compliance_result=ev.compliance_result,
+                    reasoning=f"Handle raised {type(exc).__name__}: {exc}",
+                    escalated_to=ev.escalated_to,
+                )
+                raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )
+
+
+__all__ = [
+    "ChargebackAgent",
+    "ChargebackHandle",
+    "ChargebackMask",
+    "GetChargebackStatusIntent",
+    "InitiateChargebackIntent",
+    "SubmitRepresentmentIntent",
+]

--- a/tests/agents/test_chargeback_agent.py
+++ b/tests/agents/test_chargeback_agent.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.agents.chargeback_agent import (
+    ChargebackAgent,
+    ChargebackMask,
+    GetChargebackStatusIntent,
+    InitiateChargebackIntent,
+    SubmitRepresentmentIntent,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeRecorder(DecisionRecorder):
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+class FakeChargebackHandle:
+    """In-memory chargeback handle stub for testing."""
+
+    def __init__(self, raise_value_error: bool = False) -> None:
+        self._raise = raise_value_error
+        self.initiate_calls: list[dict] = []
+        self.submit_calls: list[dict] = []
+        self.status_calls: list[str] = []
+
+    def initiate_chargeback(
+        self,
+        dispute_id: str,
+        scheme: str,
+        amount: Decimal,
+        reason_code: str,
+    ) -> dict[str, str]:
+        if self._raise:
+            raise ValueError("fake domain error: unknown scheme")
+        self.initiate_calls.append({"dispute_id": dispute_id, "scheme": scheme})
+        return {
+            "chargeback_id": "CB-001",
+            "dispute_id": dispute_id,
+            "scheme": scheme,
+            "amount": str(amount),
+            "status": "INITIATED",
+        }
+
+    def submit_representment(
+        self,
+        chargeback_id: str,
+        evidence_hashes: list[str],
+    ) -> dict[str, object]:
+        if self._raise:
+            raise ValueError("fake domain error: not found")
+        self.submit_calls.append({"chargeback_id": chargeback_id})
+        return {
+            "chargeback_id": chargeback_id,
+            "status": "REPRESENTMENT_SUBMITTED",
+            "evidence_count": len(evidence_hashes),
+        }
+
+    def get_chargeback_status(self, chargeback_id: str) -> dict[str, str]:
+        if self._raise:
+            raise ValueError("fake domain error: not found")
+        self.status_calls.append(chargeback_id)
+        return {"chargeback_id": chargeback_id, "status": "INITIATED"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CAP = CostCap(
+    max_request_tokens=5000,
+    max_request_cost=Decimal("5.00"),
+    max_window_tokens=50000,
+    max_window_cost=Decimal("50.00"),
+)
+_SMALL_COST = RequestCost(tokens=100, cost=Decimal("0.10"))
+_PROC = ProcessRef(process_id="CB-P-001", version="v1.0")
+_UNRESOLVED = ProcessRef(process_id="", version="")
+
+
+def make_mask(**overrides: object) -> ChargebackMask:
+    base: dict[str, object] = {"cost_cap": _DEFAULT_CAP}
+    base.update(overrides)
+    return ChargebackMask(**base)  # type: ignore[arg-type]
+
+
+def make_agent(
+    *,
+    mask: ChargebackMask | None = None,
+    window: CostWindow | None = None,
+    raise_value_error: bool = False,
+) -> tuple[ChargebackAgent, FakeChargebackHandle, FakeRecorder]:
+    handle = FakeChargebackHandle(raise_value_error=raise_value_error)
+    rec = FakeRecorder()
+    agent = ChargebackAgent(
+        chargeback_handle=handle,
+        recorder=rec,
+        mask=mask or make_mask(),
+        cost_window=window,
+    )
+    return agent, handle, rec
+
+
+def initiate_intent(
+    confidence: float = 0.95,
+    dispute_id: str = "DSP-001",
+    proc: ProcessRef = _PROC,
+) -> InitiateChargebackIntent:
+    return InitiateChargebackIntent(
+        intent_text="initiate chargeback",
+        process_ref=proc,
+        dispute_id=dispute_id,
+        scheme="VISA",
+        amount=Decimal("250.00"),
+        reason_code="4853",
+        correlation_id="corr-001",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+    )
+
+
+def submit_intent(
+    confidence: float = 0.95,
+    chargeback_id: str = "CB-001",
+    proc: ProcessRef = _PROC,
+) -> SubmitRepresentmentIntent:
+    return SubmitRepresentmentIntent(
+        intent_text="submit representment",
+        process_ref=proc,
+        chargeback_id=chargeback_id,
+        evidence_hashes=("hash-abc", "hash-def"),
+        correlation_id="corr-002",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+    )
+
+
+def status_intent(
+    confidence: float = 0.95,
+    chargeback_id: str = "CB-001",
+    proc: ProcessRef = _PROC,
+) -> GetChargebackStatusIntent:
+    return GetChargebackStatusIntent(
+        intent_text="get chargeback status",
+        process_ref=proc,
+        chargeback_id=chargeback_id,
+        correlation_id="corr-003",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+    )
+
+
+# ---------------------------------------------------------------------------
+# L1 AUTO read — get_chargeback_status happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_get_status_auto_proceeds_and_returns_result() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.get_chargeback_status(status_intent(confidence=0.95))
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, dict)
+    assert outcome.result["status"] == "INITIATED"
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "GET_CHARGEBACK_STATUS"
+    # R-SEC: result dict NOT in the lineage record
+    assert not hasattr(rec.records[0], "result")
+    assert handle.status_calls == ["CB-001"]
+
+
+# ---------------------------------------------------------------------------
+# L2 REVIEW happy path — initiate/submit WITH reviewer → domain called
+# ---------------------------------------------------------------------------
+
+
+async def test_initiate_with_reviewer_proceeds_domain_called() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.initiate_chargeback(
+        initiate_intent(confidence=0.95), human_reviewed_by="coo@banxe.com"
+    )
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.REVIEW  # force_review pushed AUTO→REVIEW
+    assert outcome.result is not None
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "INITIATE_CHARGEBACK"
+    assert rec.records[0].human_reviewed_by == "coo@banxe.com"
+    assert len(handle.initiate_calls) == 1
+
+
+async def test_submit_with_reviewer_proceeds_domain_called() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.submit_representment(
+        submit_intent(confidence=0.95), human_reviewed_by="coo@banxe.com"
+    )
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.result is not None
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "SUBMIT_REPRESENTMENT"
+    assert len(handle.submit_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# HOLD_FOR_REVIEW — L2 ops with no reviewer → domain NOT called, escalate→COO
+# ---------------------------------------------------------------------------
+
+
+async def test_initiate_no_reviewer_hold_for_review_domain_not_called() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.initiate_chargeback(initiate_intent(confidence=0.95))
+    assert outcome.executed is False
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.requires_hitl is True
+    assert outcome.escalated_to == "COO"
+    assert rec.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert rec.records[0].escalated_to == "COO"
+    assert handle.initiate_calls == []
+
+
+async def test_submit_no_reviewer_hold_for_review_domain_not_called() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.submit_representment(submit_intent(confidence=0.95))
+    assert outcome.executed is False
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.requires_hitl is True
+    assert outcome.escalated_to == "COO"
+    assert rec.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert handle.submit_calls == []
+
+
+# ---------------------------------------------------------------------------
+# HALT_UNRESOLVED_PROCESS
+# ---------------------------------------------------------------------------
+
+
+async def test_halt_unresolved_process_ref_initiate() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.initiate_chargeback(initiate_intent(proc=_UNRESOLVED))
+    assert outcome.executed is False
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert outcome.requires_hitl is True
+    assert rec.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+    assert handle.initiate_calls == []
+
+
+# ---------------------------------------------------------------------------
+# REJECT_OUT_OF_SCOPE
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_out_of_scope_op() -> None:
+    mask = make_mask(scope=("OTHER.op",))
+    agent, handle, rec = make_agent(mask=mask)
+    outcome = await agent.initiate_chargeback(initiate_intent())
+    assert outcome.halt_reason == "out_of_scope"
+    assert rec.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+    assert handle.initiate_calls == []
+
+
+# ---------------------------------------------------------------------------
+# HALT_REVIEW_DEFERRED — status read below AUTO band → domain NOT called
+# ---------------------------------------------------------------------------
+
+
+async def test_status_review_band_halts_deferred_domain_not_called() -> None:
+    agent, handle, rec = make_agent()
+    # confidence=0.80 → REVIEW band, no force_review → HALT_REVIEW_DEFERRED
+    outcome = await agent.get_chargeback_status(status_intent(confidence=0.80))
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert outcome.requires_hitl is True
+    assert rec.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+    assert handle.status_calls == []
+
+
+# ---------------------------------------------------------------------------
+# BLOCK_LOW_CONFIDENCE
+# ---------------------------------------------------------------------------
+
+
+async def test_block_low_confidence_initiate() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.initiate_chargeback(initiate_intent(confidence=0.50))
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert rec.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+    assert handle.initiate_calls == []
+
+
+async def test_block_low_confidence_status() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.get_chargeback_status(status_intent(confidence=0.60))
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert rec.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+# ---------------------------------------------------------------------------
+# HALT_COST_CAP_BREACH (per-request tokens / per-request cost /
+#                        per-window tokens / per-window cost)
+# ---------------------------------------------------------------------------
+
+
+async def test_halt_cost_cap_per_request_tokens() -> None:
+    cap = CostCap(
+        max_request_tokens=50,  # < _SMALL_COST.tokens=100
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=50000,
+        max_window_cost=Decimal("100.00"),
+    )
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap))
+    outcome = await agent.initiate_chargeback(initiate_intent(), human_reviewed_by="coo@banxe.com")
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert rec.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+async def test_halt_cost_cap_per_request_cost() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("0.05"),  # < 0.10
+        max_window_tokens=50000,
+        max_window_cost=Decimal("100.00"),
+    )
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap))
+    outcome = await agent.initiate_chargeback(initiate_intent(), human_reviewed_by="coo@banxe.com")
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+async def test_halt_cost_cap_per_window_tokens() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=150,  # used_tokens=100 + request=100 = 200 > 150
+        max_window_cost=Decimal("100.00"),
+    )
+    window = CostWindow(used_tokens=100)
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.initiate_chargeback(initiate_intent(), human_reviewed_by="coo@banxe.com")
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+async def test_halt_cost_cap_per_window_cost() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=50000,
+        max_window_cost=Decimal("0.15"),  # used=0.10 + request=0.10 = 0.20 > 0.15
+    )
+    window = CostWindow(used_cost=Decimal("0.10"))
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.initiate_chargeback(initiate_intent(), human_reviewed_by="coo@banxe.com")
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+# ---------------------------------------------------------------------------
+# HALT_COMPLIANCE_BLOCK — non-PASS → escalate to COO
+# ---------------------------------------------------------------------------
+
+
+async def test_halt_compliance_fail_escalates_to_coo() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.initiate_chargeback(
+        initiate_intent(),
+        human_reviewed_by="coo@banxe.com",
+        compliance_result=ComplianceResult.FAIL,
+    )
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "COO"
+    assert rec.records[0].escalated_to == "COO"
+    assert rec.records[0].action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert handle.initiate_calls == []
+
+
+async def test_halt_compliance_escalate_also_blocks() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.get_chargeback_status(
+        status_intent(), compliance_result=ComplianceResult.ESCALATE
+    )
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "COO"
+
+
+# ---------------------------------------------------------------------------
+# HALT_PROVIDER_ERROR — handle raises ValueError → emit executed=False + re-raise
+# ---------------------------------------------------------------------------
+
+
+async def test_provider_error_initiate_emits_record_then_reraises() -> None:
+    agent, _, rec = make_agent(raise_value_error=True)
+    with pytest.raises(ValueError, match="fake domain error"):
+        await agent.initiate_chargeback(initiate_intent(), human_reviewed_by="coo@banxe.com")
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken.startswith("HALT_PROVIDER_ERROR")
+    assert rec.records[0].action_taken == "HALT_PROVIDER_ERROR:ValueError"
+
+
+async def test_provider_error_status_emits_record_then_reraises() -> None:
+    agent, _, rec = make_agent(raise_value_error=True)
+    with pytest.raises(ValueError):
+        await agent.get_chargeback_status(status_intent(confidence=0.95))
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken.startswith("HALT_PROVIDER_ERROR")
+
+
+# ---------------------------------------------------------------------------
+# ValueError on confidence out of [0, 1]
+# ---------------------------------------------------------------------------
+
+
+async def test_confidence_above_one_raises_value_error() -> None:
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.initiate_chargeback(initiate_intent(confidence=1.01))
+
+
+async def test_confidence_below_zero_raises_value_error() -> None:
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_chargeback_status(status_intent(confidence=-0.01))
+
+
+# ---------------------------------------------------------------------------
+# Band boundaries
+# ---------------------------------------------------------------------------
+
+
+async def test_band_boundary_exactly_090_status_is_auto_proceeds() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.get_chargeback_status(status_intent(confidence=0.90))
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert handle.status_calls == ["CB-001"]
+
+
+async def test_band_boundary_exactly_070_status_is_review_deferred() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.get_chargeback_status(status_intent(confidence=0.70))
+    # 0.70 >= review_floor → REVIEW band → HALT_REVIEW_DEFERRED for L1 read
+    assert outcome.halt_reason == "review_deferred"
+    assert outcome.decision is ConfirmationDecision.REVIEW
+
+
+async def test_band_boundary_exactly_090_initiate_force_review_hold() -> None:
+    agent, handle, rec = make_agent()
+    # confidence=0.90 → AUTO band → force_review pushes to REVIEW → no reviewer → HOLD
+    outcome = await agent.initiate_chargeback(initiate_intent(confidence=0.90))
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert handle.initiate_calls == []
+
+
+# ---------------------------------------------------------------------------
+# R-SEC — no amount or PII in any lineage record field
+# ---------------------------------------------------------------------------
+
+
+async def test_rsec_no_amount_in_triggering_event_initiate() -> None:
+    agent, _, rec = make_agent()
+    await agent.initiate_chargeback(initiate_intent(dispute_id="DSP-SEC-01"))
+    r = rec.records[0]
+    # amount "250.00" must not appear in triggering_event or intent text
+    assert "250" not in r.triggering_event
+    assert "250" not in (r.intent or "")
+    # triggering_event is keyed on opaque dispute_id only
+    assert r.triggering_event == "initiate_chargeback:DSP-SEC-01"
+
+
+async def test_rsec_result_not_in_record_status() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.get_chargeback_status(status_intent(confidence=0.95))
+    assert outcome.result is not None
+    # AgentDecisionRecord has no 'result' field — result rides on AgentOutcome only
+    assert not hasattr(rec.records[0], "result")
+
+
+async def test_rsec_no_amount_in_record_submit() -> None:
+    agent, _, rec = make_agent()
+    await agent.submit_representment(
+        submit_intent(chargeback_id="CB-SEC-02"), human_reviewed_by="coo@banxe.com"
+    )
+    r = rec.records[0]
+    assert "CB-SEC-02" in r.triggering_event
+    assert r.triggering_event == "submit_representment:CB-SEC-02"
+
+
+# ---------------------------------------------------------------------------
+# Exactly 1 record per action
+# ---------------------------------------------------------------------------
+
+
+async def test_exactly_one_record_per_action() -> None:
+    agent, _, rec = make_agent()
+    # L1 read (AUTO)
+    await agent.get_chargeback_status(status_intent(confidence=0.95))
+    # HOLD (no reviewer)
+    await agent.initiate_chargeback(initiate_intent(confidence=0.95))
+    # HALT_UNRESOLVED
+    await agent.submit_representment(submit_intent(proc=_UNRESOLVED))
+    assert len(rec.records) == 3
+
+
+# ---------------------------------------------------------------------------
+# Window accumulation
+# ---------------------------------------------------------------------------
+
+
+async def test_window_accumulates_on_success() -> None:
+    agent, _, _ = make_agent()
+    assert agent._window.used_tokens == 0
+    await agent.get_chargeback_status(status_intent(confidence=0.95))
+    assert agent._window.used_tokens == 100
+    assert agent._window.used_cost == Decimal("0.10")
+
+
+async def test_window_not_accumulated_on_halt() -> None:
+    agent, _, _ = make_agent()
+    await agent.initiate_chargeback(initiate_intent(proc=_UNRESOLVED))
+    assert agent._window.used_tokens == 0


### PR DESCRIPTION
## COO ChargebackAgent — sprint-50 (MASK_ONLY, first of audit Tier-2)

Implements ORG §2.6.1 `ChargebackAgent` — *Dispute handling*, **L2 Review, gate COO** — as a **thin §D2 client-facing mask over the EXISTING `services/dispute_resolution/` domain**. Per the IL-176 reconciliation audit (verdict MASK_ONLY): domain already exists + is tested, so only a mask was needed. Precedent: §D2 TreasuryAgent mask coexists with domain treasury_agent.

**`services/agents/chargeback_agent.py`** delegates to the chargeback/dispute domain (`ChargebackBridge`) via an injected handle `Protocol` (DI typing) — **NO domain rewrite, NO new port**.
- Actions: `initiate_chargeback` + `submit_representment` (L2 → COO review step-up; no reviewer → HOLD_FOR_REVIEW, domain **not** called, escalate→COO); `get_chargeback_status` (AUTO read).
- Full ADR-049 §D2 chain + one ADR-046 `AgentDecisionRecord` per action; handle + DecisionRecorder injected.
- Domain `ValueError` (unknown scheme / non-positive amount / not-found) → emit(executed=False) + re-raise (precise catch).
- **R-SEC:** only opaque handles (chargeback_id/dispute_id) in lineage — never amounts/PII; domain dict rides on `AgentOutcome.result`.

**Files (2, scope-locked):** `services/agents/chargeback_agent.py`, `tests/agents/test_chargeback_agent.py`. **dispute_resolution domain untouched.**

**Gates:** ruff check ✅ · ruff format --check ✅ · semgrep ✅ · pytest **29 tests, 100% coverage** on the mask ✅ · full suite **10697 passed / 0 failed** ✅

Paired banxe-architecture PR (ORG §2.6.1 + IL-178). PR-only — no merge.