### PR TITLE
feat(nps-agent): NPSAgent §D2 mask over support feedback (MASK_ONLY, L1 read-only) — sprint-53 / IL-183

### DIFF
--- a/services/agents/nps_agent.py
+++ b/services/agents/nps_agent.py
@@ -1,0 +1,424 @@
+"""NPSAgent — L1-Auto §D2 mask over support feedback domain (MASK_ONLY).
+
+WHY: ORG §2.8 (Front Office, CRO quarterly review §2.8.1) defines NPSAgent as the
+governed client-facing surface through which a resolved NPS/CSAT read intent becomes
+a bounded FeedbackAnalyticsAgent.get_metrics action. This module enforces the ADR-049
+§D2 gate chain in front of the support feedback domain.
+
+NPSAgent is READ-ONLY reporting. It DOES NOT submit or record feedback.
+submit_csat is NOT in scope — any attempt is REJECT_OUT_OF_SCOPE (INVARIANT).
+
+GOVERNANCE (ADR-049 §D2 gate-chain, fixed order):
+    process_ref → scope → band → cost_cap → compliance(CONSUMER_DUTY) → handle call
+
+* ``scope``          — FeedbackAnalyticsAgent READ ops only (1-op allow-list:
+                       get_metrics). submit_csat is out-of-scope (ADR-054 §D1 pattern).
+* ``autonomy_level`` — L1-Auto: every read is AUTO-eligible within cap. Below-AUTO →
+                       HALT_REVIEW_DEFERRED (domain NOT called). No HITL hold path.
+* ``cost_cap``       — per-request AND per-window hard caps (ADR-047 §D2).
+* ``lineage``        — one AgentDecisionRecord per action, every exit path (ADR-046).
+* ``compliance``     — CONSUMER_DUTY overlay; non-PASS → BLOCK + escalate to CRO.
+
+INVARIANT (L1 read-only): mask scope contains ONLY get_metrics. The write op
+submit_csat is NOT present. Any attempt to call an off-list op is REJECT_OUT_OF_SCOPE
+before the handle is ever reached. I-27: PROPOSES findings only, never applies.
+
+Provider-error: if the handle raises ValueError, one lineage record is emitted
+(executed=False, action_taken=HALT_PROVIDER_ERROR:ValueError) then re-raised.
+
+R-SEC (ADR-021): triggering_event is keyed on OPAQUE handles only (period_days /
+survey_id / cohort). Raw customer feedback text, CSAT comments, and PII MUST NEVER
+appear in any AgentDecisionRecord field. FeedbackMetrics aggregate rides on
+AgentOutcome.result ONLY — never on the lineage record.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+
+# ---------------------------------------------------------------------------
+# Narrow DI Protocol (typing only — not a new heavy port)
+# ---------------------------------------------------------------------------
+
+
+class FeedbackHandle(Protocol):
+    """Narrow typing Protocol for the injected support feedback domain handle.
+
+    Matches FeedbackAnalyticsAgent.get_metrics (the read op) only.
+    The write op submit_csat is intentionally absent — NPSAgent is read-only.
+    """
+
+    async def get_metrics(self, period_days: int = 30) -> object: ...
+
+
+# ---------------------------------------------------------------------------
+# Mask (config-as-data)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NPSMask:
+    """Config-as-data CRO-reviewed NPS/CSAT reporting mask (ORG §2.8 / §2.8.1).
+
+    scope contains ONLY get_metrics (the read op). submit_csat is not present
+    (INVARIANT: see module docstring). All gate values are governed config.
+    """
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    lineage_obligation: bool = True
+    agent_id: str = "nps_agent"
+    # INVARIANT: only the read op. submit_csat MUST NOT appear here.
+    scope: tuple[str, ...] = ("FeedbackAnalyticsAgent.get_metrics",)
+    compliance_gate: tuple[str, ...] = ("CONSUMER_DUTY",)
+    cro_role: str = "CRO"
+
+
+# ---------------------------------------------------------------------------
+# Intent vocabulary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GetFeedbackMetricsIntent:
+    """Resolved NPS/CSAT metrics read intent (FeedbackAnalyticsAgent.get_metrics).
+
+    R-SEC: triggering_event keyed on opaque handles only (period_days / survey_id /
+    cohort). Raw feedback text and PII MUST NOT appear on any intent field used in
+    the lineage record. FeedbackMetrics rides on AgentOutcome.result ONLY.
+    """
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    period_days: int = 30
+    survey_id: str = ""
+    cohort: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation types (private)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class NPSAgent:
+    """L1-Auto CRO NPS/CSAT reporting agent enforcing the ADR-049 §D2 gate chain.
+
+    READ-ONLY: delegates get_feedback_metrics to the injected FeedbackHandle.
+    DOES NOT submit or record feedback — submit_csat is REJECT_OUT_OF_SCOPE.
+    I-27: PROPOSES findings only, never applies changes autonomously.
+    """
+
+    def __init__(
+        self,
+        *,
+        feedback_handle: FeedbackHandle,
+        recorder: DecisionRecorder,
+        mask: NPSMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._handle = feedback_handle
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def get_feedback_metrics(
+        self,
+        intent: GetFeedbackMetricsIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """NPS/CSAT aggregate read via FeedbackAnalyticsAgent.get_metrics.
+
+        AUTO-eligible within cap. CONSUMER_DUTY overlay MUST PASS; non-PASS blocks
+        and escalates to CRO. A read below the AUTO band halts (L1-Auto: no HITL hold).
+        FeedbackMetrics rides on AgentOutcome.result ONLY (R-SEC — no metric values
+        or PII in lineage).
+        """
+        # Build opaque triggering_event — no feedback text or PII (R-SEC).
+        parts: list[str] = [f"period={intent.period_days}"]
+        if intent.survey_id:
+            parts.append(f"survey={intent.survey_id}")
+        if intent.cohort:
+            parts.append(f"cohort={intent.cohort}")
+
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event="get_feedback_metrics:" + ":".join(parts),
+            success_action="REPORT_FEEDBACK_METRICS",
+            op="FeedbackAnalyticsAgent.get_metrics",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._handle.get_metrics(intent.period_days))
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:  # noqa: PLR0911
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError(f"confidence_score {ctx.confidence_score!r} must be in [0.0, 1.0]")
+
+        policies: list[str] = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no handle call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. Scope allow-list — submit_csat and all off-list ops are refused outright.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op!r} is not on the NPS mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band. REVIEW → HALT_REVIEW_DEFERRED (L1-Auto: no HITL hold).
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+        if band is ConfirmationDecision.REVIEW:
+            return _Evaluation(
+                band,
+                False,
+                "HALT_REVIEW_DEFERRED",
+                "Read intent below AUTO band; reads are AUTO-only, no HITL hold (L1-Auto).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="review_deferred",
+                requires_hitl=True,
+            )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window tokens/cost); refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. CONSUMER_DUTY compliance gate. Non-PASS → block AND escalate to CRO.
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            escalated = self._mask.cro_role
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"CONSUMER_DUTY overlay returned {ctx.compliance_result}; "
+                f"action blocked and escalated to {escalated}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=escalated,
+            )
+
+        # All gates satisfied — clear to commit the read.
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All NPS mask gates satisfied at {band.value} confidence; committing read.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except ValueError as exc:
+                    # Handle raises ValueError; emit lineage (executed=False), re-raise.
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=ev.compliance_result,
+                        reasoning=f"Handle raised {type(exc).__name__}: {exc}",
+                        escalated_to=ev.escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,  # noqa: ARG002
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies_evaluated=list(ev.policies),
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=None,
+            correlation_id=ctx.correlation_id,
+            cost_tokens=ctx.request_cost.tokens,
+            cost_amount=ctx.request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "FeedbackHandle",
+    "GetFeedbackMetricsIntent",
+    "NPSAgent",
+    "NPSMask",
+]

--- a/tests/agents/test_nps_agent.py
+++ b/tests/agents/test_nps_agent.py
@@ -1,0 +1,701 @@
+"""NPSAgent test suite — 100% coverage over services/agents/nps_agent.py.
+
+Validates: ADR-049 §D2 gate-chain branches (process-ref resolution, scope allow-list,
+confidence band, per-request and per-window cost-cap, compliance gate, successful
+handle call, ValueError provider-error path), ADR-046 lineage invariants (one record
+per action on every exit path), R-SEC-NEW-01 (no raw feedback metrics / PII in any
+lineage record — result rides on AgentOutcome.result only), and the READ-ONLY INVARIANT
+(mask scope has only get_metrics; submit_csat is REJECT_OUT_OF_SCOPE).
+
+asyncio_mode = "auto" (pyproject.toml): every ``async def test_*`` is auto-collected.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.agents.nps_agent import (
+    GetFeedbackMetricsIntent,
+    NPSAgent,
+    NPSMask,
+    _ActionContext,  # private — test-only access for scope-invariant test
+)
+from services.support.support_models import FeedbackMetrics
+
+# ---------------------------------------------------------------------------
+# In-test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeRecorder(DecisionRecorder):
+    """In-memory DecisionRecorder that collects records for assertion."""
+
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+class FakeFeedbackHandle:
+    """In-memory FeedbackHandle stub — async get_metrics, optional ValueError raise."""
+
+    def __init__(
+        self,
+        metrics: FeedbackMetrics | None = None,
+        raise_value_error: bool = False,
+    ) -> None:
+        self._metrics = metrics or _default_metrics()
+        self._raise = raise_value_error
+        self.call_count: int = 0
+        self.last_period_days: int | None = None
+
+    async def get_metrics(self, period_days: int = 30) -> FeedbackMetrics:
+        self.call_count += 1
+        self.last_period_days = period_days
+        if self._raise:
+            raise ValueError("fake domain error: provider unavailable")
+        return self._metrics
+
+
+# ---------------------------------------------------------------------------
+# Builders / helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_metrics() -> FeedbackMetrics:
+    return FeedbackMetrics(
+        period_days=30,
+        total_responses=100,
+        avg_csat=4.2,
+        avg_nps=7.5,
+        nps_promoters=60,
+        nps_detractors=15,
+        nps_passives=25,
+        nps_score=45.0,
+        by_category={"PAYMENT": 4.5, "KYC": 3.8},
+    )
+
+
+_DEFAULT_CAP = CostCap(
+    max_request_tokens=1_000,
+    max_request_cost=Decimal("1.00"),
+    max_window_tokens=10_000,
+    max_window_cost=Decimal("10.00"),
+)
+
+
+def make_mask(**overrides: object) -> NPSMask:
+    base: dict[str, object] = {"cost_cap": _DEFAULT_CAP}
+    base.update(overrides)
+    return NPSMask(**base)  # type: ignore[arg-type]
+
+
+def make_agent(
+    mask: NPSMask | None = None,
+    handle: FakeFeedbackHandle | None = None,
+    recorder: FakeRecorder | None = None,
+    window: CostWindow | None = None,
+) -> tuple[NPSAgent, FakeFeedbackHandle, FakeRecorder]:
+    h = handle or FakeFeedbackHandle()
+    r = recorder or FakeRecorder()
+    m = mask or make_mask()
+    return NPSAgent(feedback_handle=h, recorder=r, mask=m, cost_window=window), h, r
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    return ProcessRef(process_id="proc-nps-001" if resolved else "", version="1.0")
+
+
+def _cost(tokens: int = 10, cost: str = "0.01") -> RequestCost:
+    return RequestCost(tokens=tokens, cost=Decimal(cost))
+
+
+def make_metrics_intent(
+    *,
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+    period_days: int = 30,
+    survey_id: str = "",
+    cohort: str = "",
+) -> GetFeedbackMetricsIntent:
+    return GetFeedbackMetricsIntent(
+        intent_text="CRO quarterly NPS/CSAT review",
+        process_ref=_ref(resolved),
+        correlation_id="corr-nps-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+        period_days=period_days,
+        survey_id=survey_id,
+        cohort=cohort,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. AUTO happy path — get_feedback_metrics
+# ---------------------------------------------------------------------------
+
+
+async def test_get_feedback_metrics_auto_happy_path() -> None:
+    """Confidence 0.95 > 0.90 → AUTO band; handle called; exactly one lineage record.
+
+    FeedbackMetrics rides on outcome.result ONLY — not on the record (R-SEC).
+    """
+    agent, handle, recorder = make_agent()
+    outcome = await agent.get_feedback_metrics(make_metrics_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.halt_reason is None
+    assert outcome.requires_hitl is False
+    assert outcome.escalated_to is None
+    assert len(recorder.records) == 1
+
+    rec = recorder.records[0]
+    assert rec.action_taken == "REPORT_FEEDBACK_METRICS"
+    assert rec.agent_id == "nps_agent"
+    assert rec.compliance_result is ComplianceResult.PASS
+    assert rec.budget_breach_flag is BudgetBreach.NONE
+    assert rec.human_reviewed_by is None
+
+    # FeedbackMetrics rides on outcome.result ONLY (R-SEC).
+    assert isinstance(outcome.result, FeedbackMetrics)
+    assert outcome.record is rec
+    assert handle.call_count == 1
+    assert handle.last_period_days == 30
+
+
+# ---------------------------------------------------------------------------
+# 2. survey_id and cohort appear in triggering_event (opaque handles)
+# ---------------------------------------------------------------------------
+
+
+async def test_triggering_event_includes_survey_and_cohort() -> None:
+    """survey_id and cohort are included in triggering_event as opaque labels."""
+    agent, _, recorder = make_agent()
+    intent = make_metrics_intent(survey_id="SRV-Q2-2026", cohort="premium")
+    await agent.get_feedback_metrics(intent)
+
+    rec = recorder.records[0]
+    assert "survey=SRV-Q2-2026" in rec.triggering_event
+    assert "cohort=premium" in rec.triggering_event
+    assert "period=30" in rec.triggering_event
+
+
+async def test_triggering_event_period_only_when_no_survey_or_cohort() -> None:
+    """With no survey_id/cohort, triggering_event contains only the period label."""
+    agent, _, recorder = make_agent()
+    await agent.get_feedback_metrics(make_metrics_intent(period_days=7))
+
+    rec = recorder.records[0]
+    assert rec.triggering_event == "get_feedback_metrics:period=7"
+    assert "survey" not in rec.triggering_event
+    assert "cohort" not in rec.triggering_event
+
+
+# ---------------------------------------------------------------------------
+# 3. Unresolved process_ref → HALT_UNRESOLVED_PROCESS
+# ---------------------------------------------------------------------------
+
+
+async def test_unresolved_process_ref_blocks() -> None:
+    """Empty process_id → unresolved; handle NOT called; one lineage record."""
+    agent, handle, recorder = make_agent()
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(resolved=False))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert outcome.requires_hitl is True
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+    assert handle.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. REJECT_OUT_OF_SCOPE — submit_csat op refused (READ-ONLY INVARIANT)
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_out_of_scope_submit_csat_refused() -> None:
+    """submit_csat op is NOT on the NPS mask scope allow-list → REJECT_OUT_OF_SCOPE.
+
+    INVARIANT: NPSAgent.scope contains ONLY get_metrics (the read op). The write
+    op submit_csat is refused before the handle is ever called.
+    """
+    agent, handle, recorder = make_agent()
+    # Construct a context with op = submit_csat (the write op outside scope).
+    ctx = _ActionContext(
+        intent_text="attempt to submit csat via nps agent",
+        process_ref=_ref(resolved=True),
+        correlation_id="scope-test-001",
+        confidence_score=0.95,
+        triggering_event="test:submit_csat",
+        success_action="SUBMIT_CSAT",
+        op="FeedbackAnalyticsAgent.submit_csat",
+        request_cost=_cost(),
+        compliance_result=ComplianceResult.PASS,
+    )
+    outcome = await agent._run_action(ctx, None)
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "out_of_scope"
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+    assert handle.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. HALT_REVIEW_DEFERRED — below AUTO band (L1-Auto: no HITL hold)
+# ---------------------------------------------------------------------------
+
+
+async def test_halt_review_deferred_below_auto_band() -> None:
+    """Confidence 0.80 is in REVIEW band (0.70–0.90); reads are AUTO-only (L1-Auto)."""
+    agent, handle, recorder = make_agent()
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(confidence=0.80))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+    assert handle.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. BLOCK_LOW_CONFIDENCE — confidence below review_floor
+# ---------------------------------------------------------------------------
+
+
+async def test_block_low_confidence() -> None:
+    """Confidence 0.50 < 0.70 → BLOCK; handle NOT called."""
+    agent, handle, recorder = make_agent()
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(confidence=0.50))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+    assert handle.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. HALT_COST_CAP_BREACH — per-request token breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_request_cost_cap_tokens_breach() -> None:
+    """tokens=100 > max_request_tokens=5 → breach; handle NOT called."""
+    tight_cap = CostCap(
+        max_request_tokens=5,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, handle, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert len(recorder.records) == 1
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+    assert handle.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 8. HALT_COST_CAP_BREACH — per-request monetary breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_request_cost_cap_monetary_breach() -> None:
+    """cost=0.10 > max_request_cost=0.001 → breach; handle NOT called."""
+    tight_cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("0.001"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(cost="0.10"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+# ---------------------------------------------------------------------------
+# 9. HALT_COST_CAP_BREACH — per-window token breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_window_tokens_breach() -> None:
+    """Window nearly full on tokens; next request overflows → breach."""
+    window = CostWindow(used_tokens=9990, used_cost=Decimal("0.00"), window_ref="nps_agent:test")
+    agent, _, recorder = make_agent(window=window)
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert len(recorder.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# 10. HALT_COST_CAP_BREACH — per-window monetary breach
+# ---------------------------------------------------------------------------
+
+
+async def test_per_window_monetary_breach() -> None:
+    """Window nearly full on cost; next request overflows → breach."""
+    window = CostWindow(used_tokens=0, used_cost=Decimal("9.99"), window_ref="nps_agent:test")
+    cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=1_000_000,
+        max_window_cost=Decimal("10.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(tokens=1, cost="0.02"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+# ---------------------------------------------------------------------------
+# 11. HALT_COMPLIANCE_BLOCK — CONSUMER_DUTY FAIL escalates to CRO
+# ---------------------------------------------------------------------------
+
+
+async def test_compliance_fail_blocks_escalates_to_cro() -> None:
+    """CONSUMER_DUTY FAIL → HALT_COMPLIANCE_BLOCK; escalated_to = CRO."""
+    agent, handle, recorder = make_agent()
+    outcome = await agent.get_feedback_metrics(
+        make_metrics_intent(),
+        compliance_result=ComplianceResult.FAIL,
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CRO"
+    assert outcome.requires_hitl is True
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.escalated_to == "CRO"
+    assert rec.action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert handle.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 12. HALT_COMPLIANCE_BLOCK — CONSUMER_DUTY ESCALATE also blocks
+# ---------------------------------------------------------------------------
+
+
+async def test_compliance_escalate_blocks_escalates_to_cro() -> None:
+    """CONSUMER_DUTY ESCALATE also halts and escalates to CRO."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_feedback_metrics(
+        make_metrics_intent(),
+        compliance_result=ComplianceResult.ESCALATE,
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "CRO"
+    assert len(recorder.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# 13. HALT_PROVIDER_ERROR — handle raises ValueError → lineage + re-raise
+# ---------------------------------------------------------------------------
+
+
+async def test_halt_provider_error_emits_lineage_then_reraises() -> None:
+    """ValueError from handle: one lineage record with HALT_PROVIDER_ERROR; re-raised."""
+    h = FakeFeedbackHandle(raise_value_error=True)
+    agent, _, recorder = make_agent(handle=h)
+
+    with pytest.raises(ValueError, match="provider unavailable"):
+        await agent.get_feedback_metrics(make_metrics_intent())
+
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.action_taken == "HALT_PROVIDER_ERROR:ValueError"
+    assert rec.budget_breach_flag is BudgetBreach.NONE
+
+
+# ---------------------------------------------------------------------------
+# 14. Confidence out of [0, 1] → ValueError, NO lineage record
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_confidence_above_range_raises_no_record() -> None:
+    """confidence=1.1 → ValueError; _evaluate raises before any lineage record."""
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_feedback_metrics(make_metrics_intent(confidence=1.1))
+    assert len(recorder.records) == 0
+
+
+async def test_invalid_confidence_below_range_raises_no_record() -> None:
+    """confidence=-0.01 → ValueError; no lineage record."""
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_feedback_metrics(make_metrics_intent(confidence=-0.01))
+    assert len(recorder.records) == 0
+
+
+# ---------------------------------------------------------------------------
+# 15. Band boundary values
+# ---------------------------------------------------------------------------
+
+
+async def test_band_boundary_exactly_auto_threshold_is_review() -> None:
+    """confidence=0.90 is NOT > 0.90 → falls to REVIEW → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(confidence=0.90))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+async def test_band_boundary_exactly_review_floor_is_review() -> None:
+    """confidence=0.70 is >= 0.70 → REVIEW → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(confidence=0.70))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+async def test_band_boundary_just_above_auto_threshold_is_auto() -> None:
+    """confidence=0.901 > 0.90 → AUTO band; handle called."""
+    agent, handle, _ = make_agent()
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(confidence=0.901))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert handle.call_count == 1
+
+
+async def test_band_boundary_just_below_review_floor_is_block() -> None:
+    """confidence=0.699 < 0.70 → BLOCK; handle NOT called."""
+    agent, handle, _ = make_agent()
+    outcome = await agent.get_feedback_metrics(make_metrics_intent(confidence=0.699))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "low_confidence"
+    assert handle.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 16. R-SEC: no feedback metrics values / PII in any lineage record field
+# ---------------------------------------------------------------------------
+
+
+async def test_rsec_no_feedback_metrics_in_lineage_record() -> None:
+    """FeedbackMetrics sentinel values MUST NOT appear in any AgentDecisionRecord field.
+
+    FeedbackMetrics rides on AgentOutcome.result ONLY (R-SEC-NEW-01, ADR-021).
+    """
+    sentinel_nps = 45.0
+    sentinel_csat = 4.2
+    metrics = FeedbackMetrics(
+        period_days=30,
+        total_responses=100,
+        avg_csat=sentinel_csat,
+        avg_nps=7.5,
+        nps_promoters=60,
+        nps_detractors=15,
+        nps_passives=25,
+        nps_score=sentinel_nps,
+        by_category={"PAYMENT": 4.5},
+    )
+    h = FakeFeedbackHandle(metrics=metrics)
+    agent, _, recorder = make_agent(handle=h)
+
+    outcome = await agent.get_feedback_metrics(make_metrics_intent())
+
+    # FeedbackMetrics rides on outcome.result — confirmed it's there.
+    assert isinstance(outcome.result, FeedbackMetrics)
+    assert outcome.result.nps_score == sentinel_nps  # type: ignore[union-attr]
+
+    rec = recorder.records[0]
+    nps_str = str(sentinel_nps)
+    csat_str = str(sentinel_csat)
+    # No raw metric value in any record string field.
+    assert nps_str not in rec.triggering_event
+    assert nps_str not in rec.intent
+    assert nps_str not in rec.reasoning_summary
+    assert nps_str not in rec.action_taken
+    assert all(nps_str not in p for p in rec.policies_evaluated)
+    assert csat_str not in rec.triggering_event
+    assert csat_str not in rec.reasoning_summary
+
+
+async def test_rsec_no_pii_in_triggering_event() -> None:
+    """triggering_event uses opaque handles only — no customer data or feedback text."""
+    agent, _, recorder = make_agent()
+    intent = GetFeedbackMetricsIntent(
+        intent_text="Q2 NPS review for premium cohort",
+        process_ref=_ref(),
+        correlation_id="pii-test",
+        confidence_score=0.95,
+        request_cost=_cost(),
+        period_days=30,
+        survey_id="SRV-OPAQUE-001",
+        cohort="premium",
+    )
+    await agent.get_feedback_metrics(intent)
+
+    rec = recorder.records[0]
+    # triggering_event contains opaque labels only.
+    assert "SRV-OPAQUE-001" in rec.triggering_event
+    assert "premium" in rec.triggering_event
+    # No raw PII patterns — no customer_id, no feedback_text content.
+    assert "customer" not in rec.triggering_event.lower()
+    assert "feedback_text" not in rec.triggering_event
+
+
+# ---------------------------------------------------------------------------
+# 17. ADR-046 lineage-per-action: exactly 1 record per call on every exit path
+# ---------------------------------------------------------------------------
+
+
+async def test_exactly_one_record_per_action_every_exit_path() -> None:
+    """Every action call (succeed or halt) emits exactly 1 record; total increments by 1."""
+    agent, _, recorder = make_agent()
+
+    assert len(recorder.records) == 0
+    await agent.get_feedback_metrics(make_metrics_intent())  # AUTO success
+    assert len(recorder.records) == 1
+
+    await agent.get_feedback_metrics(make_metrics_intent(resolved=False))  # HALT_UNRESOLVED
+    assert len(recorder.records) == 2
+
+    await agent.get_feedback_metrics(make_metrics_intent(confidence=0.80))  # HALT_REVIEW_DEFERRED
+    assert len(recorder.records) == 3
+
+    await agent.get_feedback_metrics(make_metrics_intent(confidence=0.50))  # BLOCK_LOW_CONFIDENCE
+    assert len(recorder.records) == 4
+
+    await agent.get_feedback_metrics(
+        make_metrics_intent(), compliance_result=ComplianceResult.FAIL
+    )  # HALT_COMPLIANCE_BLOCK
+    assert len(recorder.records) == 5
+
+
+# ---------------------------------------------------------------------------
+# 18. Window accumulates only on successful reads
+# ---------------------------------------------------------------------------
+
+
+async def test_window_accumulates_on_successful_read() -> None:
+    """Window.used_tokens / used_cost increment per successful handle call."""
+    window = CostWindow(window_ref="nps_agent:test")
+    agent, _, _ = make_agent(window=window)
+
+    assert window.used_tokens == 0
+    assert window.used_cost == Decimal("0")
+
+    await agent.get_feedback_metrics(make_metrics_intent(tokens=50, cost="0.05"))
+    assert window.used_tokens == 50
+    assert window.used_cost == Decimal("0.05")
+
+    await agent.get_feedback_metrics(make_metrics_intent(tokens=20, cost="0.02"))
+    assert window.used_tokens == 70
+    assert window.used_cost == Decimal("0.07")
+
+
+async def test_window_not_accumulated_on_halt() -> None:
+    """A halted call MUST NOT advance the window."""
+    window = CostWindow(window_ref="nps_agent:test")
+    agent, _, _ = make_agent(window=window)
+
+    await agent.get_feedback_metrics(make_metrics_intent(resolved=False))
+    assert window.used_tokens == 0
+    assert window.used_cost == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# 19. Default window_ref is set from mask.agent_id
+# ---------------------------------------------------------------------------
+
+
+async def test_default_window_ref_uses_agent_id() -> None:
+    """When no cost_window is injected, window_ref defaults to '{agent_id}:default'."""
+    agent, _, _ = make_agent()
+    assert agent._window.window_ref == "nps_agent:default"
+
+
+# ---------------------------------------------------------------------------
+# 20. INVARIANT: default mask scope is ONLY get_metrics (no submit_csat)
+# ---------------------------------------------------------------------------
+
+
+async def test_invariant_scope_contains_only_get_metrics() -> None:
+    """Default mask scope MUST NOT contain submit_csat or any write op.
+
+    INVARIANT (L1 read-only): NPSAgent is reporting only. The scope allow-list
+    enforces this — any off-list op is REJECT_OUT_OF_SCOPE.
+    """
+    mask = make_mask()
+    scope_str = " ".join(mask.scope).lower()
+
+    assert "submit_csat" not in scope_str
+    assert "submit" not in scope_str
+    assert "write" not in scope_str
+
+    # Exactly one op in scope: get_metrics.
+    assert mask.scope == ("FeedbackAnalyticsAgent.get_metrics",)
+    assert len(mask.scope) == 1
+
+
+# ---------------------------------------------------------------------------
+# 21. ComplianceResult.NA passes through (L1-Auto gate)
+# ---------------------------------------------------------------------------
+
+
+async def test_compliance_na_passes_through() -> None:
+    """ComplianceResult.NA is treated as non-blocking at the compliance gate."""
+    agent, handle, recorder = make_agent()
+    outcome = await agent.get_feedback_metrics(
+        make_metrics_intent(),
+        compliance_result=ComplianceResult.NA,
+    )
+
+    assert outcome.executed is True
+    assert outcome.halt_reason is None
+    assert handle.call_count == 1
+    assert len(recorder.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# 22. handle.get_metrics receives the correct period_days
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_receives_correct_period_days() -> None:
+    """period_days from intent is forwarded to handle.get_metrics."""
+    agent, handle, _ = make_agent()
+    await agent.get_feedback_metrics(make_metrics_intent(period_days=90))
+
+    assert handle.last_period_days == 90


### PR DESCRIPTION
## Front-Office NPSAgent — sprint-53 (MASK_ONLY, LAST of audit Tier-2)

ORG §2.8 Front Office `NPSAgent` (L1 Auto) as a thin §D2 mask over the EXISTING `services/support/` feedback domain (per IL-176 audit). Delegates to `FeedbackAnalyticsAgent.get_metrics` (NPS + CSAT aggregate) via an injected handle `Protocol` — **NO domain rewrite, NO new port**. Distinct from the existing `FeedbackAnalyticsAgent` domain agent (§2.8.1).

- Action: `get_feedback_metrics` (AUTO read). Full ADR-049 §D2 chain + one ADR-046 record/action; handle + DecisionRecorder injected. Domain `ValueError` → emit(executed=False)+reraise. Compliance non-PASS → escalate→CRO.
- **L1 read-only invariant (tested):** mask scope = the read op only; the write `submit_csat` is out-of-scope and refused.
- **R-SEC:** only opaque handles (survey_id/cohort/period_days) in lineage — never raw customer feedback text / CSAT comments / PII (support is a RED trust zone); the FeedbackMetrics aggregate rides on `AgentOutcome.result`.

**Files (2, scope-locked):** `services/agents/nps_agent.py`, `tests/agents/test_nps_agent.py`. **support domain untouched.**

**Gates:** ruff check ✅ · format --check ✅ · semgrep ✅ · pytest **29 tests, 100% coverage** on the mask ✅ · full suite **10810 passed / 0 failed** ✅

Completes audit Tier-2 (MASK_ONLY) — all 4 agents. Paired banxe-architecture PR (ORG §2.8 + IL-183). PR-only — no merge.