### PR TITLE
feat(churn): ChurnPredictionAgent + ChurnSignalPort (Tier-3 BUILD, L1 read-only) [IL-189]

### DIFF
--- a/services/agents/churn_prediction_agent.py
+++ b/services/agents/churn_prediction_agent.py
@@ -1,0 +1,531 @@
+"""ChurnPredictionAgent — L1-Auto Customer-Operations churn / at-risk detection agent
+(ORG-STRUCTURE §2.6.3, IL-188).
+
+WHY: ORG-STRUCTURE §2.6.3 (Customer Operations) defines ``ChurnPredictionAgent`` (L1 Auto,
+"At-risk customer alerts") as the governed surface through which a resolved churn-read
+intent becomes a bounded ChurnSignalPort read action. This module implements the agent
+*logic* and *governance enforcement* of the churn mask in front of the ChurnSignalPort
+CONTRACT. It is the sibling of ``services/agents/data_quality_agent.py`` and
+``services/agents/risk_oversight_agent.py`` (the L1-Auto read-only pattern).
+
+The agent DETECTS and REPORTS at-risk customers (derived, read-only, from the existing
+``services/customer_lifecycle/`` customer-state domain BEHIND the port). It operates
+READ-ONLY: it NEVER modifies customer state, NEVER triggers a retention campaign or
+action, NEVER writes to the lifecycle FSM, and NEVER makes an autonomous decision.
+
+INVARIANT (CRITICAL — enforced in code):
+    ChurnPredictionAgent is detection/reporting only. It MUST NEVER modify customer state
+    or trigger retention actions autonomously. Enforced by three independent mechanisms:
+      (1) the mask scope allow-list contains ONLY the 2 read ops:
+          get_at_risk_customers, get_churn_signals;
+      (2) ChurnSignalPort has NO mutate / trigger / retention / write method — calling one
+          would require a method that does not exist on the port;
+      (3) every ``success_action`` in this module is a DETECT/REPORT verb
+          (REPORT_AT_RISK, DETECT_CHURN_SIGNALS) — the strings RETENTION, TRIGGER, WRITE,
+          UPDATE, SUSPEND do not appear as success actions.
+
+    I-27 (CLAUDE.md): this agent PROPOSES alerts only; it never applies a retention action
+    or customer-state change autonomously (out-of-scope ops are refused).
+
+GOVERNANCE (ADR-049 §D2 gate-chain, fixed order):
+    process_ref → scope → band → cost_cap → compliance(PII) → port call
+
+* ``scope``              — ChurnSignalPort READ ops only (allow-list:
+                           get_at_risk_customers / get_churn_signals). Off-list ops
+                           (any retention / write / state-change op) are refused outright.
+* ``autonomy_level``     — L1-Auto: every read is AUTO-eligible within cap. NO REVIEW HITL
+                           hold, NO biometric step-up. A read below the AUTO band halts for
+                           a re-check (HALT_REVIEW_DEFERRED, requires_hitl=True).
+* ``confirmation_policy``— AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70 (ADR-047).
+                           REVIEW band → HALT_REVIEW_DEFERRED.
+* ``cost_cap``           — per-request AND per-window hard caps in both token and monetary
+                           (Decimal) dimensions (ADR-047 §D2).
+* ``lineage_obligation`` — one ``AgentDecisionRecord`` per action on every exit path
+                           (ADR-046), non-optional.
+* ``compliance_gate``    — PII overlay (ADR-016): the L3 check MUST PASS before a port call;
+                           a non-PASS verdict halts (BLOCK) and escalates to the DPO
+                           (config-as-data on the mask).
+
+Any one of {unresolved process_ref, out-of-scope op, below-band confidence, cost-cap breach,
+compliance(PII) fail} halts the action (ADR-049 §D4). The port's own validation is
+defense-in-depth: if the port raises ChurnSignalPortError, lineage is emitted
+(executed=False) and the error is re-raised. Mask values are config-as-data, carried on
+:class:`ChurnPredictionMask`.
+
+R-SEC (R-SEC-NEW-01, ADR-021): no raw risk score, signal weight, or PII ever enters a
+lineage record. triggering_event is keyed on opaque handles ONLY (cohort / customer_id) —
+never risk scores or signal values. The port's return value (list[AtRiskCustomer] /
+ChurnSignalSet) rides on ``AgentOutcome.result`` ONLY — NEVER on the recorded
+``AgentDecisionRecord``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.churn.churn_signal_port import ChurnSignalPort, ChurnSignalPortError
+
+# ---------------------------------------------------------------------------
+# Mask (config-as-data)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChurnPredictionMask:
+    """Config-as-data Customer-Operations churn-prediction (ORG-STRUCTURE §2.6.3) mask.
+
+    All gate values are governed config, not hardcoded flow logic. The AUTO/REVIEW/BLOCK
+    scale is ADR-047 canon. The scope is the exclusive read-only allow-list — no retention /
+    trigger / write / state-change op is present (INVARIANT: see module docstring).
+    """
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    lineage_obligation: bool = True
+    agent_id: str = "churn_prediction_agent"
+    # The mask scope (allow-list): ONLY the 2 ChurnSignalPort READ ops.
+    # INVARIANT: no retention / trigger / write / update op is present in this tuple.
+    # Any attempt to call one is REJECT_OUT_OF_SCOPE.
+    scope: tuple[str, ...] = (
+        "ChurnSignalPort.get_at_risk_customers",
+        "ChurnSignalPort.get_churn_signals",
+    )
+    # L3 compliance contour required before any port call: PII overlay (ADR-016).
+    compliance_gate: tuple[str, ...] = ("PII",)
+    # Escalation role for a compliance non-PASS verdict (config-as-data).
+    dpo_role: str = "DPO"
+
+
+# ---------------------------------------------------------------------------
+# Intent vocabulary
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AtRiskScanIntent:
+    """A resolved at-risk scan intent (``ChurnSignalPort.get_at_risk_customers``) — the
+    primary churn alert read op (ORG §2.6.3). Returns the at-risk customers at or above a
+    risk ``threshold`` for a cohort. A read below the AUTO band halts for a re-check, not a
+    HITL hold. The PII overlay MUST PASS; a non-PASS verdict blocks and escalates to the DPO.
+    The list[AtRiskCustomer] rides on ``AgentOutcome.result`` ONLY (R-SEC)."""
+
+    cohort: str
+    threshold: Decimal
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class ChurnSignalsIntent:
+    """A resolved per-customer churn-signal read intent (``ChurnSignalPort.get_churn_signals``)
+    — the derived signals for one customer (ORG §2.6.3). A read below the AUTO band halts for
+    a re-check. The PII overlay MUST PASS; non-PASS escalates to the DPO. The ChurnSignalSet
+    rides on ``AgentOutcome.result`` ONLY (R-SEC)."""
+
+    customer_id: str
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    """All inputs a single masked churn action evaluates against."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class ChurnPredictionAgent:
+    """L1-Auto Customer-Operations churn / at-risk detection agent enforcing the
+    ADR-049 §D2 gate chain.
+
+    The :class:`~services.churn.churn_signal_port.ChurnSignalPort` and the lineage recorder
+    are injected as interfaces (constructor injection); the agent contains pure governance
+    logic and is unit-testable without any live infra.
+
+    INVARIANT: DETECTION/REPORTING ONLY. This agent MUST NEVER modify customer state or
+    trigger retention actions. See module docstring for the three independent enforcement
+    mechanisms. I-27: PROPOSES alerts only, never applies autonomously.
+    """
+
+    def __init__(
+        self,
+        *,
+        churn_signal_port: ChurnSignalPort,
+        recorder: DecisionRecorder,
+        mask: ChurnPredictionMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._port = churn_signal_port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def report_at_risk_customers(
+        self,
+        intent: AtRiskScanIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """At-risk scan via ``ChurnSignalPort.get_at_risk_customers`` (ORG §2.6.3).
+
+        AUTO-eligible within cap. The PII overlay (``compliance_result``) MUST PASS; a
+        non-PASS verdict blocks and escalates to the DPO. A read below the AUTO band halts
+        for a re-check (L1-Auto). The list[AtRiskCustomer] rides on ``AgentOutcome.result``
+        ONLY (R-SEC — no risk score in lineage; triggering_event keyed on the opaque cohort)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_at_risk_customers:{intent.cohort}",
+            success_action="REPORT_AT_RISK",
+            op="ChurnSignalPort.get_at_risk_customers",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(
+            ctx, lambda: self._port.get_at_risk_customers(intent.threshold)
+        )
+
+    async def get_churn_signals(
+        self,
+        intent: ChurnSignalsIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Per-customer churn-signal read via ``ChurnSignalPort.get_churn_signals`` (ORG §2.6.3).
+
+        AUTO-eligible within cap. The PII overlay MUST PASS; non-PASS blocks and escalates to
+        the DPO. A read below the AUTO band halts for a re-check (L1-Auto). The ChurnSignalSet
+        rides on ``AgentOutcome.result`` ONLY (R-SEC — no risk score or signal weight in
+        lineage; triggering_event keyed on the opaque customer_id)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_churn_signals:{intent.customer_id}",
+            success_action="DETECT_CHURN_SIGNALS",
+            op="ChurnSignalPort.get_churn_signals",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_churn_signals(intent.customer_id))
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be in [0.0, 1.0]")
+        policies = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no port call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. Scope allow-list — an off-list op (any retention / write / state-change) is
+        #    refused outright. INVARIANT: the mask scope has read ops only.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op} is not on the churn mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band. REVIEW → HALT_REVIEW_DEFERRED: reads are AUTO-only
+        #    (L1-Auto); there is no HITL hold path in this agent.
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+        if band is ConfirmationDecision.REVIEW:
+            return _Evaluation(
+                band,
+                False,
+                "HALT_REVIEW_DEFERRED",
+                "Read intent below AUTO band; reads are AUTO-only, no HITL hold (L1-Auto).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="review_deferred",
+                requires_hitl=True,
+            )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window tokens/cost); action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. PII compliance gate (ADR-016). A non-PASS verdict halts AND escalates to the DPO.
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            escalated = self._mask.dpo_role
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"PII overlay returned {ctx.compliance_result}; "
+                f"action blocked and escalated to {escalated}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=escalated,
+            )
+
+        # All gates satisfied — clear to commit the read.
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All churn mask gates satisfied at {band.value} confidence; committing within scope.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except ChurnSignalPortError as exc:
+                    # Defense-in-depth: the port's own read guard fired. Emit one lineage
+                    # record (executed=False) then re-raise — no raw risk score, signal
+                    # weight, or PII recorded.
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=ev.compliance_result,
+                        reasoning=f"Port rejected the action: {exc}",
+                        escalated_to=ev.escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        return await self._record(
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies=ev.policies,
+            compliance_result=compliance_result,
+            reasoning=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            correlation_id=ctx.correlation_id,
+            request_cost=ctx.request_cost,
+            budget_breach=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+
+    async def _record(
+        self,
+        *,
+        triggering_event: str,
+        intent: str,
+        policies: list[str],
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        confidence_score: float,
+        action_taken: str,
+        correlation_id: str,
+        request_cost: RequestCost,
+        budget_breach: BudgetBreach,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        """Build, persist, and return exactly one ADR-046 lineage record (the single
+        producer→sink seam used by every exit path). R-SEC: triggering_event uses opaque
+        cohort / customer_id labels only — never risk scores, signal weights, or PII. Port
+        return values ride on AgentOutcome.result, never on this record."""
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=triggering_event,
+            intent=intent,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=None,
+            correlation_id=correlation_id,
+            cost_tokens=request_cost.tokens,
+            cost_amount=request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "AtRiskScanIntent",
+    "BudgetBreach",
+    "ChurnPredictionAgent",
+    "ChurnPredictionMask",
+    "ChurnSignalPortError",
+    "ChurnSignalsIntent",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "ProcessRef",
+    "RequestCost",
+]

--- a/services/churn/__init__.py
+++ b/services/churn/__init__.py
@@ -1,0 +1,1 @@
+# services/churn — Customer-Operations churn detection domain (ORG §2.6.3, IL-188).

--- a/services/churn/churn_signal_port.py
+++ b/services/churn/churn_signal_port.py
@@ -1,0 +1,326 @@
+"""services/churn/churn_signal_port.py — ChurnSignalPort: governed READ-ONLY
+at-risk / churn-signal CONTRACT (ORG §2.6.3, IL-188 ChurnPredictionAgent).
+
+EXPLICIT BOUNDARY: READ ONLY — detection and reporting of churn / at-risk signals
+only. This port does NOT mutate customer state, trigger retention campaigns, write
+to the lifecycle FSM, or train any model. There are NO mutate / trigger / write
+methods on this port at all (I-10: no fake integrations, I-27: no autonomous
+customer-state changes or retention actions).
+
+WHY: ORG §2.6.3 (Customer Operations) defines ``ChurnPredictionAgent`` (L1 Auto, at-risk
+customer alerts) as the governed surface through which Customer Operations reads at-risk
+signals. The ChurnSignalPort is the CONTRACT boundary the ChurnPredictionAgent mask
+``scope`` allow-lists (ADR-049 §D1). The read-only constraint is an invariant: the port
+has no mutating methods, so the agent cannot accidentally call one.
+
+DERIVED FROM THE LIFECYCLE DOMAIN (NOT a new ML model):
+The at-risk signals are DERIVED, read-only, from the existing customer-state domain
+``services/customer_lifecycle/`` (``CustomerState`` — e.g. DORMANT / SUSPENDED — and the
+append-only transition history). :class:`ChurnSignalCode` mirrors those state-derived
+signals (DORMANCY, SUSPENSION, INACTIVITY, REACTIVATION_LAPSE). This port is the CONTRACT
+boundary only; any production adapter reads the lifecycle domain BEHIND this port and
+MUST NOT modify it (a later sprint, like the analytics adapter). This file authors no such
+adapter and touches no customer_lifecycle logic — it ships the contract + an in-memory
+double for unit tests.
+
+Governance contract (ADR-049 §D1 — canonical):
+  reads: get_at_risk_customers, get_churn_signals
+
+PII / R-SEC (R-SEC-NEW-01, ADR-021):
+  All value types carry only opaque handles (``customer_id`` / ``cohort``) and aggregate
+  signals. No method accepts or returns raw PII (no name / email / IBAN / address).
+  ``customer_id`` is an opaque handle, never a personal reference.
+
+I-01 (CLAUDE.md): every numeric field (risk_score, signal weight) is Decimal, never float.
+"""
+
+from __future__ import annotations
+
+import abc
+from abc import abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import StrEnum
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+# Opaque customer / cohort handles. NEVER raw PII (no name / email / IBAN / address).
+CustomerId = str
+Cohort = str
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class RiskBand(StrEnum):
+    """Coarse at-risk band for a customer (derived from the aggregate risk_score)."""
+
+    LOW = "LOW"
+    ELEVATED = "ELEVATED"
+    HIGH = "HIGH"
+
+
+class ChurnSignalCode(StrEnum):
+    """A state-derived churn signal. Mirrors the customer_lifecycle ``CustomerState``
+    signals the production adapter reads BEHIND this port (read-only derivation):
+
+      DORMANCY           — customer is in ``CustomerState.DORMANT``.
+      SUSPENSION         — customer is in ``CustomerState.SUSPENDED``.
+      INACTIVITY         — approaching the dormancy inactivity window (no transition).
+      REACTIVATION_LAPSE — reactivated then lapsed back toward dormancy.
+    """
+
+    DORMANCY = "DORMANCY"
+    SUSPENSION = "SUSPENSION"
+    INACTIVITY = "INACTIVITY"
+    REACTIVATION_LAPSE = "REACTIVATION_LAPSE"
+
+
+# ---------------------------------------------------------------------------
+# Value types (frozen=True — immutable after construction, I-01 Decimal)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChurnSignal:
+    """A single derived churn signal contributing to a customer's risk (READ-ONLY).
+
+    I-01: ``weight`` is Decimal, never float.
+
+    Required fields:
+      code   — the state-derived signal code.
+      weight — contribution of this signal to the aggregate risk_score, Decimal [0.0, 1.0].
+
+    Optional fields:
+      detail — short opaque, non-PII note (e.g. "dormant 120d"); defaults to "".
+    """
+
+    code: ChurnSignalCode
+    weight: Decimal
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class AtRiskCustomer:
+    """An at-risk customer entry in an at-risk scan result (READ-ONLY).
+
+    I-01: ``risk_score`` is Decimal, never float. R-SEC: ``customer_id`` / ``cohort``
+    are opaque handles only — never raw PII.
+
+    Required fields:
+      customer_id — opaque customer handle (no raw PII).
+      cohort      — opaque cohort label the customer belongs to (no raw PII).
+      risk_score  — aggregate churn risk as Decimal [0.0, 1.0].
+      band        — coarse risk band derived from risk_score.
+    """
+
+    customer_id: CustomerId
+    cohort: Cohort
+    risk_score: Decimal
+    band: RiskBand
+
+
+@dataclass(frozen=True)
+class ChurnSignalSet:
+    """The full set of derived churn signals for one customer (READ-ONLY).
+
+    I-01: ``risk_score`` and every signal weight are Decimal, never float.
+
+    Required fields:
+      customer_id — opaque customer handle (no raw PII).
+      cohort      — opaque cohort label (no raw PII).
+      risk_score  — aggregate churn risk as Decimal [0.0, 1.0].
+      band        — coarse risk band derived from risk_score.
+
+    Optional fields:
+      signals     — the individual derived signals; defaults to empty.
+    """
+
+    customer_id: CustomerId
+    cohort: Cohort
+    risk_score: Decimal
+    band: RiskBand
+    signals: tuple[ChurnSignal, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class ChurnSignalPortError(Exception):
+    """Base error for ChurnSignalPort read failures.
+
+    Adapters raise this (or a subclass) when a churn-signal fetch fails.
+    ChurnPredictionAgent catches it, emits one lineage record (executed=False),
+    then re-raises — defense-in-depth (ADR-046 / ADR-027).
+    """
+
+
+class CustomerNotFound(ChurnSignalPortError):
+    """The requested ``customer_id`` has no derived churn signals (unknown handle)."""
+
+
+# ---------------------------------------------------------------------------
+# Abstract port (READ-ONLY CONTRACT)
+# ---------------------------------------------------------------------------
+
+
+class ChurnSignalPort(abc.ABC):
+    """Abstract CONTRACT for governed READ-ONLY at-risk / churn-signal reads (ORG §2.6.3).
+
+    INVARIANT: Every method on this port is a pure read. There are NO methods for
+    triggering retention campaigns, writing customer state, or mutating any state.
+    The absence of mutating methods is the primary enforcement mechanism for the
+    ChurnPredictionAgent read-only invariant (I-27).
+
+    Conformance rules:
+      Read-only: NO operation mutates state, triggers retention, or changes the
+      customer lifecycle. The two reads MUST NOT trigger any state change.
+
+      I-01: every numeric field (risk_score, weight) is Decimal, never float.
+
+      R-SEC: only opaque handles (customer_id / cohort) cross this boundary — no raw PII.
+    """
+
+    @abstractmethod
+    async def get_at_risk_customers(self, threshold: Decimal) -> list[AtRiskCustomer]:
+        """Return the at-risk customers whose risk_score >= ``threshold`` (read-only).
+
+        Read-only; MUST NOT trigger any state change or retention action. I-01:
+        ``threshold`` and every returned risk_score are Decimal.
+
+        Args:
+            threshold: minimum aggregate risk_score to include, Decimal [0.0, 1.0].
+
+        Returns:
+            A list of AtRiskCustomer (possibly empty), highest risk first.
+
+        Raises:
+            ChurnSignalPortError: if the threshold is out of range or the read fails.
+        """
+        ...  # pragma: no cover
+
+    @abstractmethod
+    async def get_churn_signals(self, customer_id: CustomerId) -> ChurnSignalSet:
+        """Return the derived churn signals for one customer (read-only).
+
+        Read-only; MUST NOT trigger any state change or retention action.
+
+        Args:
+            customer_id: opaque customer handle to read signals for (no raw PII).
+
+        Returns:
+            The ChurnSignalSet for the customer.
+
+        Raises:
+            CustomerNotFound: ``customer_id`` has no derived signals (unknown handle).
+            ChurnSignalPortError: if the read otherwise fails.
+        """
+        ...  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# InMemory implementation (for unit tests)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryChurnSignalPort(ChurnSignalPort):
+    """Configurable in-memory stub for unit tests.
+
+    Seed data is provided at construction time. Pass ``fail_on_call=True`` to make
+    every method raise :class:`ChurnSignalPortError` — exercises the agent
+    HALT_PROVIDER_ERROR branch. Raises :class:`CustomerNotFound` for unknown customers
+    and :class:`ChurnSignalPortError` for an out-of-range threshold. READ-ONLY: there is
+    no method to mutate state or trigger retention.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_on_call: bool = False,
+        signals: Mapping[CustomerId, ChurnSignalSet] | None = None,
+    ) -> None:
+        self._fail = fail_on_call
+        self._signals: dict[CustomerId, ChurnSignalSet] = dict(
+            signals
+            if signals is not None
+            else {
+                "cust-1001": ChurnSignalSet(
+                    customer_id="cust-1001",
+                    cohort="retail-eu",
+                    risk_score=Decimal("0.82"),
+                    band=RiskBand.HIGH,
+                    signals=(
+                        ChurnSignal(
+                            code=ChurnSignalCode.DORMANCY,
+                            weight=Decimal("0.60"),
+                            detail="dormant 120d",
+                        ),
+                        ChurnSignal(
+                            code=ChurnSignalCode.INACTIVITY,
+                            weight=Decimal("0.22"),
+                            detail="no transition 90d",
+                        ),
+                    ),
+                ),
+                "cust-1002": ChurnSignalSet(
+                    customer_id="cust-1002",
+                    cohort="retail-eu",
+                    risk_score=Decimal("0.30"),
+                    band=RiskBand.ELEVATED,
+                    signals=(
+                        ChurnSignal(
+                            code=ChurnSignalCode.REACTIVATION_LAPSE,
+                            weight=Decimal("0.30"),
+                            detail="re-lapsed after reactivate",
+                        ),
+                    ),
+                ),
+            }
+        )
+
+    def _check_fail(self) -> None:
+        if self._fail:
+            raise ChurnSignalPortError("InMemoryChurnSignalPort configured to fail")
+
+    async def get_at_risk_customers(self, threshold: Decimal) -> list[AtRiskCustomer]:
+        self._check_fail()
+        if not Decimal("0") <= threshold <= Decimal("1"):
+            raise ChurnSignalPortError(f"threshold out of range: {threshold!r}")
+        at_risk = [
+            AtRiskCustomer(
+                customer_id=s.customer_id,
+                cohort=s.cohort,
+                risk_score=s.risk_score,
+                band=s.band,
+            )
+            for s in self._signals.values()
+            if s.risk_score >= threshold
+        ]
+        return sorted(at_risk, key=lambda c: c.risk_score, reverse=True)
+
+    async def get_churn_signals(self, customer_id: CustomerId) -> ChurnSignalSet:
+        self._check_fail()
+        if customer_id not in self._signals:
+            raise CustomerNotFound(f"Unknown customer: {customer_id!r}")
+        return self._signals[customer_id]
+
+
+__all__ = [
+    "AtRiskCustomer",
+    "ChurnSignal",
+    "ChurnSignalCode",
+    "ChurnSignalPort",
+    "ChurnSignalPortError",
+    "ChurnSignalSet",
+    "Cohort",
+    "CustomerId",
+    "CustomerNotFound",
+    "InMemoryChurnSignalPort",
+    "RiskBand",
+]

--- a/tests/agents/test_churn_prediction_agent.py
+++ b/tests/agents/test_churn_prediction_agent.py
@@ -1,0 +1,602 @@
+"""ChurnPredictionAgent test suite — 100% coverage over
+services/agents/churn_prediction_agent.py.
+
+Validates: ADR-049 §D2 gate-chain branches (process-ref resolution, scope allow-list,
+confidence band, cost-cap per-request and per-window, PII compliance gate, successful port
+call, port ChurnSignalPortError path), ADR-046 lineage invariants (one record per action on
+every exit path), R-SEC-NEW-01 (no raw risk score / signal weight / PII in any lineage
+record — result rides on AgentOutcome.result only), and the DETECTION/REPORTING INVARIANT
+(mask scope has no retention / trigger / write op; the agent never mutates customer state;
+all success_actions use DETECT_ or REPORT_ prefix).
+
+asyncio_mode = "auto" (pyproject.toml): every ``async def test_*`` is auto-collected
+without @pytest.mark.asyncio.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.agents.churn_prediction_agent import (
+    AtRiskScanIntent,
+    ChurnPredictionAgent,
+    ChurnPredictionMask,
+    ChurnSignalsIntent,
+)
+from services.churn.churn_signal_port import (
+    AtRiskCustomer,
+    ChurnSignal,
+    ChurnSignalCode,
+    ChurnSignalPortError,
+    ChurnSignalSet,
+    InMemoryChurnSignalPort,
+    RiskBand,
+)
+
+# ---------------------------------------------------------------------------
+# In-test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeRecorder(DecisionRecorder):
+    """In-memory DecisionRecorder that collects records for assertion."""
+
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CAP = CostCap(
+    max_request_tokens=1_000,
+    max_request_cost=Decimal("1.00"),
+    max_window_tokens=10_000,
+    max_window_cost=Decimal("10.00"),
+)
+
+
+def make_mask(**overrides: object) -> ChurnPredictionMask:
+    base: dict[str, object] = {"cost_cap": _DEFAULT_CAP}
+    base.update(overrides)
+    return ChurnPredictionMask(**base)  # type: ignore[arg-type]
+
+
+def make_agent(
+    mask: ChurnPredictionMask | None = None,
+    port: InMemoryChurnSignalPort | None = None,
+    recorder: FakeRecorder | None = None,
+    window: CostWindow | None = None,
+) -> tuple[ChurnPredictionAgent, InMemoryChurnSignalPort, FakeRecorder]:
+    p = port or InMemoryChurnSignalPort()
+    r = recorder or FakeRecorder()
+    m = mask or make_mask()
+    return ChurnPredictionAgent(churn_signal_port=p, recorder=r, mask=m, cost_window=window), p, r
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    pid = "proc-churn-001" if resolved else ""
+    return ProcessRef(process_id=pid, version="1.0")
+
+
+def _cost(tokens: int = 10, cost: str = "0.01") -> RequestCost:
+    return RequestCost(tokens=tokens, cost=Decimal(cost))
+
+
+def make_scan_intent(
+    *,
+    cohort: str = "retail-eu",
+    threshold: str = "0.50",
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> AtRiskScanIntent:
+    return AtRiskScanIntent(
+        cohort=cohort,
+        threshold=Decimal(threshold),
+        intent_text="report at-risk customers for retail-eu cohort",
+        process_ref=_ref(resolved),
+        correlation_id="corr-scan-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+def make_signals_intent(
+    *,
+    customer_id: str = "cust-1001",
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> ChurnSignalsIntent:
+    return ChurnSignalsIntent(
+        customer_id=customer_id,
+        intent_text="detect churn signals for a customer",
+        process_ref=_ref(resolved),
+        correlation_id="corr-signals-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1-2. AUTO happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_report_at_risk_auto_read_executes() -> None:
+    """Confidence 0.95 > 0.90 → AUTO band; port called; exactly one lineage record."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_at_risk_customers(make_scan_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.halt_reason is None
+    assert outcome.requires_hitl is False
+    assert outcome.escalated_to is None
+    assert isinstance(outcome.result, list)
+    assert all(isinstance(c, AtRiskCustomer) for c in outcome.result)
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.action_taken == "REPORT_AT_RISK"
+    assert rec.agent_id == "churn_prediction_agent"
+    assert rec.compliance_result is ComplianceResult.PASS
+    assert rec.budget_breach_flag is BudgetBreach.NONE
+    assert rec.triggering_event == "get_at_risk_customers:retail-eu"
+    assert outcome.record is rec
+
+
+async def test_get_churn_signals_auto_read_executes() -> None:
+    """Confidence 0.95 → AUTO; port called; result is ChurnSignalSet."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_churn_signals(make_signals_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, ChurnSignalSet)
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "DETECT_CHURN_SIGNALS"
+    assert recorder.records[0].triggering_event == "get_churn_signals:cust-1001"
+
+
+# ---------------------------------------------------------------------------
+# 3. Unresolved process_ref → HALT_UNRESOLVED_PROCESS
+# ---------------------------------------------------------------------------
+
+
+async def test_unresolved_process_ref_blocks() -> None:
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_at_risk_customers(make_scan_intent(resolved=False))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert outcome.requires_hitl is True
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+# ---------------------------------------------------------------------------
+# 4. Out-of-scope op → REJECT_OUT_OF_SCOPE (retention-trigger op refused)
+# ---------------------------------------------------------------------------
+
+
+async def test_out_of_scope_retention_trigger_refused() -> None:
+    """Scope restricted to a retention-trigger (mutate) op; the read op is off-list → REJECT.
+
+    INVARIANT: ChurnSignalPort.trigger_retention is never in the default allow-list. When a
+    scope containing only a mutate op is configured, the read op is REJECT_OUT_OF_SCOPE —
+    demonstrating a retention/write op cannot be reached via the normal agent flow (the port
+    also has no such method).
+    """
+    scoped_mask = make_mask(scope=("ChurnSignalPort.trigger_retention",))
+    agent, port, recorder = make_agent(mask=scoped_mask)
+    outcome = await agent.report_at_risk_customers(make_scan_intent())
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "out_of_scope"
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+# ---------------------------------------------------------------------------
+# 5. Below-AUTO band (REVIEW) → HALT_REVIEW_DEFERRED, port NOT called
+# ---------------------------------------------------------------------------
+
+
+async def test_below_auto_band_read_halts_review_deferred() -> None:
+    """Confidence 0.80 is in REVIEW band (0.70–0.90); reads are AUTO-only (L1-Auto)."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_at_risk_customers(make_scan_intent(confidence=0.80))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+async def test_band_boundary_exactly_auto_threshold_is_review() -> None:
+    """confidence=0.90 is NOT > 0.90 → REVIEW band → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.report_at_risk_customers(make_scan_intent(confidence=0.90))
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+async def test_band_boundary_exactly_review_floor_is_review() -> None:
+    """confidence=0.70 is >= 0.70 → REVIEW band → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.get_churn_signals(make_signals_intent(confidence=0.70))
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+# ---------------------------------------------------------------------------
+# 6. Low confidence (<0.70) → BLOCK_LOW_CONFIDENCE
+# ---------------------------------------------------------------------------
+
+
+async def test_block_low_confidence() -> None:
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_at_risk_customers(make_scan_intent(confidence=0.50))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+# ---------------------------------------------------------------------------
+# 7. Cost-cap breaches — per-request (tokens + monetary) and per-window
+# ---------------------------------------------------------------------------
+
+
+async def test_per_request_cost_cap_tokens_breach() -> None:
+    tight_cap = CostCap(
+        max_request_tokens=5,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.report_at_risk_customers(make_scan_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+async def test_per_request_cost_cap_monetary_breach() -> None:
+    tight_cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("0.001"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.report_at_risk_customers(make_scan_intent(cost="0.10"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+async def test_per_window_token_cost_cap_breach() -> None:
+    window = CostWindow(
+        used_tokens=9990, used_cost=Decimal("0.00"), window_ref="churn_prediction_agent:test"
+    )
+    agent, _, recorder = make_agent(window=window)
+    outcome = await agent.report_at_risk_customers(make_scan_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert len(recorder.records) == 1
+
+
+async def test_per_window_monetary_cost_cap_breach() -> None:
+    window = CostWindow(
+        used_tokens=0, used_cost=Decimal("9.99"), window_ref="churn_prediction_agent:test"
+    )
+    cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=1_000_000,
+        max_window_cost=Decimal("10.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.report_at_risk_customers(make_scan_intent(tokens=1, cost="0.02"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+# ---------------------------------------------------------------------------
+# 8. PII compliance gate → HALT_COMPLIANCE_BLOCK, escalated to DPO
+# ---------------------------------------------------------------------------
+
+
+async def test_compliance_fail_blocks_escalates_to_dpo() -> None:
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_at_risk_customers(
+        make_scan_intent(), compliance_result=ComplianceResult.FAIL
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "DPO"
+    assert outcome.requires_hitl is True
+    rec = recorder.records[0]
+    assert rec.escalated_to == "DPO"
+    assert rec.action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert rec.compliance_result is ComplianceResult.FAIL
+
+
+async def test_compliance_escalate_blocks_escalates_to_dpo() -> None:
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_churn_signals(
+        make_signals_intent(), compliance_result=ComplianceResult.ESCALATE
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "DPO"
+    assert len(recorder.records) == 1
+
+
+async def test_custom_dpo_role_used() -> None:
+    agent, _, _ = make_agent(mask=make_mask(dpo_role="DataProtectionOfficer"))
+    outcome = await agent.report_at_risk_customers(
+        make_scan_intent(), compliance_result=ComplianceResult.FAIL
+    )
+    assert outcome.escalated_to == "DataProtectionOfficer"
+
+
+# ---------------------------------------------------------------------------
+# 9. Port raises ChurnSignalPortError → lineage emitted (executed=False), re-raised
+# ---------------------------------------------------------------------------
+
+
+async def test_port_error_emits_lineage_then_reraises_on_scan() -> None:
+    port = InMemoryChurnSignalPort(fail_on_call=True)
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(ChurnSignalPortError):
+        await agent.report_at_risk_customers(make_scan_intent())
+
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert "HALT_PROVIDER_ERROR" in rec.action_taken
+    assert "ChurnSignalPortError" in rec.action_taken
+
+
+async def test_port_error_emits_lineage_then_reraises_on_signals() -> None:
+    port = InMemoryChurnSignalPort(fail_on_call=True)
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(ChurnSignalPortError):
+        await agent.get_churn_signals(make_signals_intent())
+
+    assert len(recorder.records) == 1
+    assert "HALT_PROVIDER_ERROR" in recorder.records[0].action_taken
+
+
+async def test_port_customer_not_found_reraised_as_provider_error() -> None:
+    """A CustomerNotFound (ChurnSignalPortError subclass) is recorded then re-raised."""
+    port = InMemoryChurnSignalPort(signals={})
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(ChurnSignalPortError):
+        await agent.get_churn_signals(make_signals_intent(customer_id="ghost"))
+
+    assert recorder.records[0].action_taken == "HALT_PROVIDER_ERROR:CustomerNotFound"
+
+
+# ---------------------------------------------------------------------------
+# 10. Invalid confidence → ValueError, NO lineage record
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_confidence_above_range_raises_no_record() -> None:
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.report_at_risk_customers(make_scan_intent(confidence=1.1))
+    assert len(recorder.records) == 0
+
+
+async def test_invalid_confidence_below_range_raises_no_record() -> None:
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_churn_signals(make_signals_intent(confidence=-0.01))
+    assert len(recorder.records) == 0
+
+
+# ---------------------------------------------------------------------------
+# 11. R-SEC: no raw risk score / signal weight in any lineage record field
+# ---------------------------------------------------------------------------
+
+
+async def test_no_raw_risk_score_in_lineage_record() -> None:
+    """A risk-score sentinel reachable ONLY through the port result MUST NOT appear in any
+    AgentDecisionRecord field — the ChurnSignalSet rides on AgentOutcome.result only."""
+    sentinel = Decimal("0.87654321")
+    signal_set = ChurnSignalSet(
+        customer_id="cust-opaque-7",
+        cohort="retail-eu",
+        risk_score=sentinel,
+        band=RiskBand.HIGH,
+        signals=(ChurnSignal(code=ChurnSignalCode.DORMANCY, weight=Decimal("0.99119911")),),
+    )
+    port = InMemoryChurnSignalPort(signals={"cust-opaque-7": signal_set})
+    agent, _, recorder = make_agent(port=port)
+
+    outcome = await agent.get_churn_signals(make_signals_intent(customer_id="cust-opaque-7"))
+
+    # Result delivered to the caller …
+    assert isinstance(outcome.result, ChurnSignalSet)
+    assert outcome.result.risk_score == sentinel  # type: ignore[union-attr]
+
+    rec = recorder.records[0]
+    serialised = " ".join(
+        str(v)
+        for v in (
+            rec.triggering_event,
+            rec.intent,
+            rec.reasoning_summary,
+            rec.action_taken,
+            rec.correlation_id,
+            " ".join(rec.policies_evaluated),
+        )
+    )
+    assert str(sentinel) not in serialised
+    assert "0.99119911" not in serialised
+    assert rec.cost_amount != sentinel
+    # Only the opaque customer_id is keyed into the lineage event.
+    assert "cust-opaque-7" in rec.triggering_event
+
+
+# ---------------------------------------------------------------------------
+# 12. ADR-046 lineage-per-action + window accumulation
+# ---------------------------------------------------------------------------
+
+
+async def test_lineage_one_record_per_call_adr046() -> None:
+    agent, _, recorder = make_agent()
+
+    assert len(recorder.records) == 0
+    await agent.report_at_risk_customers(make_scan_intent())
+    assert len(recorder.records) == 1
+    await agent.get_churn_signals(make_signals_intent())
+    assert len(recorder.records) == 2
+    # A halted path also emits exactly 1 record.
+    await agent.report_at_risk_customers(make_scan_intent(resolved=False))
+    assert len(recorder.records) == 3
+
+
+async def test_window_accumulates_on_successful_reads() -> None:
+    window = CostWindow(window_ref="churn_prediction_agent:test")
+    agent, _, _ = make_agent(window=window)
+
+    await agent.report_at_risk_customers(make_scan_intent(tokens=50, cost="0.05"))
+    assert window.used_tokens == 50
+    assert window.used_cost == Decimal("0.05")
+
+    await agent.get_churn_signals(make_signals_intent(tokens=30, cost="0.03"))
+    assert window.used_tokens == 80
+    assert window.used_cost == Decimal("0.08")
+
+
+async def test_window_not_accumulated_on_halt() -> None:
+    window = CostWindow(window_ref="churn_prediction_agent:test")
+    agent, _, _ = make_agent(window=window)
+    await agent.report_at_risk_customers(make_scan_intent(resolved=False))
+    assert window.used_tokens == 0
+    assert window.used_cost == Decimal("0")
+
+
+async def test_default_window_ref_uses_agent_id() -> None:
+    agent, _, _ = make_agent()
+    assert agent._window.window_ref == "churn_prediction_agent:default"
+
+
+# ---------------------------------------------------------------------------
+# 13. INVARIANT: read-only — no state mutation; scope + success_actions verified
+# ---------------------------------------------------------------------------
+
+
+async def test_invariant_scope_is_detect_report_only() -> None:
+    """Default mask scope MUST contain ONLY the 2 read ops — no retention/trigger/write op."""
+    mask = make_mask()
+    scope_lower = " ".join(mask.scope).lower()
+    for forbidden in ("retention", "trigger", "write", "update", "suspend", "close"):
+        assert forbidden not in scope_lower
+    assert set(mask.scope) == {
+        "ChurnSignalPort.get_at_risk_customers",
+        "ChurnSignalPort.get_churn_signals",
+    }
+
+
+async def test_invariant_no_customer_state_mutation() -> None:
+    """A full read flow MUST NOT mutate the port's customer-state data (read-only invariant).
+
+    The agent has no mutate capability; this asserts the port snapshot is byte-identical
+    before and after a successful read, and that success_actions are DETECT/REPORT verbs only.
+    """
+    port = InMemoryChurnSignalPort()
+    before = await port.get_churn_signals("cust-1001")
+    agent, _, recorder = make_agent(port=port)
+
+    await agent.report_at_risk_customers(make_scan_intent(threshold="0"))
+    await agent.get_churn_signals(make_signals_intent(customer_id="cust-1001"))
+
+    after = await port.get_churn_signals("cust-1001")
+    assert after == before  # frozen snapshot unchanged — no mutation
+
+    actions = " ".join(r.action_taken for r in recorder.records)
+    assert all(
+        a.startswith(("DETECT_", "REPORT_")) for a in [r.action_taken for r in recorder.records]
+    )
+    for token in ("RETENTION", "TRIGGER", "WRITE", "UPDATE", "SUSPEND"):
+        assert token not in actions
+
+
+# ---------------------------------------------------------------------------
+# 14. In-memory e2e full flow (real mask, InMemoryChurnSignalPort, FakeRecorder)
+# ---------------------------------------------------------------------------
+
+
+async def test_in_memory_e2e_report_at_risk() -> None:
+    recorder = FakeRecorder()
+    mask = ChurnPredictionMask(
+        cost_cap=CostCap(
+            max_request_tokens=500,
+            max_request_cost=Decimal("0.50"),
+            max_window_tokens=50_000,
+            max_window_cost=Decimal("50.00"),
+        ),
+        agent_id="churn_prediction_agent",
+        dpo_role="DPO",
+    )
+    port = InMemoryChurnSignalPort()
+    agent = ChurnPredictionAgent(churn_signal_port=port, recorder=recorder, mask=mask)
+    intent = AtRiskScanIntent(
+        cohort="retail-eu",
+        threshold=Decimal("0.40"),
+        intent_text="CustomerOps daily at-risk scan Q2-2026",
+        process_ref=ProcessRef(process_id="proc-e2e-churn-001", version="1.0"),
+        correlation_id="e2e-corr-churn-001",
+        confidence_score=0.97,
+        request_cost=RequestCost(tokens=100, cost=Decimal("0.10")),
+    )
+    outcome = await agent.report_at_risk_customers(intent)
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, list)
+    assert outcome.result[0].risk_score == Decimal("0.82")  # highest-risk first (cust-1001)
+    assert outcome.halt_reason is None
+    rec = recorder.records[0]
+    assert rec.correlation_id == "e2e-corr-churn-001"
+    assert rec.triggering_event == "get_at_risk_customers:retail-eu"
+    assert rec.human_reviewed_by is None  # L1-Auto: never a reviewer

--- a/tests/test_churn/test_churn_signal_port.py
+++ b/tests/test_churn/test_churn_signal_port.py
@@ -1,0 +1,196 @@
+"""ChurnSignalPort contract test suite — 100% coverage over
+services/churn/churn_signal_port.py.
+
+Validates the READ-ONLY contract and the InMemoryChurnSignalPort double:
+get_at_risk_customers (threshold filter + highest-risk-first ordering + range guard),
+get_churn_signals (known / unknown → CustomerNotFound), the fail_on_call provider-error
+path, the value types (Decimal numerics, opaque handles), the error hierarchy, and the
+read-only INVARIANT (the port exposes NO mutate / trigger / retention / write method).
+
+asyncio_mode = "auto" (pyproject.toml): every ``async def test_*`` is auto-collected.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import inspect
+
+import pytest
+
+from services.churn.churn_signal_port import (
+    AtRiskCustomer,
+    ChurnSignal,
+    ChurnSignalCode,
+    ChurnSignalPort,
+    ChurnSignalPortError,
+    ChurnSignalSet,
+    CustomerNotFound,
+    InMemoryChurnSignalPort,
+    RiskBand,
+)
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _signal_set(
+    customer_id: str,
+    *,
+    cohort: str = "retail-eu",
+    risk: str = "0.50",
+    band: RiskBand = RiskBand.ELEVATED,
+) -> ChurnSignalSet:
+    return ChurnSignalSet(
+        customer_id=customer_id,
+        cohort=cohort,
+        risk_score=Decimal(risk),
+        band=band,
+        signals=(ChurnSignal(code=ChurnSignalCode.DORMANCY, weight=Decimal("0.40"), detail="d"),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. get_at_risk_customers — threshold filter + ordering
+# ---------------------------------------------------------------------------
+
+
+async def test_at_risk_filters_by_threshold_and_orders_high_first() -> None:
+    port = InMemoryChurnSignalPort(
+        signals={
+            "a": _signal_set("a", risk="0.90", band=RiskBand.HIGH),
+            "b": _signal_set("b", risk="0.50"),
+            "c": _signal_set("c", risk="0.10", band=RiskBand.LOW),
+        }
+    )
+    result = await port.get_at_risk_customers(Decimal("0.40"))
+
+    assert [c.customer_id for c in result] == ["a", "b"]  # c (0.10) excluded; ordered desc
+    assert all(isinstance(c, AtRiskCustomer) for c in result)
+    assert result[0].risk_score == Decimal("0.90")
+    assert result[0].band is RiskBand.HIGH
+    assert result[0].cohort == "retail-eu"
+
+
+async def test_at_risk_threshold_zero_returns_all() -> None:
+    port = InMemoryChurnSignalPort()  # default seed: 2 customers
+    result = await port.get_at_risk_customers(Decimal("0"))
+    assert len(result) == 2
+
+
+async def test_at_risk_high_threshold_returns_empty() -> None:
+    port = InMemoryChurnSignalPort()
+    result = await port.get_at_risk_customers(Decimal("1"))
+    assert result == []
+
+
+@pytest.mark.parametrize("bad", [Decimal("-0.01"), Decimal("1.01")])
+async def test_at_risk_threshold_out_of_range_raises(bad: Decimal) -> None:
+    port = InMemoryChurnSignalPort()
+    with pytest.raises(ChurnSignalPortError, match="threshold out of range"):
+        await port.get_at_risk_customers(bad)
+
+
+# ---------------------------------------------------------------------------
+# 2. get_churn_signals — known / unknown
+# ---------------------------------------------------------------------------
+
+
+async def test_get_churn_signals_known_returns_set() -> None:
+    port = InMemoryChurnSignalPort(signals={"cust-x": _signal_set("cust-x", risk="0.77")})
+    out = await port.get_churn_signals("cust-x")
+    assert isinstance(out, ChurnSignalSet)
+    assert out.customer_id == "cust-x"
+    assert out.risk_score == Decimal("0.77")
+    assert out.signals[0].code is ChurnSignalCode.DORMANCY
+
+
+async def test_get_churn_signals_unknown_raises_customer_not_found() -> None:
+    port = InMemoryChurnSignalPort(signals={})
+    with pytest.raises(CustomerNotFound, match="Unknown customer"):
+        await port.get_churn_signals("nope")
+
+
+async def test_default_seed_has_expected_customers() -> None:
+    port = InMemoryChurnSignalPort()
+    out = await port.get_churn_signals("cust-1001")
+    assert out.band is RiskBand.HIGH
+    assert out.risk_score == Decimal("0.82")
+    assert len(out.signals) == 2
+
+
+# ---------------------------------------------------------------------------
+# 3. fail_on_call — provider-error path on every read
+# ---------------------------------------------------------------------------
+
+
+async def test_fail_on_call_raises_on_at_risk() -> None:
+    port = InMemoryChurnSignalPort(fail_on_call=True)
+    with pytest.raises(ChurnSignalPortError, match="configured to fail"):
+        await port.get_at_risk_customers(Decimal("0.50"))
+
+
+async def test_fail_on_call_raises_on_get_signals() -> None:
+    port = InMemoryChurnSignalPort(fail_on_call=True)
+    with pytest.raises(ChurnSignalPortError, match="configured to fail"):
+        await port.get_churn_signals("cust-1001")
+
+
+# ---------------------------------------------------------------------------
+# 4. Value types / enums (I-01 Decimal, opaque handles)
+# ---------------------------------------------------------------------------
+
+
+def test_value_types_are_decimal_and_opaque() -> None:
+    sig = ChurnSignal(code=ChurnSignalCode.SUSPENSION, weight=Decimal("0.5"))
+    assert sig.detail == ""  # default
+    arc = AtRiskCustomer(
+        customer_id="c1", cohort="coh", risk_score=Decimal("0.6"), band=RiskBand.ELEVATED
+    )
+    assert isinstance(arc.risk_score, Decimal)
+    cs = ChurnSignalSet(
+        customer_id="c1", cohort="coh", risk_score=Decimal("0.6"), band=RiskBand.ELEVATED
+    )
+    assert cs.signals == ()  # default empty
+
+
+def test_enum_values() -> None:
+    assert RiskBand.LOW.value == "LOW"
+    assert RiskBand.ELEVATED.value == "ELEVATED"
+    assert RiskBand.HIGH.value == "HIGH"
+    assert ChurnSignalCode.DORMANCY.value == "DORMANCY"
+    assert ChurnSignalCode.SUSPENSION.value == "SUSPENSION"
+    assert ChurnSignalCode.INACTIVITY.value == "INACTIVITY"
+    assert ChurnSignalCode.REACTIVATION_LAPSE.value == "REACTIVATION_LAPSE"
+
+
+def test_error_hierarchy() -> None:
+    assert issubclass(CustomerNotFound, ChurnSignalPortError)
+    assert issubclass(ChurnSignalPortError, Exception)
+
+
+# ---------------------------------------------------------------------------
+# 5. INVARIANT: the port is READ-ONLY — no mutate/trigger/retention/write method
+# ---------------------------------------------------------------------------
+
+
+def test_port_is_read_only_no_mutating_methods() -> None:
+    """ChurnSignalPort exposes ONLY the two reads — no retention/trigger/write/mutate op.
+
+    This is the contract-level enforcement of the agent's read-only invariant: a mutating
+    op cannot be reached because no such method exists on the port at all.
+    """
+    public = {
+        n
+        for n, _ in inspect.getmembers(ChurnSignalPort, inspect.isfunction)
+        if not n.startswith("_")
+    }
+    assert public == {"get_at_risk_customers", "get_churn_signals"}
+    forbidden = ("trigger", "retention", "write", "update", "mutate", "suspend", "close", "set_")
+    for name in public:
+        assert not any(tok in name.lower() for tok in forbidden), name
+
+
+def test_abstract_port_cannot_be_instantiated() -> None:
+    with pytest.raises(TypeError):
+        ChurnSignalPort()  # type: ignore[abstract]


### PR DESCRIPTION
## IL-189 / ORG §2.6.3 — ChurnPredictionAgent (Tier-3 BUILD, L1 read-only)

ORG §2.6.3 Customer Operations `ChurnPredictionAgent` (L1 Auto, "At-risk customer alerts"), **PROPOSED → IMPLEMENTED**. Tier-3 BUILD — sibling of sprint-47 RiskOversight / sprint-48 DataQuality (new read-only port + thin §D2 mask). No new ADR (fits the L1 read-only §D2 pattern). Canonical ledger anchor: **banxe-architecture IL-189** (PR #418, merged) — renumbered from IL-188 after main raced.

### ETAP A — `ChurnSignalPort` (`services/churn/churn_signal_port.py`)
Governed **READ-ONLY** contract for derived at-risk / churn signals:
- `get_at_risk_customers(threshold: Decimal)` → `list[AtRiskCustomer]` (highest-risk first)
- `get_churn_signals(customer_id)` → `ChurnSignalSet`
- `abc.ABC` + `InMemoryChurnSignalPort` + `ChurnSignalPortError` (+ `CustomerNotFound`)
- Signals **derived read-only** from the existing `services/customer_lifecycle/` domain (DORMANT/SUSPENDED → `ChurnSignalCode`). **customer_lifecycle is NOT modified.**
- **NO** mutate / trigger / retention / write method exists on the port (I-10 / I-27). `Decimal` for every numeric.

### ETAP B — `ChurnPredictionAgent` (`services/agents/churn_prediction_agent.py`)
L1-Auto mask, full **ADR-049 §D2** gate-chain (`process_ref → scope → band → cost_cap → compliance(PII) → port`), one **ADR-046** `AgentDecisionRecord` per action; port + `DecisionRecorder` injected.
- **INVARIANT (tested):** detection/reporting only — never modifies customer state or triggers retention; any write/retention-trigger op is `REJECT_OUT_OF_SCOPE`.
- **R-SEC:** only opaque handles (`customer_id` / `cohort`) in lineage — never risk scores / weights / PII; results ride on `AgentOutcome.result`.

### Tests & gates
- `tests/test_churn/test_churn_signal_port.py` + `tests/agents/test_churn_prediction_agent.py` — **100% coverage on BOTH new modules** (43 tests).
- Covers: AUTO happy path, HALT_UNRESOLVED_PROCESS, REJECT_OUT_OF_SCOPE (write/retention refused), HALT_REVIEW_DEFERRED (port not called), BLOCK_LOW_CONFIDENCE, HALT_COST_CAP_BREACH (per-request + per-window), HALT_COMPLIANCE_BLOCK, HALT_PROVIDER_ERROR (emit+reraise), invalid confidence → ValueError, R-SEC, ADR-046 (1 record/action), read-only INVARIANT (no state mutation).
- Full local suite: **10853 passed / 37 skipped / 0 failed**; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
