### PR TITLE
feat(lead-scoring): LeadScoringAgent + LeadSignalPort (Tier-3 BUILD, L1 read-only) [IL-190]

### DIFF
--- a/services/agents/lead_scoring_agent.py
+++ b/services/agents/lead_scoring_agent.py
@@ -1,0 +1,531 @@
+"""LeadScoringAgent — L1-Auto Front-Office (Sales) behavioral lead-scoring agent
+(ORG-STRUCTURE §2.8 / §2.8.2, IL-190).
+
+WHY: ORG-STRUCTURE §2.8 (Front Office) / §2.8.2 (Marketing & Growth) defines
+``LeadScoringAgent`` (Sales, L1 Auto, "Behavioral scoring (signup → active)") as the
+governed surface through which a resolved lead-read intent becomes a bounded
+LeadSignalPort read action. This module implements the agent *logic* and *governance
+enforcement* of the lead-scoring mask in front of the LeadSignalPort CONTRACT. It is the
+sibling of ``services/agents/churn_prediction_agent.py`` and
+``services/agents/risk_oversight_agent.py`` (the L1-Auto read-only pattern).
+
+The agent SCORES and REPORTS behavioral lead propensity (signup → active), read-only,
+through the port. It operates READ-ONLY: it NEVER contacts a lead, NEVER triggers outreach
+or a nurture sequence, NEVER writes to a CRM / referral record, and NEVER makes an
+autonomous decision.
+
+INVARIANT (CRITICAL — enforced in code):
+    LeadScoringAgent is scoring/reporting only. It MUST NEVER contact a lead or mutate state
+    autonomously. Enforced by three independent mechanisms:
+      (1) the mask scope allow-list contains ONLY the 2 read ops:
+          get_active_leads, get_lead_score;
+      (2) LeadSignalPort has NO contact / outreach / nurture / write method — calling one
+          would require a method that does not exist on the port;
+      (3) every ``success_action`` in this module is a SCORE/REPORT verb
+          (REPORT_ACTIVE_LEADS, SCORE_LEAD) — the strings CONTACT, OUTREACH, NURTURE, SEND,
+          EMAIL, WRITE, UPDATE do not appear as success actions.
+
+    I-27 (CLAUDE.md): this agent PROPOSES scores only; it never contacts a lead or applies a
+    customer-state change autonomously (out-of-scope ops are refused).
+
+GOVERNANCE (ADR-049 §D2 gate-chain, fixed order):
+    process_ref → scope → band → cost_cap → compliance(PII) → port call
+
+* ``scope``              — LeadSignalPort READ ops only (allow-list: get_active_leads /
+                           get_lead_score). Off-list ops (any contact / outreach / write /
+                           state-change op) are refused outright.
+* ``autonomy_level``     — L1-Auto: every read is AUTO-eligible within cap. NO REVIEW HITL
+                           hold, NO biometric step-up. A read below the AUTO band halts for
+                           a re-check (HALT_REVIEW_DEFERRED, requires_hitl=True).
+* ``confirmation_policy``— AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70 (ADR-047).
+                           REVIEW band → HALT_REVIEW_DEFERRED.
+* ``cost_cap``           — per-request AND per-window hard caps in both token and monetary
+                           (Decimal) dimensions (ADR-047 §D2).
+* ``lineage_obligation`` — one ``AgentDecisionRecord`` per action on every exit path
+                           (ADR-046), non-optional.
+* ``compliance_gate``    — PII overlay (ADR-016): the L3 check MUST PASS before a port call;
+                           a non-PASS verdict halts (BLOCK) and escalates to the DPO
+                           (config-as-data on the mask).
+
+Any one of {unresolved process_ref, out-of-scope op, below-band confidence, cost-cap breach,
+compliance(PII) fail} halts the action (ADR-049 §D4). The port's own validation is
+defense-in-depth: if the port raises LeadSignalPortError, lineage is emitted
+(executed=False) and the error is re-raised. Mask values are config-as-data, carried on
+:class:`LeadScoringMask`.
+
+R-SEC (R-SEC-NEW-01, ADR-021): no raw propensity score, signal weight, raw behavioral event,
+or PII ever enters a lineage record. triggering_event is keyed on opaque handles ONLY
+(cohort / lead_id) — never scores or signal values. The port's return value
+(list[ScoredLead] / LeadScore) rides on ``AgentOutcome.result`` ONLY — NEVER on the recorded
+``AgentDecisionRecord``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.lead_scoring.lead_signal_port import LeadSignalPort, LeadSignalPortError
+
+# ---------------------------------------------------------------------------
+# Mask (config-as-data)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LeadScoringMask:
+    """Config-as-data Front-Office (Sales) lead-scoring (ORG-STRUCTURE §2.8) mask.
+
+    All gate values are governed config, not hardcoded flow logic. The AUTO/REVIEW/BLOCK
+    scale is ADR-047 canon. The scope is the exclusive read-only allow-list — no contact /
+    outreach / nurture / write / state-change op is present (INVARIANT: see module docstring).
+    """
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    lineage_obligation: bool = True
+    agent_id: str = "lead_scoring_agent"
+    # The mask scope (allow-list): ONLY the 2 LeadSignalPort READ ops.
+    # INVARIANT: no contact / outreach / nurture / write / update op is present in this tuple.
+    # Any attempt to call one is REJECT_OUT_OF_SCOPE.
+    scope: tuple[str, ...] = (
+        "LeadSignalPort.get_active_leads",
+        "LeadSignalPort.get_lead_score",
+    )
+    # L3 compliance contour required before any port call: PII overlay (ADR-016).
+    compliance_gate: tuple[str, ...] = ("PII",)
+    # Escalation role for a compliance non-PASS verdict (config-as-data).
+    dpo_role: str = "DPO"
+
+
+# ---------------------------------------------------------------------------
+# Intent vocabulary
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ActiveLeadsIntent:
+    """A resolved active-leads scan intent (``LeadSignalPort.get_active_leads``) — the
+    primary lead-reporting read op (ORG §2.8). Returns the leads at or above a propensity
+    ``threshold`` for a cohort. A read below the AUTO band halts for a re-check, not a HITL
+    hold. The PII overlay MUST PASS; a non-PASS verdict blocks and escalates to the DPO. The
+    list[ScoredLead] rides on ``AgentOutcome.result`` ONLY (R-SEC)."""
+
+    cohort: str
+    threshold: Decimal
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class LeadScoreIntent:
+    """A resolved per-lead score read intent (``LeadSignalPort.get_lead_score``) — the
+    behavioral propensity score for one lead (ORG §2.8). A read below the AUTO band halts for
+    a re-check. The PII overlay MUST PASS; non-PASS escalates to the DPO. The LeadScore rides
+    on ``AgentOutcome.result`` ONLY (R-SEC)."""
+
+    lead_id: str
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    """All inputs a single masked lead-scoring action evaluates against."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class LeadScoringAgent:
+    """L1-Auto Front-Office (Sales) behavioral lead-scoring agent enforcing the
+    ADR-049 §D2 gate chain.
+
+    The :class:`~services.lead_scoring.lead_signal_port.LeadSignalPort` and the lineage
+    recorder are injected as interfaces (constructor injection); the agent contains pure
+    governance logic and is unit-testable without any live infra.
+
+    INVARIANT: SCORING/REPORTING ONLY. This agent MUST NEVER contact a lead or mutate state
+    autonomously. See module docstring for the three independent enforcement mechanisms.
+    I-27: PROPOSES scores only, never applies autonomously.
+    """
+
+    def __init__(
+        self,
+        *,
+        lead_signal_port: LeadSignalPort,
+        recorder: DecisionRecorder,
+        mask: LeadScoringMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._port = lead_signal_port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def report_active_leads(
+        self,
+        intent: ActiveLeadsIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Active-leads scan via ``LeadSignalPort.get_active_leads`` (ORG §2.8).
+
+        AUTO-eligible within cap. The PII overlay (``compliance_result``) MUST PASS; a
+        non-PASS verdict blocks and escalates to the DPO. A read below the AUTO band halts
+        for a re-check (L1-Auto). The list[ScoredLead] rides on ``AgentOutcome.result`` ONLY
+        (R-SEC — no score in lineage; triggering_event keyed on the opaque cohort)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_active_leads:{intent.cohort}",
+            success_action="REPORT_ACTIVE_LEADS",
+            op="LeadSignalPort.get_active_leads",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_active_leads(intent.threshold))
+
+    async def get_lead_score(
+        self,
+        intent: LeadScoreIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Per-lead behavioral score read via ``LeadSignalPort.get_lead_score`` (ORG §2.8).
+
+        AUTO-eligible within cap. The PII overlay MUST PASS; non-PASS blocks and escalates to
+        the DPO. A read below the AUTO band halts for a re-check (L1-Auto). The LeadScore
+        rides on ``AgentOutcome.result`` ONLY (R-SEC — no score or signal weight in lineage;
+        triggering_event keyed on the opaque lead_id)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"get_lead_score:{intent.lead_id}",
+            success_action="SCORE_LEAD",
+            op="LeadSignalPort.get_lead_score",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_lead_score(intent.lead_id))
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be in [0.0, 1.0]")
+        policies = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no port call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. Scope allow-list — an off-list op (any contact / outreach / write / state-change)
+        #    is refused outright. INVARIANT: the mask scope has read ops only.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op} is not on the lead-scoring mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band. REVIEW → HALT_REVIEW_DEFERRED: reads are AUTO-only
+        #    (L1-Auto); there is no HITL hold path in this agent.
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+
+        if band is ConfirmationDecision.BLOCK:
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory (ADR-049 §D4).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+            )
+        if band is ConfirmationDecision.REVIEW:
+            return _Evaluation(
+                band,
+                False,
+                "HALT_REVIEW_DEFERRED",
+                "Read intent below AUTO band; reads are AUTO-only, no HITL hold (L1-Auto).",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="review_deferred",
+                requires_hitl=True,
+            )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window tokens/cost); action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. PII compliance gate (ADR-016). A non-PASS verdict halts AND escalates to the DPO.
+        policies.append("ADR-049-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            escalated = self._mask.dpo_role
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"PII overlay returned {ctx.compliance_result}; "
+                f"action blocked and escalated to {escalated}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=escalated,
+            )
+
+        # All gates satisfied — clear to commit the read.
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All lead-scoring mask gates satisfied at {band.value} confidence; "
+            "committing within scope.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except LeadSignalPortError as exc:
+                    # Defense-in-depth: the port's own read guard fired. Emit one lineage
+                    # record (executed=False) then re-raise — no raw score, signal weight,
+                    # or PII recorded.
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=ev.compliance_result,
+                        reasoning=f"Port rejected the action: {exc}",
+                        escalated_to=ev.escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=ev.compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=ev.escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=ev.escalated_to,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        return await self._record(
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies=ev.policies,
+            compliance_result=compliance_result,
+            reasoning=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            correlation_id=ctx.correlation_id,
+            request_cost=ctx.request_cost,
+            budget_breach=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+
+    async def _record(
+        self,
+        *,
+        triggering_event: str,
+        intent: str,
+        policies: list[str],
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        confidence_score: float,
+        action_taken: str,
+        correlation_id: str,
+        request_cost: RequestCost,
+        budget_breach: BudgetBreach,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        """Build, persist, and return exactly one ADR-046 lineage record (the single
+        producer→sink seam used by every exit path). R-SEC: triggering_event uses opaque
+        cohort / lead_id labels only — never scores, signal weights, or PII. Port return
+        values ride on AgentOutcome.result, never on this record."""
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=triggering_event,
+            intent=intent,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=None,
+            correlation_id=correlation_id,
+            cost_tokens=request_cost.tokens,
+            cost_amount=request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "ActiveLeadsIntent",
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "BudgetBreach",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "LeadScoreIntent",
+    "LeadScoringAgent",
+    "LeadScoringMask",
+    "LeadSignalPortError",
+    "ProcessRef",
+    "RequestCost",
+]

--- a/services/lead_scoring/__init__.py
+++ b/services/lead_scoring/__init__.py
@@ -1,0 +1,8 @@
+"""Lead-scoring domain (ORG-STRUCTURE §2.8 Front Office / Sales, IL-190).
+
+Houses the governed READ-ONLY :class:`~services.lead_scoring.lead_signal_port.LeadSignalPort`
+CONTRACT (behavioral lead scoring, signup → active). No mutating surface lives here — the
+LeadScoringAgent reads behavioral lead signals through this port only.
+"""
+
+from __future__ import annotations

--- a/services/lead_scoring/lead_signal_port.py
+++ b/services/lead_scoring/lead_signal_port.py
@@ -1,0 +1,355 @@
+"""services/lead_scoring/lead_signal_port.py — LeadSignalPort: governed READ-ONLY
+behavioral lead-signal CONTRACT (ORG-STRUCTURE §2.8 Sales, IL-190 LeadScoringAgent).
+
+EXPLICIT BOUNDARY: READ ONLY — behavioral lead scoring and reporting only (signup →
+active). This port does NOT mutate state, contact / outreach leads, write to any CRM /
+referral record, enrol a lead in a nurture sequence, or train any model. There are NO
+mutate / contact / outreach / write methods on this port at all (I-10: no fake
+integrations, I-27: no autonomous customer-state changes or outreach actions).
+
+WHY: ORG-STRUCTURE §2.8 (Front Office) / §2.8.2 (Marketing & Growth) defines
+``LeadScoringAgent`` (Sales, L1 Auto, "Behavioral scoring (signup → active)") as the
+governed surface through which Sales reads a lead's behavioral propensity score. The
+LeadSignalPort is the CONTRACT boundary the LeadScoringAgent mask ``scope`` allow-lists
+(ADR-049 §D1). The read-only constraint is an invariant: the port has no mutating methods,
+so the agent cannot accidentally call one.
+
+A CONTRACT ABSTRACTION (NOT a real ML model / ClickHouse integration):
+The behavioral lead score is a read-only abstraction. ORG §2.8.2 names ClickHouse +
+scikit-learn as the production stack; that real adapter (reading the behavioral-event
+stream from ClickHouse and serving a scikit-learn propensity model BEHIND this port) is a
+LATER sprint (I-10: no fake integrations now — exactly like the analytics / churn
+adapters). There is NO existing lead / sales / marketing domain to derive from (``referral/``
+and ``crm/`` exist but are NOT lead scoring), so this is a full BUILD: this file ships the
+CONTRACT + an in-memory double for unit tests only, and authors no production adapter.
+
+Governance contract (ADR-049 §D1 — canonical):
+  reads: get_active_leads, get_lead_score
+
+PII / R-SEC (R-SEC-NEW-01, ADR-021):
+  All value types carry only opaque handles (``lead_id`` / ``cohort``) and aggregate
+  signals. No method accepts or returns raw PII (no name / email / IBAN / address) or raw
+  behavioral events. ``lead_id`` is an opaque handle, never a personal reference.
+
+I-01 (CLAUDE.md): every numeric field (score, signal weight, threshold) is Decimal, never
+float.
+"""
+
+from __future__ import annotations
+
+import abc
+from abc import abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import StrEnum
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+# Opaque lead / cohort handles. NEVER raw PII (no name / email / IBAN / address).
+LeadId = str
+Cohort = str
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class LeadScoreBand(StrEnum):
+    """Coarse propensity band for a lead (derived from the aggregate behavioral score)."""
+
+    COLD = "COLD"
+    WARM = "WARM"
+    HOT = "HOT"
+
+
+class LeadStage(StrEnum):
+    """A lead's position in the signup → active funnel (read-only, behavioral).
+
+    SIGNUP     — account created, no further activation behavior yet.
+    ONBOARDING — progressing through onboarding (profile / KYC steps).
+    ACTIVATED  — completed activation milestones; not yet a sustained active user.
+    ACTIVE     — sustained active engagement (the funnel goal).
+    """
+
+    SIGNUP = "SIGNUP"
+    ONBOARDING = "ONBOARDING"
+    ACTIVATED = "ACTIVATED"
+    ACTIVE = "ACTIVE"
+
+
+class LeadSignalCode(StrEnum):
+    """A behavioral signal contributing to a lead's propensity score (read-only).
+
+    These are aggregate behavioral indicators a production adapter would derive from the
+    behavioral-event stream (ClickHouse) BEHIND this port — never raw events here:
+
+      SIGNUP_COMPLETED    — completed the signup flow.
+      PROFILE_COMPLETION  — profile / KYC fields completed.
+      ONBOARDING_PROGRESS — advanced through onboarding steps.
+      FEATURE_ENGAGEMENT  — engaged with core product features.
+      SESSION_RECENCY     — recent active sessions (recency / frequency).
+    """
+
+    SIGNUP_COMPLETED = "SIGNUP_COMPLETED"
+    PROFILE_COMPLETION = "PROFILE_COMPLETION"
+    ONBOARDING_PROGRESS = "ONBOARDING_PROGRESS"
+    FEATURE_ENGAGEMENT = "FEATURE_ENGAGEMENT"
+    SESSION_RECENCY = "SESSION_RECENCY"
+
+
+# ---------------------------------------------------------------------------
+# Value types (frozen=True — immutable after construction, I-01 Decimal)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LeadSignal:
+    """A single behavioral signal contributing to a lead's propensity score (READ-ONLY).
+
+    I-01: ``weight`` is Decimal, never float.
+
+    Required fields:
+      code   — the behavioral signal code.
+      weight — contribution of this signal to the aggregate score, Decimal [0.0, 1.0].
+
+    Optional fields:
+      detail — short opaque, non-PII note (e.g. "3 sessions/7d"); defaults to "".
+    """
+
+    code: LeadSignalCode
+    weight: Decimal
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class ScoredLead:
+    """A scored lead entry in an active-leads scan result (READ-ONLY).
+
+    I-01: ``score`` is Decimal, never float. R-SEC: ``lead_id`` / ``cohort`` are opaque
+    handles only — never raw PII.
+
+    Required fields:
+      lead_id — opaque lead handle (no raw PII).
+      cohort  — opaque cohort label the lead belongs to (no raw PII).
+      score   — aggregate behavioral propensity as Decimal [0.0, 1.0].
+      band    — coarse propensity band derived from score.
+      stage   — the lead's stage in the signup → active funnel.
+    """
+
+    lead_id: LeadId
+    cohort: Cohort
+    score: Decimal
+    band: LeadScoreBand
+    stage: LeadStage
+
+
+@dataclass(frozen=True)
+class LeadScore:
+    """The full behavioral propensity score for one lead (READ-ONLY).
+
+    I-01: ``score`` and every signal weight are Decimal, never float.
+
+    Required fields:
+      lead_id — opaque lead handle (no raw PII).
+      cohort  — opaque cohort label (no raw PII).
+      score   — aggregate behavioral propensity as Decimal [0.0, 1.0].
+      band    — coarse propensity band derived from score.
+      stage   — the lead's stage in the signup → active funnel.
+
+    Optional fields:
+      signals — the individual behavioral signals; defaults to empty.
+    """
+
+    lead_id: LeadId
+    cohort: Cohort
+    score: Decimal
+    band: LeadScoreBand
+    stage: LeadStage
+    signals: tuple[LeadSignal, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class LeadSignalPortError(Exception):
+    """Base error for LeadSignalPort read failures.
+
+    Adapters raise this (or a subclass) when a lead-signal fetch fails. LeadScoringAgent
+    catches it, emits one lineage record (executed=False), then re-raises — defense-in-depth
+    (ADR-046 / ADR-027).
+    """
+
+
+class LeadNotFound(LeadSignalPortError):
+    """The requested ``lead_id`` has no behavioral score (unknown handle)."""
+
+
+# ---------------------------------------------------------------------------
+# Abstract port (READ-ONLY CONTRACT)
+# ---------------------------------------------------------------------------
+
+
+class LeadSignalPort(abc.ABC):
+    """Abstract CONTRACT for governed READ-ONLY behavioral lead-signal reads (ORG §2.8).
+
+    INVARIANT: Every method on this port is a pure read. There are NO methods for contacting
+    / outreaching leads, enrolling in a nurture sequence, writing CRM / referral state, or
+    mutating any state. The absence of mutating methods is the primary enforcement mechanism
+    for the LeadScoringAgent read-only invariant (I-27).
+
+    Conformance rules:
+      Read-only: NO operation mutates state, contacts a lead, or triggers outreach. The two
+      reads MUST NOT trigger any state change.
+
+      I-01: every numeric field (score, weight, threshold) is Decimal, never float.
+
+      R-SEC: only opaque handles (lead_id / cohort) cross this boundary — no raw PII, no raw
+      behavioral events.
+    """
+
+    @abstractmethod
+    async def get_active_leads(self, threshold: Decimal) -> list[ScoredLead]:
+        """Return the leads whose behavioral score >= ``threshold`` (read-only).
+
+        Read-only; MUST NOT trigger any state change, contact, or outreach. I-01:
+        ``threshold`` and every returned score are Decimal.
+
+        Args:
+            threshold: minimum aggregate propensity score to include, Decimal [0.0, 1.0].
+
+        Returns:
+            A list of ScoredLead (possibly empty), highest score first.
+
+        Raises:
+            LeadSignalPortError: if the threshold is out of range or the read fails.
+        """
+        ...  # pragma: no cover
+
+    @abstractmethod
+    async def get_lead_score(self, lead_id: LeadId) -> LeadScore:
+        """Return the behavioral propensity score for one lead (read-only).
+
+        Read-only; MUST NOT trigger any state change, contact, or outreach.
+
+        Args:
+            lead_id: opaque lead handle to score (no raw PII).
+
+        Returns:
+            The LeadScore for the lead.
+
+        Raises:
+            LeadNotFound: ``lead_id`` has no behavioral score (unknown handle).
+            LeadSignalPortError: if the read otherwise fails.
+        """
+        ...  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# InMemory implementation (for unit tests)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryLeadSignalPort(LeadSignalPort):
+    """Configurable in-memory stub for unit tests.
+
+    Seed data is provided at construction time. Pass ``fail_on_call=True`` to make every
+    method raise :class:`LeadSignalPortError` — exercises the agent HALT_PROVIDER_ERROR
+    branch. Raises :class:`LeadNotFound` for unknown leads and :class:`LeadSignalPortError`
+    for an out-of-range threshold. READ-ONLY: there is no method to mutate state, contact a
+    lead, or trigger outreach.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_on_call: bool = False,
+        scores: Mapping[LeadId, LeadScore] | None = None,
+    ) -> None:
+        self._fail = fail_on_call
+        self._scores: dict[LeadId, LeadScore] = dict(
+            scores
+            if scores is not None
+            else {
+                "lead-1001": LeadScore(
+                    lead_id="lead-1001",
+                    cohort="organic-eu",
+                    score=Decimal("0.88"),
+                    band=LeadScoreBand.HOT,
+                    stage=LeadStage.ACTIVATED,
+                    signals=(
+                        LeadSignal(
+                            code=LeadSignalCode.FEATURE_ENGAGEMENT,
+                            weight=Decimal("0.55"),
+                            detail="core features used",
+                        ),
+                        LeadSignal(
+                            code=LeadSignalCode.SESSION_RECENCY,
+                            weight=Decimal("0.30"),
+                            detail="5 sessions/7d",
+                        ),
+                    ),
+                ),
+                "lead-1002": LeadScore(
+                    lead_id="lead-1002",
+                    cohort="organic-eu",
+                    score=Decimal("0.34"),
+                    band=LeadScoreBand.WARM,
+                    stage=LeadStage.ONBOARDING,
+                    signals=(
+                        LeadSignal(
+                            code=LeadSignalCode.ONBOARDING_PROGRESS,
+                            weight=Decimal("0.34"),
+                            detail="2/5 onboarding steps",
+                        ),
+                    ),
+                ),
+            }
+        )
+
+    def _check_fail(self) -> None:
+        if self._fail:
+            raise LeadSignalPortError("InMemoryLeadSignalPort configured to fail")
+
+    async def get_active_leads(self, threshold: Decimal) -> list[ScoredLead]:
+        self._check_fail()
+        if not Decimal("0") <= threshold <= Decimal("1"):
+            raise LeadSignalPortError(f"threshold out of range: {threshold!r}")
+        active = [
+            ScoredLead(
+                lead_id=s.lead_id,
+                cohort=s.cohort,
+                score=s.score,
+                band=s.band,
+                stage=s.stage,
+            )
+            for s in self._scores.values()
+            if s.score >= threshold
+        ]
+        return sorted(active, key=lambda lead: lead.score, reverse=True)
+
+    async def get_lead_score(self, lead_id: LeadId) -> LeadScore:
+        self._check_fail()
+        if lead_id not in self._scores:
+            raise LeadNotFound(f"Unknown lead: {lead_id!r}")
+        return self._scores[lead_id]
+
+
+__all__ = [
+    "Cohort",
+    "InMemoryLeadSignalPort",
+    "LeadId",
+    "LeadNotFound",
+    "LeadScore",
+    "LeadScoreBand",
+    "LeadSignal",
+    "LeadSignalCode",
+    "LeadSignalPort",
+    "LeadSignalPortError",
+    "LeadStage",
+    "ScoredLead",
+]

--- a/tests/agents/test_lead_scoring_agent.py
+++ b/tests/agents/test_lead_scoring_agent.py
@@ -1,0 +1,603 @@
+"""LeadScoringAgent test suite — 100% coverage over
+services/agents/lead_scoring_agent.py.
+
+Validates: ADR-049 §D2 gate-chain branches (process-ref resolution, scope allow-list,
+confidence band, cost-cap per-request and per-window, PII compliance gate, successful port
+call, port LeadSignalPortError path), ADR-046 lineage invariants (one record per action on
+every exit path), R-SEC-NEW-01 (no raw score / signal weight / PII in any lineage record —
+result rides on AgentOutcome.result only), and the SCORING/REPORTING INVARIANT (mask scope
+has no contact / outreach / write op; the agent never contacts a lead or mutates state; all
+success_actions use SCORE_ or REPORT_ prefix).
+
+asyncio_mode = "auto" (pyproject.toml): every ``async def test_*`` is auto-collected
+without @pytest.mark.asyncio.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.agents.lead_scoring_agent import (
+    ActiveLeadsIntent,
+    LeadScoreIntent,
+    LeadScoringAgent,
+    LeadScoringMask,
+)
+from services.lead_scoring.lead_signal_port import (
+    InMemoryLeadSignalPort,
+    LeadScore,
+    LeadScoreBand,
+    LeadSignal,
+    LeadSignalCode,
+    LeadSignalPortError,
+    LeadStage,
+    ScoredLead,
+)
+
+# ---------------------------------------------------------------------------
+# In-test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeRecorder(DecisionRecorder):
+    """In-memory DecisionRecorder that collects records for assertion."""
+
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CAP = CostCap(
+    max_request_tokens=1_000,
+    max_request_cost=Decimal("1.00"),
+    max_window_tokens=10_000,
+    max_window_cost=Decimal("10.00"),
+)
+
+
+def make_mask(**overrides: object) -> LeadScoringMask:
+    base: dict[str, object] = {"cost_cap": _DEFAULT_CAP}
+    base.update(overrides)
+    return LeadScoringMask(**base)  # type: ignore[arg-type]
+
+
+def make_agent(
+    mask: LeadScoringMask | None = None,
+    port: InMemoryLeadSignalPort | None = None,
+    recorder: FakeRecorder | None = None,
+    window: CostWindow | None = None,
+) -> tuple[LeadScoringAgent, InMemoryLeadSignalPort, FakeRecorder]:
+    p = port or InMemoryLeadSignalPort()
+    r = recorder or FakeRecorder()
+    m = mask or make_mask()
+    return LeadScoringAgent(lead_signal_port=p, recorder=r, mask=m, cost_window=window), p, r
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    pid = "proc-lead-001" if resolved else ""
+    return ProcessRef(process_id=pid, version="1.0")
+
+
+def _cost(tokens: int = 10, cost: str = "0.01") -> RequestCost:
+    return RequestCost(tokens=tokens, cost=Decimal(cost))
+
+
+def make_scan_intent(
+    *,
+    cohort: str = "organic-eu",
+    threshold: str = "0.50",
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> ActiveLeadsIntent:
+    return ActiveLeadsIntent(
+        cohort=cohort,
+        threshold=Decimal(threshold),
+        intent_text="report active leads for organic-eu cohort",
+        process_ref=_ref(resolved),
+        correlation_id="corr-scan-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+def make_score_intent(
+    *,
+    lead_id: str = "lead-1001",
+    confidence: float = 0.95,
+    resolved: bool = True,
+    tokens: int = 10,
+    cost: str = "0.01",
+) -> LeadScoreIntent:
+    return LeadScoreIntent(
+        lead_id=lead_id,
+        intent_text="score behavioral propensity for a lead",
+        process_ref=_ref(resolved),
+        correlation_id="corr-score-001",
+        confidence_score=confidence,
+        request_cost=_cost(tokens, cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1-2. AUTO happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_report_active_leads_auto_read_executes() -> None:
+    """Confidence 0.95 > 0.90 → AUTO band; port called; exactly one lineage record."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_active_leads(make_scan_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.halt_reason is None
+    assert outcome.requires_hitl is False
+    assert outcome.escalated_to is None
+    assert isinstance(outcome.result, list)
+    assert all(isinstance(lead, ScoredLead) for lead in outcome.result)
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert rec.action_taken == "REPORT_ACTIVE_LEADS"
+    assert rec.agent_id == "lead_scoring_agent"
+    assert rec.compliance_result is ComplianceResult.PASS
+    assert rec.budget_breach_flag is BudgetBreach.NONE
+    assert rec.triggering_event == "get_active_leads:organic-eu"
+    assert outcome.record is rec
+
+
+async def test_get_lead_score_auto_read_executes() -> None:
+    """Confidence 0.95 → AUTO; port called; result is LeadScore."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_lead_score(make_score_intent())
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, LeadScore)
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "SCORE_LEAD"
+    assert recorder.records[0].triggering_event == "get_lead_score:lead-1001"
+
+
+# ---------------------------------------------------------------------------
+# 3. Unresolved process_ref → HALT_UNRESOLVED_PROCESS
+# ---------------------------------------------------------------------------
+
+
+async def test_unresolved_process_ref_blocks() -> None:
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_active_leads(make_scan_intent(resolved=False))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert outcome.requires_hitl is True
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+# ---------------------------------------------------------------------------
+# 4. Out-of-scope op → REJECT_OUT_OF_SCOPE (contact/outreach op refused)
+# ---------------------------------------------------------------------------
+
+
+async def test_out_of_scope_outreach_refused() -> None:
+    """Scope restricted to a contact/outreach (mutate) op; the read op is off-list → REJECT.
+
+    INVARIANT: LeadSignalPort.contact_lead is never in the default allow-list. When a scope
+    containing only an outreach op is configured, the read op is REJECT_OUT_OF_SCOPE —
+    demonstrating a contact/outreach op cannot be reached via the normal agent flow (the port
+    also has no such method).
+    """
+    scoped_mask = make_mask(scope=("LeadSignalPort.contact_lead",))
+    agent, _, recorder = make_agent(mask=scoped_mask)
+    outcome = await agent.report_active_leads(make_scan_intent())
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "out_of_scope"
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+# ---------------------------------------------------------------------------
+# 5. Below-AUTO band (REVIEW) → HALT_REVIEW_DEFERRED, port NOT called
+# ---------------------------------------------------------------------------
+
+
+async def test_below_auto_band_read_halts_review_deferred() -> None:
+    """Confidence 0.80 is in REVIEW band (0.70–0.90); reads are AUTO-only (L1-Auto)."""
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_active_leads(make_scan_intent(confidence=0.80))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+async def test_band_boundary_exactly_auto_threshold_is_review() -> None:
+    """confidence=0.90 is NOT > 0.90 → REVIEW band → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.report_active_leads(make_scan_intent(confidence=0.90))
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+async def test_band_boundary_exactly_review_floor_is_review() -> None:
+    """confidence=0.70 is >= 0.70 → REVIEW band → HALT_REVIEW_DEFERRED."""
+    agent, _, _ = make_agent()
+    outcome = await agent.get_lead_score(make_score_intent(confidence=0.70))
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.halt_reason == "review_deferred"
+
+
+# ---------------------------------------------------------------------------
+# 6. Low confidence (<0.70) → BLOCK_LOW_CONFIDENCE
+# ---------------------------------------------------------------------------
+
+
+async def test_block_low_confidence() -> None:
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_active_leads(make_scan_intent(confidence=0.50))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "low_confidence"
+    assert outcome.requires_hitl is True
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+# ---------------------------------------------------------------------------
+# 7. Cost-cap breaches — per-request (tokens + monetary) and per-window
+# ---------------------------------------------------------------------------
+
+
+async def test_per_request_cost_cap_tokens_breach() -> None:
+    tight_cap = CostCap(
+        max_request_tokens=5,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.report_active_leads(make_scan_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+async def test_per_request_cost_cap_monetary_breach() -> None:
+    tight_cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("0.001"),
+        max_window_tokens=100_000,
+        max_window_cost=Decimal("9999.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=tight_cap))
+    outcome = await agent.report_active_leads(make_scan_intent(cost="0.10"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+
+
+async def test_per_window_token_cost_cap_breach() -> None:
+    window = CostWindow(
+        used_tokens=9990, used_cost=Decimal("0.00"), window_ref="lead_scoring_agent:test"
+    )
+    agent, _, recorder = make_agent(window=window)
+    outcome = await agent.report_active_leads(make_scan_intent(tokens=100))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert len(recorder.records) == 1
+
+
+async def test_per_window_monetary_cost_cap_breach() -> None:
+    window = CostWindow(
+        used_tokens=0, used_cost=Decimal("9.99"), window_ref="lead_scoring_agent:test"
+    )
+    cap = CostCap(
+        max_request_tokens=1_000_000,
+        max_request_cost=Decimal("999.00"),
+        max_window_tokens=1_000_000,
+        max_window_cost=Decimal("10.00"),
+    )
+    agent, _, recorder = make_agent(mask=make_mask(cost_cap=cap), window=window)
+    outcome = await agent.report_active_leads(make_scan_intent(tokens=1, cost="0.02"))
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+# ---------------------------------------------------------------------------
+# 8. PII compliance gate → HALT_COMPLIANCE_BLOCK, escalated to DPO
+# ---------------------------------------------------------------------------
+
+
+async def test_compliance_fail_blocks_escalates_to_dpo() -> None:
+    agent, _, recorder = make_agent()
+    outcome = await agent.report_active_leads(
+        make_scan_intent(), compliance_result=ComplianceResult.FAIL
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "DPO"
+    assert outcome.requires_hitl is True
+    rec = recorder.records[0]
+    assert rec.escalated_to == "DPO"
+    assert rec.action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert rec.compliance_result is ComplianceResult.FAIL
+
+
+async def test_compliance_escalate_blocks_escalates_to_dpo() -> None:
+    agent, _, recorder = make_agent()
+    outcome = await agent.get_lead_score(
+        make_score_intent(), compliance_result=ComplianceResult.ESCALATE
+    )
+
+    assert outcome.executed is False
+    assert outcome.halt_reason == "compliance_block"
+    assert outcome.escalated_to == "DPO"
+    assert len(recorder.records) == 1
+
+
+async def test_custom_dpo_role_used() -> None:
+    agent, _, _ = make_agent(mask=make_mask(dpo_role="DataProtectionOfficer"))
+    outcome = await agent.report_active_leads(
+        make_scan_intent(), compliance_result=ComplianceResult.FAIL
+    )
+    assert outcome.escalated_to == "DataProtectionOfficer"
+
+
+# ---------------------------------------------------------------------------
+# 9. Port raises LeadSignalPortError → lineage emitted (executed=False), re-raised
+# ---------------------------------------------------------------------------
+
+
+async def test_port_error_emits_lineage_then_reraises_on_scan() -> None:
+    port = InMemoryLeadSignalPort(fail_on_call=True)
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(LeadSignalPortError):
+        await agent.report_active_leads(make_scan_intent())
+
+    assert len(recorder.records) == 1
+    rec = recorder.records[0]
+    assert "HALT_PROVIDER_ERROR" in rec.action_taken
+    assert "LeadSignalPortError" in rec.action_taken
+
+
+async def test_port_error_emits_lineage_then_reraises_on_score() -> None:
+    port = InMemoryLeadSignalPort(fail_on_call=True)
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(LeadSignalPortError):
+        await agent.get_lead_score(make_score_intent())
+
+    assert len(recorder.records) == 1
+    assert "HALT_PROVIDER_ERROR" in recorder.records[0].action_taken
+
+
+async def test_port_lead_not_found_reraised_as_provider_error() -> None:
+    """A LeadNotFound (LeadSignalPortError subclass) is recorded then re-raised."""
+    port = InMemoryLeadSignalPort(scores={})
+    agent, _, recorder = make_agent(port=port)
+
+    with pytest.raises(LeadSignalPortError):
+        await agent.get_lead_score(make_score_intent(lead_id="ghost"))
+
+    assert recorder.records[0].action_taken == "HALT_PROVIDER_ERROR:LeadNotFound"
+
+
+# ---------------------------------------------------------------------------
+# 10. Invalid confidence → ValueError, NO lineage record
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_confidence_above_range_raises_no_record() -> None:
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.report_active_leads(make_scan_intent(confidence=1.1))
+    assert len(recorder.records) == 0
+
+
+async def test_invalid_confidence_below_range_raises_no_record() -> None:
+    agent, _, recorder = make_agent()
+    with pytest.raises(ValueError, match="confidence_score"):
+        await agent.get_lead_score(make_score_intent(confidence=-0.01))
+    assert len(recorder.records) == 0
+
+
+# ---------------------------------------------------------------------------
+# 11. R-SEC: no raw score / signal weight in any lineage record field
+# ---------------------------------------------------------------------------
+
+
+async def test_no_raw_score_in_lineage_record() -> None:
+    """A score sentinel reachable ONLY through the port result MUST NOT appear in any
+    AgentDecisionRecord field — the LeadScore rides on AgentOutcome.result only."""
+    sentinel = Decimal("0.87654321")
+    lead_score = LeadScore(
+        lead_id="lead-opaque-7",
+        cohort="organic-eu",
+        score=sentinel,
+        band=LeadScoreBand.HOT,
+        stage=LeadStage.ACTIVE,
+        signals=(LeadSignal(code=LeadSignalCode.FEATURE_ENGAGEMENT, weight=Decimal("0.99119911")),),
+    )
+    port = InMemoryLeadSignalPort(scores={"lead-opaque-7": lead_score})
+    agent, _, recorder = make_agent(port=port)
+
+    outcome = await agent.get_lead_score(make_score_intent(lead_id="lead-opaque-7"))
+
+    # Result delivered to the caller …
+    assert isinstance(outcome.result, LeadScore)
+    assert outcome.result.score == sentinel  # type: ignore[union-attr]
+
+    rec = recorder.records[0]
+    serialised = " ".join(
+        str(v)
+        for v in (
+            rec.triggering_event,
+            rec.intent,
+            rec.reasoning_summary,
+            rec.action_taken,
+            rec.correlation_id,
+            " ".join(rec.policies_evaluated),
+        )
+    )
+    assert str(sentinel) not in serialised
+    assert "0.99119911" not in serialised
+    assert rec.cost_amount != sentinel
+    # Only the opaque lead_id is keyed into the lineage event.
+    assert "lead-opaque-7" in rec.triggering_event
+
+
+# ---------------------------------------------------------------------------
+# 12. ADR-046 lineage-per-action + window accumulation
+# ---------------------------------------------------------------------------
+
+
+async def test_lineage_one_record_per_call_adr046() -> None:
+    agent, _, recorder = make_agent()
+
+    assert len(recorder.records) == 0
+    await agent.report_active_leads(make_scan_intent())
+    assert len(recorder.records) == 1
+    await agent.get_lead_score(make_score_intent())
+    assert len(recorder.records) == 2
+    # A halted path also emits exactly 1 record.
+    await agent.report_active_leads(make_scan_intent(resolved=False))
+    assert len(recorder.records) == 3
+
+
+async def test_window_accumulates_on_successful_reads() -> None:
+    window = CostWindow(window_ref="lead_scoring_agent:test")
+    agent, _, _ = make_agent(window=window)
+
+    await agent.report_active_leads(make_scan_intent(tokens=50, cost="0.05"))
+    assert window.used_tokens == 50
+    assert window.used_cost == Decimal("0.05")
+
+    await agent.get_lead_score(make_score_intent(tokens=30, cost="0.03"))
+    assert window.used_tokens == 80
+    assert window.used_cost == Decimal("0.08")
+
+
+async def test_window_not_accumulated_on_halt() -> None:
+    window = CostWindow(window_ref="lead_scoring_agent:test")
+    agent, _, _ = make_agent(window=window)
+    await agent.report_active_leads(make_scan_intent(resolved=False))
+    assert window.used_tokens == 0
+    assert window.used_cost == Decimal("0")
+
+
+async def test_default_window_ref_uses_agent_id() -> None:
+    agent, _, _ = make_agent()
+    assert agent._window.window_ref == "lead_scoring_agent:default"
+
+
+# ---------------------------------------------------------------------------
+# 13. INVARIANT: scoring/reporting only — no contact/mutation; scope + actions verified
+# ---------------------------------------------------------------------------
+
+
+async def test_invariant_scope_is_score_report_only() -> None:
+    """Default mask scope MUST contain ONLY the 2 read ops — no contact/outreach/write op."""
+    mask = make_mask()
+    scope_lower = " ".join(mask.scope).lower()
+    for forbidden in ("contact", "outreach", "nurture", "send", "email", "write", "update"):
+        assert forbidden not in scope_lower
+    assert set(mask.scope) == {
+        "LeadSignalPort.get_active_leads",
+        "LeadSignalPort.get_lead_score",
+    }
+
+
+async def test_invariant_no_lead_state_mutation() -> None:
+    """A full read flow MUST NOT mutate the port's lead data (read-only invariant).
+
+    The agent has no contact/mutate capability; this asserts the port snapshot is
+    byte-identical before and after a successful read, and that success_actions are
+    SCORE/REPORT verbs only.
+    """
+    port = InMemoryLeadSignalPort()
+    before = await port.get_lead_score("lead-1001")
+    agent, _, recorder = make_agent(port=port)
+
+    await agent.report_active_leads(make_scan_intent(threshold="0"))
+    await agent.get_lead_score(make_score_intent(lead_id="lead-1001"))
+
+    after = await port.get_lead_score("lead-1001")
+    assert after == before  # frozen snapshot unchanged — no mutation
+
+    actions = " ".join(r.action_taken for r in recorder.records)
+    assert all(r.action_taken.startswith(("SCORE_", "REPORT_")) for r in recorder.records)
+    for token in ("CONTACT", "OUTREACH", "NURTURE", "SEND", "EMAIL", "WRITE", "UPDATE"):
+        assert token not in actions
+
+
+# ---------------------------------------------------------------------------
+# 14. In-memory e2e full flow (real mask, InMemoryLeadSignalPort, FakeRecorder)
+# ---------------------------------------------------------------------------
+
+
+async def test_in_memory_e2e_report_active_leads() -> None:
+    recorder = FakeRecorder()
+    mask = LeadScoringMask(
+        cost_cap=CostCap(
+            max_request_tokens=500,
+            max_request_cost=Decimal("0.50"),
+            max_window_tokens=50_000,
+            max_window_cost=Decimal("50.00"),
+        ),
+        agent_id="lead_scoring_agent",
+        dpo_role="DPO",
+    )
+    port = InMemoryLeadSignalPort()
+    agent = LeadScoringAgent(lead_signal_port=port, recorder=recorder, mask=mask)
+    intent = ActiveLeadsIntent(
+        cohort="organic-eu",
+        threshold=Decimal("0.40"),
+        intent_text="Sales daily active-leads scan Q2-2026",
+        process_ref=ProcessRef(process_id="proc-e2e-lead-001", version="1.0"),
+        correlation_id="e2e-corr-lead-001",
+        confidence_score=0.97,
+        request_cost=RequestCost(tokens=100, cost=Decimal("0.10")),
+    )
+    outcome = await agent.report_active_leads(intent)
+
+    assert outcome.executed is True
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert isinstance(outcome.result, list)
+    assert outcome.result[0].score == Decimal("0.88")  # highest-score first (lead-1001)
+    assert outcome.halt_reason is None
+    rec = recorder.records[0]
+    assert rec.correlation_id == "e2e-corr-lead-001"
+    assert rec.triggering_event == "get_active_leads:organic-eu"
+    assert rec.human_reviewed_by is None  # L1-Auto: never a reviewer

--- a/tests/test_lead_scoring/test_lead_signal_port.py
+++ b/tests/test_lead_scoring/test_lead_signal_port.py
@@ -1,0 +1,216 @@
+"""LeadSignalPort contract test suite — 100% coverage over
+services/lead_scoring/lead_signal_port.py.
+
+Validates the READ-ONLY contract and the InMemoryLeadSignalPort double:
+get_active_leads (threshold filter + highest-score-first ordering + range guard),
+get_lead_score (known / unknown → LeadNotFound), the fail_on_call provider-error path,
+the value types (Decimal numerics, opaque handles), the error hierarchy, and the read-only
+INVARIANT (the port exposes NO contact / outreach / nurture / write method).
+
+asyncio_mode = "auto" (pyproject.toml): every ``async def test_*`` is auto-collected.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import inspect
+
+import pytest
+
+from services.lead_scoring.lead_signal_port import (
+    InMemoryLeadSignalPort,
+    LeadNotFound,
+    LeadScore,
+    LeadScoreBand,
+    LeadSignal,
+    LeadSignalCode,
+    LeadSignalPort,
+    LeadSignalPortError,
+    LeadStage,
+    ScoredLead,
+)
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _score(
+    lead_id: str,
+    *,
+    cohort: str = "organic-eu",
+    score: str = "0.50",
+    band: LeadScoreBand = LeadScoreBand.WARM,
+    stage: LeadStage = LeadStage.ONBOARDING,
+) -> LeadScore:
+    return LeadScore(
+        lead_id=lead_id,
+        cohort=cohort,
+        score=Decimal(score),
+        band=band,
+        stage=stage,
+        signals=(
+            LeadSignal(code=LeadSignalCode.FEATURE_ENGAGEMENT, weight=Decimal("0.40"), detail="e"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. get_active_leads — threshold filter + ordering
+# ---------------------------------------------------------------------------
+
+
+async def test_active_leads_filters_by_threshold_and_orders_high_first() -> None:
+    port = InMemoryLeadSignalPort(
+        scores={
+            "a": _score("a", score="0.90", band=LeadScoreBand.HOT, stage=LeadStage.ACTIVE),
+            "b": _score("b", score="0.50"),
+            "c": _score("c", score="0.10", band=LeadScoreBand.COLD, stage=LeadStage.SIGNUP),
+        }
+    )
+    result = await port.get_active_leads(Decimal("0.40"))
+
+    assert [lead.lead_id for lead in result] == ["a", "b"]  # c (0.10) excluded; ordered desc
+    assert all(isinstance(lead, ScoredLead) for lead in result)
+    assert result[0].score == Decimal("0.90")
+    assert result[0].band is LeadScoreBand.HOT
+    assert result[0].stage is LeadStage.ACTIVE
+    assert result[0].cohort == "organic-eu"
+
+
+async def test_active_leads_threshold_zero_returns_all() -> None:
+    port = InMemoryLeadSignalPort()  # default seed: 2 leads
+    result = await port.get_active_leads(Decimal("0"))
+    assert len(result) == 2
+
+
+async def test_active_leads_high_threshold_returns_empty() -> None:
+    port = InMemoryLeadSignalPort()
+    result = await port.get_active_leads(Decimal("1"))
+    assert result == []
+
+
+@pytest.mark.parametrize("bad", [Decimal("-0.01"), Decimal("1.01")])
+async def test_active_leads_threshold_out_of_range_raises(bad: Decimal) -> None:
+    port = InMemoryLeadSignalPort()
+    with pytest.raises(LeadSignalPortError, match="threshold out of range"):
+        await port.get_active_leads(bad)
+
+
+# ---------------------------------------------------------------------------
+# 2. get_lead_score — known / unknown
+# ---------------------------------------------------------------------------
+
+
+async def test_get_lead_score_known_returns_score() -> None:
+    port = InMemoryLeadSignalPort(scores={"lead-x": _score("lead-x", score="0.77")})
+    out = await port.get_lead_score("lead-x")
+    assert isinstance(out, LeadScore)
+    assert out.lead_id == "lead-x"
+    assert out.score == Decimal("0.77")
+    assert out.signals[0].code is LeadSignalCode.FEATURE_ENGAGEMENT
+
+
+async def test_get_lead_score_unknown_raises_lead_not_found() -> None:
+    port = InMemoryLeadSignalPort(scores={})
+    with pytest.raises(LeadNotFound, match="Unknown lead"):
+        await port.get_lead_score("nope")
+
+
+async def test_default_seed_has_expected_leads() -> None:
+    port = InMemoryLeadSignalPort()
+    out = await port.get_lead_score("lead-1001")
+    assert out.band is LeadScoreBand.HOT
+    assert out.stage is LeadStage.ACTIVATED
+    assert out.score == Decimal("0.88")
+    assert len(out.signals) == 2
+
+
+# ---------------------------------------------------------------------------
+# 3. fail_on_call — provider-error path on every read
+# ---------------------------------------------------------------------------
+
+
+async def test_fail_on_call_raises_on_active_leads() -> None:
+    port = InMemoryLeadSignalPort(fail_on_call=True)
+    with pytest.raises(LeadSignalPortError, match="configured to fail"):
+        await port.get_active_leads(Decimal("0.50"))
+
+
+async def test_fail_on_call_raises_on_get_lead_score() -> None:
+    port = InMemoryLeadSignalPort(fail_on_call=True)
+    with pytest.raises(LeadSignalPortError, match="configured to fail"):
+        await port.get_lead_score("lead-1001")
+
+
+# ---------------------------------------------------------------------------
+# 4. Value types / enums (I-01 Decimal, opaque handles)
+# ---------------------------------------------------------------------------
+
+
+def test_value_types_are_decimal_and_opaque() -> None:
+    sig = LeadSignal(code=LeadSignalCode.SESSION_RECENCY, weight=Decimal("0.5"))
+    assert sig.detail == ""  # default
+    lead = ScoredLead(
+        lead_id="l1",
+        cohort="coh",
+        score=Decimal("0.6"),
+        band=LeadScoreBand.WARM,
+        stage=LeadStage.ONBOARDING,
+    )
+    assert isinstance(lead.score, Decimal)
+    ls = LeadScore(
+        lead_id="l1",
+        cohort="coh",
+        score=Decimal("0.6"),
+        band=LeadScoreBand.WARM,
+        stage=LeadStage.ONBOARDING,
+    )
+    assert ls.signals == ()  # default empty
+
+
+def test_enum_values() -> None:
+    assert LeadScoreBand.COLD.value == "COLD"
+    assert LeadScoreBand.WARM.value == "WARM"
+    assert LeadScoreBand.HOT.value == "HOT"
+    assert LeadStage.SIGNUP.value == "SIGNUP"
+    assert LeadStage.ONBOARDING.value == "ONBOARDING"
+    assert LeadStage.ACTIVATED.value == "ACTIVATED"
+    assert LeadStage.ACTIVE.value == "ACTIVE"
+    assert LeadSignalCode.SIGNUP_COMPLETED.value == "SIGNUP_COMPLETED"
+    assert LeadSignalCode.PROFILE_COMPLETION.value == "PROFILE_COMPLETION"
+    assert LeadSignalCode.ONBOARDING_PROGRESS.value == "ONBOARDING_PROGRESS"
+    assert LeadSignalCode.FEATURE_ENGAGEMENT.value == "FEATURE_ENGAGEMENT"
+    assert LeadSignalCode.SESSION_RECENCY.value == "SESSION_RECENCY"
+
+
+def test_error_hierarchy() -> None:
+    assert issubclass(LeadNotFound, LeadSignalPortError)
+    assert issubclass(LeadSignalPortError, Exception)
+
+
+# ---------------------------------------------------------------------------
+# 5. INVARIANT: the port is READ-ONLY — no contact/outreach/nurture/write method
+# ---------------------------------------------------------------------------
+
+
+def test_port_is_read_only_no_mutating_methods() -> None:
+    """LeadSignalPort exposes ONLY the two reads — no contact/outreach/nurture/write op.
+
+    This is the contract-level enforcement of the agent's read-only invariant: a mutating
+    op cannot be reached because no such method exists on the port at all.
+    """
+    public = {
+        n
+        for n, _ in inspect.getmembers(LeadSignalPort, inspect.isfunction)
+        if not n.startswith("_")
+    }
+    assert public == {"get_active_leads", "get_lead_score"}
+    forbidden = ("contact", "outreach", "nurture", "email", "send", "write", "update", "set_")
+    for name in public:
+        assert not any(tok in name.lower() for tok in forbidden), name
+
+
+def test_abstract_port_cannot_be_instantiated() -> None:
+    with pytest.raises(TypeError):
+        LeadSignalPort()  # type: ignore[abstract]


### PR DESCRIPTION
## IL-190 — Sprint-55 LeadScoringAgent (Tier-3 BUILD; LeadSignalPort + L1 read-only mask)

ORG-STRUCTURE §2.8 Front Office / Sales `LeadScoringAgent` (L1 Auto, "Behavioral scoring (signup → active)"): **PROPOSED → IMPLEMENTED**. Second Tier-3 BUILD of the audit IL-176 remainder, following the **IL-189 ChurnPredictionAgent** read-only pattern (new read-only port + thin §D2 mask).

**Distinction:** there is NO existing lead/sales/marketing domain (`referral/` + `crm/` exist but are NOT lead scoring), so this is a full BUILD. `LeadSignalPort` is a read-only CONTRACT abstraction; the real adapter (ClickHouse behavioral events + scikit-learn propensity model behind the port) is a later sprint (I-10: no fake integrations now).

### ETAP A — port (`services/lead_scoring/lead_signal_port.py`)
- READ-ONLY `LeadSignalPort`: `get_active_leads(threshold: Decimal) -> list[ScoredLead]` (highest-score first) + `get_lead_score(lead_id) -> LeadScore`.
- `abc.ABC` + `InMemoryLeadSignalPort` + `LeadSignalPortError` (+ `LeadNotFound`).
- Frozen value types `ScoredLead`/`LeadScore`/`LeadSignal`; `LeadScoreBand`/`LeadStage`/`LeadSignalCode` enums.
- NO mutate/contact/outreach/write method on the port at all (I-10/I-27). Decimal for every numeric.

### ETAP B — mask (`services/agents/lead_scoring_agent.py`)
- L1-Auto `LeadScoringAgent`, full ADR-049 §D2 gate-chain (process_ref → scope → band → cost_cap → compliance(PII) → port), one ADR-046 `AgentDecisionRecord` per action on every exit path; port + `DecisionRecorder` injected.
- Reads AUTO-only: below-AUTO → `HALT_REVIEW_DEFERRED` (no HITL hold, no biometric step-up).
- **INVARIANT (tested):** scores/reports only — never contacts a lead or mutates state autonomously; any contact/outreach/write op is `REJECT_OUT_OF_SCOPE` (scope = the 2 read ops; the port has no mutate method; success_actions are `SCORE_`/`REPORT_` verbs only). compliance non-PASS → BLOCK + escalate→DPO.
- Provider-error: `LeadSignalPortError` (incl. `LeadNotFound`) → emit(executed=False) + reraise. **R-SEC:** only opaque handles (lead_id / cohort) in lineage — never scores/weights/PII; `list[ScoredLead]` / `LeadScore` ride on `AgentOutcome.result` only.

### Tests & proof
- `tests/test_lead_scoring/test_lead_signal_port.py` + `tests/agents/test_lead_scoring_agent.py` — **43 tests, 100% coverage on BOTH new modules**.
- Covers: AUTO happy path, HALT_UNRESOLVED_PROCESS, REJECT_OUT_OF_SCOPE (contact/outreach refused), HALT_REVIEW_DEFERRED (port not called), BLOCK_LOW_CONFIDENCE, HALT_COST_CAP_BREACH (per-request + per-window), HALT_COMPLIANCE_BLOCK, HALT_PROVIDER_ERROR (emit+reraise), invalid confidence → ValueError, R-SEC, ADR-046 (1 record/action), read-only INVARIANT.
- Full suite: **10896 passed / 37 skipped / 0 failed**; `ruff check` + `ruff format --check` clean.

### Doc-sync (banxe-architecture, separate PR)
ORG §2.8 `(PROPOSED)` removed on `LeadScoringAgent` only; new `### IL-190` block; MEMORY sprint-55 block; `instruction-ledger/sprint-55/IL-LEAD-01-*.md`. NO new ADR (fits the existing L1 read-only ADR-049 §D2 pattern).

**Refs:** ADR-049 §D2; ADR-046; ADR-016 (PII); audit IL-176 (BUILD); IL-189 ChurnPredictionAgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)