### PR TITLE
feat(credit-agent): CreditScoringAgent §D2 mask over lending — HITL-on-reject (MASK_ONLY) — sprint-51 / IL-179

### DIFF
--- a/services/agents/credit_scoring_agent.py
+++ b/services/agents/credit_scoring_agent.py
@@ -1,0 +1,557 @@
+"""CreditScoringAgent — §D2 MASK_ONLY over lending domain (Credit/Risk; EU AI Act Art.14).
+
+REGULATORY INVARIANT (CRITICAL — enforced in code AND tests):
+    If the proposed outcome is a REJECTION (is_rejection=True), the mask sets
+    force_review=True + requires_step_up=True regardless of confidence.
+    No reviewer supplied → HOLD_FOR_REVIEW (proceed=False, handle.decide NOT called,
+    escalate→CREDIT_OFFICER). There is NO code path that passes a rejection
+    to the lending domain without a human reviewer present.
+
+GOVERNANCE (ADR-049 §D2 gate-chain, fixed order):
+    process_ref → scope → band [+CREDIT_OFFICER step-up] → cost_cap
+    → compliance(CREDIT+CONSUMER_DUTY) → handle call
+
+R-SEC (ADR-021): triggering_event uses opaque handles (customer_id / application_id)
+ONLY — never income, aml_risk_score, score values, or PII. Domain returns ride on
+AgentOutcome.result ONLY, never on AgentDecisionRecord.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Protocol
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+
+# ---------------------------------------------------------------------------
+# Narrow DI Protocol (typing only — avoids cross-service model import)
+# ---------------------------------------------------------------------------
+
+
+class CreditHandle(Protocol):
+    """Narrow typing Protocol for the injected credit domain handle.
+
+    Structurally compatible with CreditScorer (score_customer / get_latest_score)
+    and LoanOriginator (decide). Return types are `object` to avoid importing
+    lending domain models into the mask module.
+    """
+
+    def score_customer(
+        self,
+        customer_id: str,
+        income: Decimal,
+        account_age_months: int,
+        aml_risk_score: Decimal,
+    ) -> object: ...
+
+    def get_latest_score(self, customer_id: str) -> object | None: ...
+
+    def decide(self, application_id: str, credit_score: object, actor: str = "system") -> dict: ...
+
+
+# ---------------------------------------------------------------------------
+# Mask (config-as-data)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CreditScoringMask:
+    """Config-as-data Credit/Risk mask (EU AI Act Art.14 high-risk; FCA CONC).
+
+    scope is the exclusive allow-list; credit_reviewer_role is the escalation
+    target for compliance failures and mandatory rejection step-up.
+    """
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    lineage_obligation: bool = True
+    agent_id: str = "credit_scoring_agent"
+    scope: tuple[str, ...] = (
+        "CreditHandle.score_customer",
+        "CreditHandle.get_latest_score",
+        "CreditHandle.decide",
+    )
+    compliance_gate: tuple[str, ...] = ("CREDIT", "CONSUMER_DUTY")
+    credit_reviewer_role: str = "CREDIT_OFFICER"
+
+
+# ---------------------------------------------------------------------------
+# Intent vocabulary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoreCustomerIntent:
+    """Resolved score-customer intent (L1 AUTO read).
+
+    R-SEC: income / aml_risk_score passed to handle but NEVER recorded.
+    triggering_event uses customer_id (opaque) only.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    customer_id: str
+    income: Decimal  # I-01: Decimal for money, never float
+    account_age_months: int
+    aml_risk_score: Decimal  # I-01
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass(frozen=True)
+class GetLatestScoreIntent:
+    """Resolved get-latest-score intent (L1 AUTO read).
+
+    R-SEC: triggering_event uses customer_id (opaque) only.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    customer_id: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass(frozen=True)
+class DecideIntent:
+    """Resolved credit-decision intent (L2 normal; L3 step-up on rejection).
+
+    is_rejection=True activates mandatory HITL step-up (EU AI Act Art.14 / FCA CONC):
+    force_review=True + requires_step_up=True regardless of confidence. credit_score
+    is an opaque domain object passed through to handle.decide().
+
+    R-SEC: triggering_event uses application_id only — never score values or PII.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    application_id: str
+    credit_score: object  # lending domain CreditScore; opaque to this mask
+    is_rejection: bool
+    actor: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation types (private)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+    human_reviewed_by: str | None
+    force_review: bool = False
+    review_escalate_to: str | None = None
+    requires_step_up: bool = False
+    auto_only: bool = False
+
+
+@dataclass(frozen=True)
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies_evaluated: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class CreditScoringAgent:
+    """§D2 MASK_ONLY Credit/Risk agent (EU AI Act Art.14; FCA CONC / ADR-049).
+
+    score_customer and get_latest_score are L1-Auto reads (AUTO-eligible within cap;
+    REVIEW band → HALT_REVIEW_DEFERRED, no HITL hold). decide is L2/L3: APPROVED /
+    REFERRED proposals follow the normal band; DECLINED (is_rejection=True) always
+    forces step-up — no reviewer → HOLD_FOR_REVIEW, handle.decide NEVER called.
+
+    CreditHandle and recorder are injected; this class contains pure governance logic.
+    """
+
+    def __init__(
+        self,
+        *,
+        credit_handle: CreditHandle,
+        recorder: DecisionRecorder,
+        mask: CreditScoringMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._handle = credit_handle
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def score_customer(
+        self,
+        intent: ScoreCustomerIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Score a customer's creditworthiness (L1 AUTO read).
+
+        REVIEW band → HALT_REVIEW_DEFERRED (reads are AUTO-only; no HITL hold).
+        R-SEC: income / aml_risk_score never appear in the lineage record.
+        """
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"score_customer:{intent.customer_id}",
+            success_action="SCORE_CUSTOMER",
+            op="CreditHandle.score_customer",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=None,
+            auto_only=True,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._handle.score_customer(
+                intent.customer_id,
+                intent.income,
+                intent.account_age_months,
+                intent.aml_risk_score,
+            ),
+        )
+
+    async def get_latest_score(
+        self,
+        intent: GetLatestScoreIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Retrieve latest credit score (L1 AUTO read).
+
+        REVIEW band → HALT_REVIEW_DEFERRED. R-SEC: customer_id only in record.
+        """
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_latest_score:{intent.customer_id}",
+            success_action="GET_LATEST_SCORE",
+            op="CreditHandle.get_latest_score",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=None,
+            auto_only=True,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._handle.get_latest_score(intent.customer_id),
+        )
+
+    async def decide(
+        self,
+        intent: DecideIntent,
+        *,
+        human_reviewed_by: str | None = None,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Apply credit decision governance (L2 normal; L3 rejection step-up).
+
+        REGULATORY INVARIANT: is_rejection=True → force_review=True +
+        requires_step_up=True. No reviewer → HOLD_FOR_REVIEW (handle.decide NOT
+        called, escalate→CREDIT_OFFICER). Reviewer present → delegate to handle.
+        R-SEC: triggering_event uses application_id only — no score/PII.
+        """
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"decide:{intent.application_id}",
+            success_action="CREDIT_DECIDE",
+            op="CreditHandle.decide",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            human_reviewed_by=human_reviewed_by,
+            force_review=intent.is_rejection,
+            review_escalate_to=self._mask.credit_reviewer_role,
+            requires_step_up=intent.is_rejection,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._handle.decide(intent.application_id, intent.credit_score, intent.actor),
+        )
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, score: float) -> ConfirmationDecision:
+        if score >= self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if score >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:  # noqa: PLR0911
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError(f"confidence_score {ctx.confidence_score!r} must be in [0.0, 1.0]")
+
+        policies: list[str] = ["ADR-048-process-resolution"]
+
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                decision=ConfirmationDecision.BLOCK,
+                proceed=False,
+                action_taken="HALT_UNRESOLVED_PROCESS",
+                reasoning_summary="Intent has no resolved process_ref; governance event, never improvised.",
+                policies_evaluated=policies,
+                compliance_result=ComplianceResult.NA,
+                budget_breach=BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                decision=ConfirmationDecision.BLOCK,
+                proceed=False,
+                action_taken="REJECT_OUT_OF_SCOPE",
+                reasoning_summary=f"Operation {ctx.op!r} not on credit scope allow-list; refused.",
+                policies_evaluated=policies,
+                compliance_result=ComplianceResult.NA,
+                budget_breach=BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+        if ctx.force_review and band is ConfirmationDecision.AUTO:
+            policies.append("ADR-046-CREDIT-OFFICER-step-up")
+            band = ConfirmationDecision.REVIEW
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                decision=band,
+                proceed=False,
+                action_taken="BLOCK_LOW_CONFIDENCE",
+                reasoning_summary="Confidence below 0.70; human confirmation mandatory (ADR-049 §D4).",
+                policies_evaluated=policies,
+                compliance_result=ctx.compliance_result,
+                budget_breach=BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+
+        if band is ConfirmationDecision.REVIEW:
+            if ctx.force_review:
+                if ctx.human_reviewed_by is None:
+                    reason = (
+                        "Rejection decision: mandatory human review (EU AI Act Art.14 / FCA CONC). "
+                        "No reviewer — HOLD, escalated to CREDIT_OFFICER."
+                        if ctx.requires_step_up
+                        else "Credit decision: CREDIT_OFFICER sign-off required. "
+                        "No reviewer — HOLD, escalated to CREDIT_OFFICER."
+                    )
+                    return _Evaluation(
+                        decision=band,
+                        proceed=False,
+                        action_taken="HOLD_FOR_REVIEW",
+                        reasoning_summary=reason,
+                        policies_evaluated=policies,
+                        compliance_result=ctx.compliance_result,
+                        budget_breach=BudgetBreach.NONE,
+                        halt_reason="hitl_review_required",
+                        requires_step_up=ctx.requires_step_up,
+                        requires_hitl=True,
+                        escalated_to=ctx.review_escalate_to,
+                    )
+                # reviewer present → fall through to cost / compliance gates
+            else:
+                return _Evaluation(
+                    decision=band,
+                    proceed=False,
+                    action_taken="HALT_REVIEW_DEFERRED",
+                    reasoning_summary="Credit read below AUTO band; reads are AUTO-only (L1), no HITL hold.",
+                    policies_evaluated=policies,
+                    compliance_result=ctx.compliance_result,
+                    budget_breach=BudgetBreach.NONE,
+                    halt_reason="review_deferred",
+                    requires_hitl=True,
+                )
+
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                decision=ConfirmationDecision.BLOCK,
+                proceed=False,
+                action_taken="HALT_COST_CAP_BREACH",
+                reasoning_summary="Per-request or per-window cost-cap breach; action refused (ADR-047).",
+                policies_evaluated=policies,
+                compliance_result=ComplianceResult.NA,
+                budget_breach=BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            return _Evaluation(
+                decision=ConfirmationDecision.BLOCK,
+                proceed=False,
+                action_taken="HALT_COMPLIANCE_BLOCK",
+                reasoning_summary=(
+                    f"CREDIT/CONSUMER_DUTY overlay {ctx.compliance_result!r}; "
+                    f"blocked, escalated to {self._mask.credit_reviewer_role}."
+                ),
+                policies_evaluated=policies,
+                compliance_result=ctx.compliance_result,
+                budget_breach=BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=self._mask.credit_reviewer_role,
+            )
+
+        note = f" (reviewed by {ctx.human_reviewed_by})" if ctx.human_reviewed_by else ""
+        return _Evaluation(
+            decision=band,
+            proceed=True,
+            action_taken=ctx.success_action,
+            reasoning_summary=f"All credit gates satisfied at {band.value} confidence{note}.",
+            policies_evaluated=policies,
+            compliance_result=ctx.compliance_result,
+            budget_breach=BudgetBreach.NONE,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,  # noqa: ARG002
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies_evaluated=list(ev.policies_evaluated),
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=ctx.human_reviewed_by,
+            correlation_id=ctx.correlation_id,
+            cost_tokens=ctx.request_cost.tokens,
+            cost_amount=ctx.request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], object],
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            try:
+                result = port_call()
+            except ValueError as exc:
+                action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                await self._emit(
+                    ctx,
+                    ev,
+                    action_taken,
+                    executed=False,
+                    compliance_result=ev.compliance_result,
+                    reasoning=f"Handle raised {type(exc).__name__}: {exc}",
+                    escalated_to=ev.escalated_to,
+                )
+                raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_step_up=ev.requires_step_up,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )
+
+
+__all__ = [
+    "CreditHandle",
+    "CreditScoringAgent",
+    "CreditScoringMask",
+    "DecideIntent",
+    "GetLatestScoreIntent",
+    "ScoreCustomerIntent",
+]

--- a/tests/agents/test_credit_scoring_agent.py
+++ b/tests/agents/test_credit_scoring_agent.py
@@ -1,0 +1,541 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.agents.credit_scoring_agent import (
+    CreditScoringAgent,
+    CreditScoringMask,
+    DecideIntent,
+    GetLatestScoreIntent,
+    ScoreCustomerIntent,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeRecorder(DecisionRecorder):
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+class FakeCreditHandle:
+    """In-memory credit handle stub for testing."""
+
+    def __init__(self, raise_value_error: bool = False) -> None:
+        self._raise = raise_value_error
+        self.score_calls: list[str] = []
+        self.get_score_calls: list[str] = []
+        self.decide_calls: list[dict] = []
+
+    def score_customer(
+        self,
+        customer_id: str,
+        income: Decimal,
+        account_age_months: int,
+        aml_risk_score: Decimal,
+    ) -> object:
+        if self._raise:
+            raise ValueError("fake domain error: invalid income")
+        self.score_calls.append(customer_id)
+        return {"customer_id": customer_id, "score": "750", "stub": True}
+
+    def get_latest_score(self, customer_id: str) -> object | None:
+        if self._raise:
+            raise ValueError("fake domain error: customer not found")
+        self.get_score_calls.append(customer_id)
+        return {"customer_id": customer_id, "score": "700", "stub": True}
+
+    def decide(self, application_id: str, credit_score: object, actor: str = "system") -> dict:
+        if self._raise:
+            raise ValueError("fake domain error: application not found")
+        self.decide_calls.append({"application_id": application_id, "actor": actor})
+        return {"status": "HITL_REQUIRED", "application_id": application_id}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CAP = CostCap(
+    max_request_tokens=5000,
+    max_request_cost=Decimal("5.00"),
+    max_window_tokens=50000,
+    max_window_cost=Decimal("50.00"),
+)
+_SMALL_COST = RequestCost(tokens=100, cost=Decimal("0.10"))
+_PROC = ProcessRef(process_id="CREDIT-P-001", version="v1.0")
+_UNRESOLVED = ProcessRef(process_id="", version="")
+
+
+def make_mask(**overrides: object) -> CreditScoringMask:
+    base: dict[str, object] = {"cost_cap": _DEFAULT_CAP}
+    base.update(overrides)
+    return CreditScoringMask(**base)  # type: ignore[arg-type]
+
+
+def make_agent(
+    *,
+    mask: CreditScoringMask | None = None,
+    window: CostWindow | None = None,
+    raise_value_error: bool = False,
+) -> tuple[CreditScoringAgent, FakeCreditHandle, FakeRecorder]:
+    handle = FakeCreditHandle(raise_value_error=raise_value_error)
+    rec = FakeRecorder()
+    agent = CreditScoringAgent(
+        credit_handle=handle,
+        recorder=rec,
+        mask=mask or make_mask(),
+        cost_window=window,
+    )
+    return agent, handle, rec
+
+
+def score_intent(
+    confidence: float = 0.95,
+    customer_id: str = "CUST-001",
+    proc: ProcessRef = _PROC,
+) -> ScoreCustomerIntent:
+    return ScoreCustomerIntent(
+        intent_text="score customer creditworthiness",
+        process_ref=proc,
+        customer_id=customer_id,
+        income=Decimal("45000.00"),
+        account_age_months=18,
+        aml_risk_score=Decimal("5.0"),
+        correlation_id="corr-score-001",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+    )
+
+
+def get_score_intent(
+    confidence: float = 0.95,
+    customer_id: str = "CUST-001",
+    proc: ProcessRef = _PROC,
+) -> GetLatestScoreIntent:
+    return GetLatestScoreIntent(
+        intent_text="get latest credit score",
+        process_ref=proc,
+        customer_id=customer_id,
+        correlation_id="corr-get-001",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+    )
+
+
+def decide_intent(
+    confidence: float = 0.95,
+    application_id: str = "APP-001",
+    is_rejection: bool = False,
+    proc: ProcessRef = _PROC,
+) -> DecideIntent:
+    return DecideIntent(
+        intent_text="apply credit decision",
+        process_ref=proc,
+        application_id=application_id,
+        credit_score={"score": "750"},
+        is_rejection=is_rejection,
+        actor="underwriter",
+        correlation_id="corr-decide-001",
+        confidence_score=confidence,
+        request_cost=_SMALL_COST,
+    )
+
+
+# ---------------------------------------------------------------------------
+# L1 AUTO read — score_customer happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_score_customer_auto_proceeds_and_returns_result() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.score_customer(score_intent(confidence=0.95))
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, dict)
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "SCORE_CUSTOMER"
+    assert handle.score_calls == ["CUST-001"]
+    assert not hasattr(rec.records[0], "result")
+
+
+# ---------------------------------------------------------------------------
+# L1 AUTO read — get_latest_score happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_get_latest_score_auto_proceeds_and_returns_result() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.get_latest_score(get_score_intent(confidence=0.95))
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, dict)
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "GET_LATEST_SCORE"
+    assert handle.get_score_calls == ["CUST-001"]
+
+
+# ---------------------------------------------------------------------------
+# decide — APPROVED (is_rejection=False) high confidence → proceeds
+# ---------------------------------------------------------------------------
+
+
+async def test_decide_approved_high_confidence_domain_called() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.decide(decide_intent(confidence=0.95, is_rejection=False))
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.result is not None
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "CREDIT_DECIDE"
+    assert len(handle.decide_calls) == 1
+    assert handle.decide_calls[0]["application_id"] == "APP-001"
+
+
+# ---------------------------------------------------------------------------
+# ⭐ MANDATORY-HITL-ON-REJECT INVARIANT
+# ---------------------------------------------------------------------------
+
+
+async def test_decide_rejection_no_reviewer_hold_for_review_domain_never_called() -> None:
+    """REGULATORY: rejection at confidence=1.0 with no reviewer → HOLD_FOR_REVIEW."""
+    agent, handle, rec = make_agent()
+    outcome = await agent.decide(decide_intent(confidence=1.0, is_rejection=True))
+    assert outcome.executed is False
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.requires_step_up is True
+    assert outcome.requires_hitl is True
+    assert outcome.escalated_to == "CREDIT_OFFICER"
+    assert rec.records[0].action_taken == "HOLD_FOR_REVIEW"
+    assert rec.records[0].escalated_to == "CREDIT_OFFICER"
+    assert handle.decide_calls == []  # domain NEVER called
+
+
+async def test_decide_rejection_with_reviewer_proceeds() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.decide(
+        decide_intent(confidence=0.95, is_rejection=True),
+        human_reviewed_by="officer@banxe.com",
+    )
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.REVIEW  # force_review pulled AUTO→REVIEW
+    assert outcome.result is not None
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "CREDIT_DECIDE"
+    assert rec.records[0].human_reviewed_by == "officer@banxe.com"
+    assert len(handle.decide_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# HALT_UNRESOLVED_PROCESS
+# ---------------------------------------------------------------------------
+
+
+async def test_halt_unresolved_process_ref_score() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.score_customer(score_intent(proc=_UNRESOLVED))
+    assert outcome.executed is False
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert outcome.requires_hitl is True
+    assert rec.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+    assert handle.score_calls == []
+
+
+async def test_halt_unresolved_process_ref_decide() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.decide(decide_intent(proc=_UNRESOLVED))
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert handle.decide_calls == []
+
+
+# ---------------------------------------------------------------------------
+# REJECT_OUT_OF_SCOPE
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_out_of_scope_op() -> None:
+    mask = make_mask(scope=("OTHER.op",))
+    agent, handle, rec = make_agent(mask=mask)
+    outcome = await agent.score_customer(score_intent())
+    assert outcome.halt_reason == "out_of_scope"
+    assert rec.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+    assert handle.score_calls == []
+
+
+# ---------------------------------------------------------------------------
+# HALT_REVIEW_DEFERRED — L1 read below AUTO band → domain NOT called
+# ---------------------------------------------------------------------------
+
+
+async def test_halt_review_deferred_score_below_auto() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.score_customer(score_intent(confidence=0.80))
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert outcome.requires_hitl is True
+    assert rec.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+    assert handle.score_calls == []
+
+
+async def test_halt_review_deferred_get_score_below_auto() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.get_latest_score(get_score_intent(confidence=0.80))
+    assert outcome.halt_reason == "review_deferred"
+    assert handle.get_score_calls == []
+
+
+# ---------------------------------------------------------------------------
+# BLOCK_LOW_CONFIDENCE
+# ---------------------------------------------------------------------------
+
+
+async def test_block_low_confidence_score() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.score_customer(score_intent(confidence=0.50))
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert rec.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+    assert handle.score_calls == []
+
+
+async def test_block_low_confidence_decide() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.decide(decide_intent(confidence=0.50))
+    assert outcome.halt_reason == "low_confidence"
+    assert rec.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+# ---------------------------------------------------------------------------
+# HALT_COST_CAP_BREACH (per-request tokens / cost; per-window tokens / cost)
+# ---------------------------------------------------------------------------
+
+
+async def test_halt_cost_cap_per_request_tokens() -> None:
+    cap = CostCap(
+        max_request_tokens=50,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=50000,
+        max_window_cost=Decimal("100.00"),
+    )
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap))
+    outcome = await agent.score_customer(score_intent())
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert rec.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+async def test_halt_cost_cap_per_request_cost() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("0.05"),
+        max_window_tokens=50000,
+        max_window_cost=Decimal("100.00"),
+    )
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap))
+    outcome = await agent.score_customer(score_intent())
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+async def test_halt_cost_cap_per_window_tokens() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=150,
+        max_window_cost=Decimal("100.00"),
+    )
+    window = CostWindow(used_tokens=100)
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.score_customer(score_intent())
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+async def test_halt_cost_cap_per_window_cost() -> None:
+    cap = CostCap(
+        max_request_tokens=5000,
+        max_request_cost=Decimal("100.00"),
+        max_window_tokens=50000,
+        max_window_cost=Decimal("0.15"),
+    )
+    window = CostWindow(used_cost=Decimal("0.10"))
+    agent, _, rec = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.score_customer(score_intent())
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+# ---------------------------------------------------------------------------
+# HALT_COMPLIANCE_BLOCK — non-PASS → escalate to CREDIT_OFFICER
+# ---------------------------------------------------------------------------
+
+
+async def test_halt_compliance_fail_escalates_to_credit_officer() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.score_customer(score_intent(), compliance_result=ComplianceResult.FAIL)
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CREDIT_OFFICER"
+    assert rec.records[0].escalated_to == "CREDIT_OFFICER"
+    assert rec.records[0].action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert handle.score_calls == []
+
+
+async def test_halt_compliance_escalate_also_blocks() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.get_latest_score(
+        get_score_intent(), compliance_result=ComplianceResult.ESCALATE
+    )
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CREDIT_OFFICER"
+
+
+# ---------------------------------------------------------------------------
+# HALT_PROVIDER_ERROR — handle raises ValueError → emit executed=False + re-raise
+# ---------------------------------------------------------------------------
+
+
+async def test_provider_error_score_emits_record_then_reraises() -> None:
+    agent, _, rec = make_agent(raise_value_error=True)
+    with pytest.raises(ValueError, match="fake domain error"):
+        await agent.score_customer(score_intent())
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken == "HALT_PROVIDER_ERROR:ValueError"
+
+
+async def test_provider_error_decide_emits_record_then_reraises() -> None:
+    agent, _, rec = make_agent(raise_value_error=True)
+    with pytest.raises(ValueError, match="fake domain error"):
+        await agent.decide(decide_intent(), human_reviewed_by="officer@banxe.com")
+    assert len(rec.records) == 1
+    assert rec.records[0].action_taken.startswith("HALT_PROVIDER_ERROR")
+
+
+# ---------------------------------------------------------------------------
+# ValueError on confidence out of [0, 1]
+# ---------------------------------------------------------------------------
+
+
+async def test_confidence_above_one_raises_value_error() -> None:
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.score_customer(score_intent(confidence=1.01))
+
+
+async def test_confidence_below_zero_raises_value_error() -> None:
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_latest_score(get_score_intent(confidence=-0.01))
+
+
+# ---------------------------------------------------------------------------
+# Band boundaries
+# ---------------------------------------------------------------------------
+
+
+async def test_band_boundary_exactly_090_score_is_auto_proceeds() -> None:
+    agent, handle, rec = make_agent()
+    outcome = await agent.score_customer(score_intent(confidence=0.90))
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert handle.score_calls == ["CUST-001"]
+
+
+async def test_band_boundary_exactly_070_score_is_review_deferred() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.score_customer(score_intent(confidence=0.70))
+    assert outcome.halt_reason == "review_deferred"
+    assert outcome.decision is ConfirmationDecision.REVIEW
+
+
+async def test_band_boundary_rejection_confidence_090_force_review_hold() -> None:
+    """Rejection with confidence=0.90 → AUTO → force_review → REVIEW → no reviewer → HOLD."""
+    agent, handle, rec = make_agent()
+    outcome = await agent.decide(decide_intent(confidence=0.90, is_rejection=True))
+    assert outcome.halt_reason == "hitl_review_required"
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.requires_step_up is True
+    assert handle.decide_calls == []
+
+
+# ---------------------------------------------------------------------------
+# R-SEC — no score / income / PII in any AgentDecisionRecord field
+# ---------------------------------------------------------------------------
+
+
+async def test_rsec_no_income_in_triggering_event() -> None:
+    agent, _, rec = make_agent()
+    await agent.score_customer(score_intent(customer_id="CUST-SEC-01"))
+    r = rec.records[0]
+    assert "45000" not in r.triggering_event
+    assert "45000" not in (r.intent or "")
+    assert r.triggering_event == "score_customer:CUST-SEC-01"
+
+
+async def test_rsec_no_aml_risk_in_record() -> None:
+    agent, _, rec = make_agent()
+    await agent.score_customer(score_intent(customer_id="CUST-SEC-02"))
+    r = rec.records[0]
+    assert "5.0" not in r.triggering_event
+    assert not hasattr(r, "aml_risk_score")
+
+
+async def test_rsec_result_not_in_decision_record() -> None:
+    agent, _, rec = make_agent()
+    outcome = await agent.score_customer(score_intent())
+    assert outcome.result is not None
+    assert not hasattr(rec.records[0], "result")
+
+
+async def test_rsec_decide_application_id_only_in_triggering_event() -> None:
+    agent, _, rec = make_agent()
+    await agent.decide(decide_intent(application_id="APP-SEC-03"))
+    r = rec.records[0]
+    assert r.triggering_event == "decide:APP-SEC-03"
+    assert "750" not in r.triggering_event
+
+
+# ---------------------------------------------------------------------------
+# Exactly 1 record per action — every exit path
+# ---------------------------------------------------------------------------
+
+
+async def test_exactly_one_record_per_action() -> None:
+    agent, _, rec = make_agent()
+    await agent.score_customer(score_intent(confidence=0.95))  # AUTO proceeds
+    await agent.get_latest_score(get_score_intent(confidence=0.80))  # HALT_REVIEW_DEFERRED
+    await agent.decide(decide_intent(is_rejection=True))  # HOLD_FOR_REVIEW
+    await agent.score_customer(score_intent(proc=_UNRESOLVED))  # HALT_UNRESOLVED_PROCESS
+    assert len(rec.records) == 4
+
+
+# ---------------------------------------------------------------------------
+# Window accumulation
+# ---------------------------------------------------------------------------
+
+
+async def test_window_accumulates_on_success() -> None:
+    agent, _, _ = make_agent()
+    assert agent._window.used_tokens == 0
+    await agent.score_customer(score_intent(confidence=0.95))
+    assert agent._window.used_tokens == 100
+    assert agent._window.used_cost == Decimal("0.10")
+
+
+async def test_window_not_accumulated_on_halt() -> None:
+    agent, _, _ = make_agent()
+    await agent.score_customer(score_intent(proc=_UNRESOLVED))
+    assert agent._window.used_tokens == 0


### PR DESCRIPTION
## CreditScoringAgent — sprint-51 (MASK_ONLY, audit Tier-2)

ORG Risk/Credit `CreditScoringAgent` (EU AI Act Art.14 high-risk; **HITL required on all rejections**) as a thin §D2 mask over the EXISTING `services/lending/` domain (per IL-176 audit). Delegates to `CreditScorer` + `LoanOriginator` via an injected handle `Protocol` — **NO domain rewrite, NO new port**.

- Actions: `score_customer` / `get_latest_score` (AUTO reads), `decide` (credit decision). Full ADR-049 §D2 chain + one ADR-046 record/action; handle + DecisionRecorder injected. Domain `ValueError` → emit(executed=False)+reraise. R-SEC: opaque handles only (customer_id/application_id) — never income/score/aml/PII.

**⭐ REGULATORY INVARIANT (enforced + tested):** a credit **rejection can never be finalized autonomously** — a proposed DECLINED outcome forces step-up to mandatory human review regardless of confidence; no reviewer → HOLD_FOR_REVIEW, `handle.decide` **never called**, escalate→CREDIT_OFFICER. `test_decide_rejection_no_reviewer_hold_for_review_domain_never_called` proves reject@confidence=1.0 HALTs with the domain never invoked (call-spy). Composes with the domain's own I-27 HITL_REQUIRED wrapping.

**Files (2, scope-locked):** `services/agents/credit_scoring_agent.py`, `tests/agents/test_credit_scoring_agent.py`. **lending domain untouched.**

**Gates:** ruff check ✅ · format --check ✅ · semgrep ✅ · pytest **32 tests, 100% coverage** on the mask ✅ · full suite **10729 passed / 0 failed** ✅

Paired banxe-architecture PR (ORG + IL-179). PR-only — no merge.