### PR TITLE
feat(incident-response): IncidentResponseAgent + IncidentSignalPort (Tier-3, L2, CRITICAL→CTO+CEO step-up) [IL-196]

### DIFF
--- a/services/agents/_lineage.py
+++ b/services/agents/_lineage.py
@@ -173,6 +173,10 @@ class AgentOutcome:
     requires_step_up: bool = False
     requires_hitl: bool = False
     escalated_to: str | None = None
+    # Escalation SLA in hours (additive, defaults None). Set by masks with a
+    # regulatory notification deadline — e.g. the IncidentResponse mask carries the
+    # FCA SYSC 8.1 ≤2h CRITICAL CTO+CEO notification SLA. Other masks leave it None.
+    sla_hours: int | None = None
 
 
 class DecisionRecorder(ABC):

--- a/services/agents/incident_response_agent.py
+++ b/services/agents/incident_response_agent.py
@@ -1,0 +1,631 @@
+"""IncidentResponseAgent — L2 security-incident triage agent (ORG §2.7.4, SYSC 8.1 mask).
+
+WHY: ORG-STRUCTURE §2.7.4 (Security & Compliance) specifies the
+``IncidentResponseAgent`` (L2; gate **CTO + CEO for CRITICAL**). This module is the
+emi-stack analogue of the §D2 masks (``campaign_agent.py`` / ``kyc_onboarding_agent.py``):
+it implements the agent *logic* and *governance enforcement* of the incident-response
+mask over :class:`~services.incident_response.incident_signal_port.IncidentSignalPort`;
+it does NOT implement the port, any SIEM/pager adapter, the LLM-orchestration/routing
+layer (``AGENT_ROUTING_ENABLED`` stays out of scope), or any lineage sink. The
+observability / device-fingerprint / ATO-prevention domains are NOT touched — they are
+read-only signal sources the port derives from.
+
+THE REGULATORY INVARIANT (FCA SYSC 8.1 — enforced in code AND test)
+-------------------------------------------------------------------
+A security incident classified CRITICAL can NEVER be auto-resolved / suppressed /
+closed by the agent. It MUST force a step-up escalation to **CTO + CEO regardless of
+confidence**, flagged with a ≤2h notification SLA. The agent may triage / classify and
+propose, but a CRITICAL disposition proceeds ONLY with a human (CTO + CEO) reviewer:
+with no reviewer the action HALTS, the triage disposition is NEVER committed, and the
+action escalates to CTO + CEO with ``sla_hours = 2``. The signal port exposes no close
+seam at all, so auto-closure is impossible by construction (defence-in-depth).
+
+The incident mask (ORG §2.7.4), enforced in the fixed §D2 chain order
+(process_ref → scope → band → cost_cap → compliance → step-up → port call):
+
+* ``scope``               — :class:`IncidentSignalPort` ops only (the allow-list:
+                            get_incidents / get_incident / classify_severity).
+* ``autonomy_level``      — REVIEW (L2). Reads (list/inspect) are AUTO-eligible within
+                            cap; non-critical triage is REVIEW-biased; a CRITICAL triage
+                            is a mandatory CTO+CEO step-up regardless of confidence.
+* ``confirmation_policy`` — AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70 (ADR-047).
+* ``cost_cap``            — per-request AND per-window hard caps, token AND monetary.
+* ``lineage_obligation``  — one ``AgentDecisionRecord`` per action (ADR-046), on every
+                            exit path.
+* ``compliance_gate``     — SYSC 8.1 + security; a non-PASS result halts AND escalates
+                            to CTO + CEO.
+* ``critical_step_up``    — SYSC 8.1: a CRITICAL incident closure requires CTO + CEO
+                            sign-off (mandatory step-up, never autonomous), ≤2h SLA.
+
+Mask *values* (caps, thresholds, scope, gate, escalation role, SLA) are config-as-data,
+carried on :class:`IncidentResponseMask`, never hardcoded in flow logic — EXCEPT the
+SYSC 8.1 CRITICAL step-up, which is a hard regulatory floor mask config can only
+*strengthen*, never disable.
+
+R-SEC (ADR-021): the lineage record carries opaque metadata ONLY — ``incident_id`` and
+the derived severity/source, never raw security payloads, log lines, or PII.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.incident_response.incident_signal_port import (
+    IncidentSeverity,
+    IncidentSignalPort,
+    IncidentSignalPortError,
+)
+
+# ---------------------------------------------------------------------------
+# Mask vocabulary
+# ---------------------------------------------------------------------------
+
+
+class AutonomyLevel(StrEnum):
+    """Mask autonomy posture. Incident triage is REVIEW-biased: reads are AUTO-eligible,
+    non-critical triage is L2 HITL-capable, a CRITICAL triage is mandatory CTO+CEO."""
+
+    AUTO_BIASED = "auto_biased"
+    REVIEW_BIASED = "review_biased"
+
+
+# ---------------------------------------------------------------------------
+# Value types — mask config (shared cost/lineage primitives live in ``_lineage``)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IncidentResponseMask:
+    """Config-as-data incident-response mask (ORG §2.7.4). The SYSC 8.1 CRITICAL
+    step-up is a regulatory floor: a CRITICAL incident ALWAYS forces a CTO+CEO
+    step-up with the ``critical_sla_hours`` deadline — config can strengthen the
+    escalation role / SLA but can never disable the step-up."""
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    autonomy_level: AutonomyLevel = AutonomyLevel.REVIEW_BIASED
+    lineage_obligation: bool = True
+    # The human double a CRITICAL incident (and any compliance/security escalation)
+    # is forced up to — FCA SYSC 8.1 / ORG §2.7.4 line 430: CTO + CEO.
+    critical_escalation_role: str = "CTO+CEO"
+    # FCA SYSC 8.1: CEO must be notified of a CRITICAL security incident within 2h.
+    critical_sla_hours: int = 2
+    agent_id: str = "incident_response_agent"
+
+    # The mask scope (ADR-049 §D3 allow-list): the only port ops this mask may reach.
+    # There is intentionally no close/suppress op — the port exposes none.
+    scope: tuple[str, ...] = (
+        "IncidentSignalPort.get_incidents",
+        "IncidentSignalPort.get_incident",
+        "IncidentSignalPort.classify_severity",
+    )
+
+    # Compliance contour required before any triage disposition.
+    compliance_gate: tuple[str, ...] = ("SYSC8_1", "SECURITY")
+
+
+@dataclass
+class ListIncidentsIntent:
+    """A resolved low-consequence read intent (``get_incidents``) — AUTO-eligible; a
+    read below the AUTO band halts for a re-check, not a HITL hold."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    severity: IncidentSeverity | None = None
+
+
+@dataclass
+class InspectIncidentIntent:
+    """A resolved low-consequence read intent (``get_incident``) for one incident."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    incident_id: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class TriageIncidentIntent:
+    """A resolved intent to TRIAGE / dispose an incident (classify + close-or-escalate).
+
+    SYSC 8.1 mandatory step-up: a CRITICAL ``severity`` triage is NEVER autonomous — it
+    forces a CTO+CEO step-up regardless of the confidence band and proceeds only with a
+    human reviewer. With no reviewer the disposition HALTS and is never committed; the
+    incident is left for CTO+CEO with a ≤2h SLA. Non-critical triage is normal L2."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    incident_id: str
+    severity: IncidentSeverity
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    """All inputs a single masked action evaluates against."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+    # SYSC 8.1 CRITICAL step-up: True when this triage disposes a CRITICAL incident and
+    # therefore needs a CTO+CEO reviewer to proceed (mandatory, regardless of band).
+    requires_critical_escalation: bool = False
+    human_reviewed_by: str | None = None
+    # REVIEW-biased triage holds for HITL in the REVIEW band; pure reads instead halt
+    # below AUTO. Defaults False so the read path is unchanged.
+    supports_review_hitl: bool = False
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+    sla_hours: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class IncidentResponseAgent:
+    """L2 security-incident triage agent enforcing the ORG §2.7.4 / SYSC 8.1 mask.
+
+    The signal port and the lineage recorder are injected as interfaces; the agent
+    contains pure governance logic and is unit-testable without any live infra.
+    """
+
+    def __init__(
+        self,
+        *,
+        signal_port: IncidentSignalPort,
+        recorder: DecisionRecorder,
+        mask: IncidentResponseMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._port = signal_port
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def list_incidents(
+        self,
+        intent: ListIncidentsIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Low-consequence read via ``IncidentSignalPort.get_incidents`` — AUTO-eligible,
+        no HITL hold and no step-up (the mask's within-cap read path)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"list_incidents:{intent.severity.value if intent.severity else 'all'}",
+            success_action="LIST_INCIDENTS",
+            op="IncidentSignalPort.get_incidents",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_incidents(intent.severity))
+
+    async def inspect_incident(
+        self,
+        intent: InspectIncidentIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Low-consequence read of one incident via ``IncidentSignalPort.get_incident``."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"inspect_incident:{intent.incident_id}",
+            success_action="INSPECT_INCIDENT",
+            op="IncidentSignalPort.get_incident",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(ctx, lambda: self._port.get_incident(intent.incident_id))
+
+    async def triage_incident(
+        self,
+        intent: TriageIncidentIntent,
+        *,
+        human_reviewed_by: str | None = None,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Triage / dispose an incident — the regulated SYSC 8.1 path.
+
+        A CRITICAL incident is NEVER auto-closed: it forces a step-up to CTO+CEO and
+        proceeds only with a ``human_reviewed_by`` sign-off, regardless of the
+        confidence band (even at confidence 1.0). With no reviewer the action HALTS,
+        no disposition is committed (the port has no close seam), and the action
+        escalates to CTO+CEO with the ≤2h SLA. Non-critical triage is normal L2.
+
+        The disposition commits no port mutation (the port is read+classify only) — a
+        triage verdict is recorded solely as ADR-046 lineage (``port_call=None``).
+        """
+        is_critical = intent.severity is IncidentSeverity.CRITICAL
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"triage_incident:{intent.incident_id}:{intent.severity.value}",
+            success_action="TRIAGE_INCIDENT",
+            op="IncidentSignalPort.classify_severity",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            requires_critical_escalation=is_critical,
+            human_reviewed_by=human_reviewed_by,
+            supports_review_hitl=True,
+        )
+        return await self._run_action(ctx, port_call=None)
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be in [0.0, 1.0]")
+        policies = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no port call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. ADR-049 §D3 — mask scope allow-list; an off-list op is refused outright.
+        #    A close/suppress op is never on the allow-list → auto-close refused.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op} is not on the incident mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band (AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70).
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+        if band is ConfirmationDecision.BLOCK:
+            # Low confidence on a CRITICAL triage still escalates to CTO+CEO.
+            escalated = (
+                self._mask.critical_escalation_role if ctx.requires_critical_escalation else None
+            )
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+                escalated_to=escalated,
+                sla_hours=self._mask.critical_sla_hours
+                if ctx.requires_critical_escalation
+                else None,
+            )
+        if band is ConfirmationDecision.REVIEW and not ctx.supports_review_hitl:
+            # Read path: reads are AUTO-only, so a below-AUTO read halts for a
+            # re-check at higher confidence, not a HITL hold.
+            return _Evaluation(
+                band,
+                False,
+                "HALT_REVIEW_DEFERRED",
+                "Read intent below AUTO band; reads are AUTO-only, no HITL hold.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="review_deferred",
+                requires_hitl=True,
+            )
+
+        # REVIEW-biased non-critical triage requires a human reviewer in the REVIEW
+        # band; the CRITICAL path is gated by the mandatory step-up below, not here.
+        needs_reviewer = (
+            ctx.supports_review_hitl
+            and not ctx.requires_critical_escalation
+            and band is ConfirmationDecision.REVIEW
+        )
+        if needs_reviewer and ctx.human_reviewed_by is None:
+            policies.append("ADR-049-D3-review-HITL")
+            return _Evaluation(
+                band,
+                False,
+                "HOLD_FOR_REVIEW",
+                "REVIEW-band triage paused for HITL; proceeds once a reviewer is supplied.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="hitl_review_required",
+                requires_hitl=True,
+            )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window); action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. Compliance gate (SYSC 8.1 + security). A non-PASS result halts AND
+        #    escalates to CTO+CEO.
+        policies.append("SYSC8.1-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"Compliance gate returned {ctx.compliance_result}; action blocked and "
+                f"escalated to {self._mask.critical_escalation_role}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=self._mask.critical_escalation_role,
+            )
+
+        # 6. SYSC 8.1 MANDATORY CTO+CEO STEP-UP — a CRITICAL incident can NEVER be
+        #    auto-closed: it requires a CTO+CEO reviewer regardless of the confidence
+        #    band, else HALT and escalate to CTO+CEO with the ≤2h SLA (no close).
+        if ctx.requires_critical_escalation and ctx.human_reviewed_by is None:
+            policies.append("SYSC8.1-CRITICAL-CTO-CEO-step-up")
+            return _Evaluation(
+                band,
+                False,
+                "HALT_CRITICAL_ESCALATION_REQUIRED",
+                "CRITICAL security incident requires CTO+CEO sign-off (FCA SYSC 8.1): no "
+                "reviewer — forced step-up, never auto-closed, escalated with a ≤2h SLA.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="critical_escalation_required",
+                requires_step_up=True,
+                requires_hitl=True,
+                escalated_to=self._mask.critical_escalation_role,
+                sla_hours=self._mask.critical_sla_hours,
+            )
+
+        # All gates satisfied — clear to commit the triage disposition.
+        reviewer = (
+            "" if ctx.human_reviewed_by is None else f" (reviewed by {ctx.human_reviewed_by})"
+        )
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All mask gates satisfied at {band.value} confidence{reviewer}; committing within scope.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+            # A CRITICAL triage that proceeds did so under CTO+CEO sign-off — surface the
+            # SYSC 8.1 SLA for the audit trail; non-critical dispositions carry none.
+            sla_hours=self._mask.critical_sla_hours if ctx.requires_critical_escalation else None,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+        compliance_result = ev.compliance_result
+        escalated_to = ev.escalated_to
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except IncidentSignalPortError as exc:
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=compliance_result,
+                        reasoning=f"Signal port rejected the action: {exc}",
+                        escalated_to=escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_step_up=ev.requires_step_up,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=escalated_to,
+            sla_hours=ev.sla_hours,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        return await self._record(
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies=ev.policies,
+            compliance_result=compliance_result,
+            reasoning=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=ctx.human_reviewed_by,
+            correlation_id=ctx.correlation_id,
+            request_cost=ctx.request_cost,
+            budget_breach=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+
+    async def _record(
+        self,
+        *,
+        triggering_event: str,
+        intent: str,
+        policies: list[str],
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        confidence_score: float,
+        action_taken: str,
+        human_reviewed_by: str | None,
+        correlation_id: str,
+        request_cost: RequestCost,
+        budget_breach: BudgetBreach,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        """Build, persist, and return exactly one ADR-046 lineage record (the single
+        producer→sink seam used by every exit path). R-SEC: opaque metadata only —
+        ``intent``/``triggering_event`` carry incident_id/severity, never raw data/PII."""
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=triggering_event,
+            intent=intent,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=human_reviewed_by,
+            correlation_id=correlation_id,
+            cost_tokens=request_cost.tokens,
+            cost_amount=request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "AutonomyLevel",
+    "BudgetBreach",
+    "ComplianceResult",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "IncidentResponseAgent",
+    "IncidentResponseMask",
+    "InspectIncidentIntent",
+    "ListIncidentsIntent",
+    "ProcessRef",
+    "RequestCost",
+    "TriageIncidentIntent",
+]

--- a/services/incident_response/__init__.py
+++ b/services/incident_response/__init__.py
@@ -1,0 +1,8 @@
+"""Incident-response signal derivation (read-only) — IL-195 / Sprint-57.
+
+Houses the :mod:`incident_signal_port` hexagonal contract used by the
+``IncidentResponseAgent`` (ORG §2.7.4) to triage security incidents. The port is
+READ + classify only: it derives incident signals from the existing read-only
+observability / device-fingerprint / ATO-prevention sources and never closes or
+suppresses an incident.
+"""

--- a/services/incident_response/incident_signal_port.py
+++ b/services/incident_response/incident_signal_port.py
@@ -1,0 +1,268 @@
+"""incident_signal_port.py — IncidentSignalPort: read-only security-incident triage contract.
+
+ORG-STRUCTURE §2.7.4 (Security & Compliance) — ``IncidentResponseAgent`` (L2; gate
+**CTO + CEO for CRITICAL**). This port isolates the incident-triage domain from any
+single signal source so adapters can be swapped without touching agent logic. It is
+the emi-stack analogue of ``fraud_port.py`` / ``campaign_port.py``.
+
+Referenced canon:
+  ORG §2.7.4        Security incident triage — AI may triage/classify, NEVER auto-close
+  FCA SYSC 8.1      Security incident CRITICAL → CEO notified within 2h
+  ADR-049 §D2/§D3   mask gate-chain + scope allow-list
+  ADR-021 / R-SEC   opaque metadata only — never raw security data or recipient PII
+
+THE READ + CLASSIFY BOUNDARY (enforced by construction)
+-------------------------------------------------------
+This port exposes EXACTLY three capabilities — :meth:`get_incidents`,
+:meth:`get_incident` (reads) and :meth:`classify_severity` (a pure read-only triage
+helper). It deliberately offers **no** close / resolve / suppress operation: an
+``IncidentResponseAgent`` therefore *cannot* auto-close or suppress a security
+incident through this port. Closure of a CRITICAL incident is a human (CTO + CEO)
+decision recorded outside this read seam (forced step-up at the agent's governance
+layer). This is defence-in-depth: the boundary is structural, not merely policy.
+
+SIGNAL DERIVATION (read-only, no domain mutation)
+-------------------------------------------------
+Incident signals are DERIVED read-only from the existing observability
+(``services/observability``), device-fingerprint (``services/device_fingerprint``)
+and ATO-prevention (``services/ato_prevention``) sources — see :class:`IncidentSource`.
+This port does NOT import, own, or mutate those domains; a production adapter would
+poll them (and a real SIEM/pager) — that integration is a LATER sprint (I-10: no fake
+integrations now). This module ships the contract + an in-memory double for unit
+tests only.
+
+R-SEC (ADR-021): :class:`IncidentSignal` carries opaque metadata ONLY — an
+``incident_id``, its derived ``severity`` / ``source`` / composite ``signal_score`` —
+never raw security payloads, log lines, credentials, or recipient PII.
+"""
+
+from __future__ import annotations
+
+import abc
+from abc import abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class IncidentSeverity(StrEnum):
+    """Triage severity for a security incident (FCA SYSC 8.1 escalation bands).
+
+    CRITICAL is the regulated band: it can NEVER be auto-closed by the agent and
+    forces a step-up to CTO + CEO with a ≤2h notification SLA.
+    """
+
+    LOW = "LOW"  # score < 40 — informational, AUTO-triageable
+    MEDIUM = "MEDIUM"  # score 40-69 — standard L2 triage
+    HIGH = "HIGH"  # score 70-84 — elevated; HITL-biased triage
+    CRITICAL = "CRITICAL"  # score >= 85 — mandatory CTO+CEO step-up, never auto-closed
+
+
+class IncidentStatus(StrEnum):
+    """Lifecycle status of a derived incident signal (read-only to the agent)."""
+
+    OPEN = "open"
+    TRIAGED = "triaged"
+    ESCALATED = "escalated"
+    CLOSED = "closed"
+
+
+class IncidentSource(StrEnum):
+    """The read-only signal source an incident was DERIVED from (never mutated)."""
+
+    COMPLIANCE_MONITOR = "observability.compliance_monitor"
+    HEALTH_AGGREGATOR = "observability.health_aggregator"
+    METRICS_COLLECTOR = "observability.metrics_collector"
+    ANOMALY_DETECTOR = "device_fingerprint.anomaly_detector"
+    ATO_ENGINE = "ato_prevention.ato_engine"
+    VELOCITY_CHECKER = "ato_prevention.velocity_checker"
+
+
+# Score → severity thresholds (mirrors the fraud_port band convention).
+_SEVERITY_BANDS: tuple[tuple[int, IncidentSeverity], ...] = (
+    (85, IncidentSeverity.CRITICAL),
+    (70, IncidentSeverity.HIGH),
+    (40, IncidentSeverity.MEDIUM),
+)
+
+
+# ---------------------------------------------------------------------------
+# Value object
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IncidentSignal:
+    """A read-only security-incident signal derived from a source.
+
+    R-SEC: opaque metadata only — ``incident_id`` / ``severity`` / ``source`` /
+    ``signal_score`` are loggable; no raw security data or PII is ever carried here.
+    """
+
+    incident_id: str
+    severity: IncidentSeverity
+    source: IncidentSource
+    signal_score: int  # 0-100 composite triage score (opaque)
+    status: IncidentStatus
+    detected_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy (all carry correlation_id for the audit trail)
+# ---------------------------------------------------------------------------
+
+
+class IncidentSignalPortError(Exception):
+    """Base for all incident-signal-port errors. Carries ``correlation_id`` so the
+    adapter can write an audit row before re-raising."""
+
+    def __init__(self, message: str, *, correlation_id: str) -> None:
+        super().__init__(message)
+        self.correlation_id: str = correlation_id
+
+
+class IncidentNotFound(IncidentSignalPortError):
+    """incident_id not present in the signal store."""
+
+
+class SignalSourceUnavailable(IncidentSignalPortError):
+    """A signal source is down or returned a transient error (caller retries)."""
+
+
+# ---------------------------------------------------------------------------
+# Abstract port
+# ---------------------------------------------------------------------------
+
+
+class IncidentSignalPort(abc.ABC):
+    """Abstract contract for read-only security-incident triage.
+
+    Boundary: READ + classify only. There is intentionally NO close / resolve /
+    suppress method — auto-closure is impossible through this seam by construction.
+    """
+
+    @abstractmethod
+    async def get_incidents(
+        self, severity: IncidentSeverity | None = None
+    ) -> tuple[IncidentSignal, ...]:
+        """Return derived incident signals, optionally filtered by ``severity``
+        (``None`` returns all). Read-only; safe to poll.
+
+        Raises:
+            SignalSourceUnavailable: a derivation source is transiently unavailable.
+        """
+        ...
+
+    @abstractmethod
+    async def get_incident(self, incident_id: str) -> IncidentSignal:
+        """Return a single derived incident signal by id (read-only).
+
+        Raises:
+            IncidentNotFound: no signal with that ``incident_id``.
+            SignalSourceUnavailable: a derivation source is transiently unavailable.
+        """
+        ...
+
+    @abstractmethod
+    def classify_severity(self, signal_score: int) -> IncidentSeverity:
+        """Pure read-only triage helper: map a 0-100 composite signal score to a
+        :class:`IncidentSeverity` band. No I/O, no mutation — never closes anything."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-memory implementation (unit-test double — I-10: no real SIEM/pager yet)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryIncidentSignalPort(IncidentSignalPort):
+    """In-memory :class:`IncidentSignalPort` for unit tests. Holds derived signals in
+    a dict and classifies by score band. Records reads for assertions and exposes a
+    transient-failure switch so the agent's provider-error path can be exercised.
+
+    It has NO close/suppress method — mirroring the abstract boundary so a test can
+    prove the agent never auto-closes a CRITICAL incident through the port."""
+
+    def __init__(self, *, unavailable: SignalSourceUnavailable | None = None) -> None:
+        self._incidents: dict[str, IncidentSignal] = {}
+        self._unavailable = unavailable
+        self.get_incidents_calls: list[IncidentSeverity | None] = []
+        self.get_incident_calls: list[str] = []
+        self.classify_calls: list[int] = []
+
+    # -- test configuration --------------------------------------------------
+
+    def add_incident(
+        self,
+        incident_id: str,
+        *,
+        signal_score: int,
+        source: IncidentSource = IncidentSource.COMPLIANCE_MONITOR,
+        status: IncidentStatus = IncidentStatus.OPEN,
+        detected_at: datetime | None = None,
+        severity: IncidentSeverity | None = None,
+    ) -> IncidentSignal:
+        signal = IncidentSignal(
+            incident_id=incident_id,
+            severity=severity or self.classify_severity(signal_score),
+            source=source,
+            signal_score=signal_score,
+            status=status,
+            detected_at=detected_at or datetime(2026, 6, 12, tzinfo=None),
+        )
+        self._incidents[incident_id] = signal
+        # classify_severity is a derivation helper — exclude its bookkeeping from the
+        # caller-facing classify spy so add_incident does not pollute call assertions.
+        self.classify_calls.clear()
+        return signal
+
+    def set_unavailable(self, exc: SignalSourceUnavailable) -> None:
+        self._unavailable = exc
+
+    # -- port API ------------------------------------------------------------
+
+    async def get_incidents(
+        self, severity: IncidentSeverity | None = None
+    ) -> tuple[IncidentSignal, ...]:
+        self.get_incidents_calls.append(severity)
+        if self._unavailable is not None:
+            raise self._unavailable
+        signals = tuple(self._incidents.values())
+        if severity is not None:
+            signals = tuple(s for s in signals if s.severity is severity)
+        return signals
+
+    async def get_incident(self, incident_id: str) -> IncidentSignal:
+        self.get_incident_calls.append(incident_id)
+        if self._unavailable is not None:
+            raise self._unavailable
+        signal = self._incidents.get(incident_id)
+        if signal is None:
+            raise IncidentNotFound(
+                f"No incident signal for id: {incident_id}", correlation_id=incident_id
+            )
+        return signal
+
+    def classify_severity(self, signal_score: int) -> IncidentSeverity:
+        self.classify_calls.append(signal_score)
+        for floor, severity in _SEVERITY_BANDS:
+            if signal_score >= floor:
+                return severity
+        return IncidentSeverity.LOW
+
+
+__all__ = [
+    "InMemoryIncidentSignalPort",
+    "IncidentNotFound",
+    "IncidentSeverity",
+    "IncidentSignal",
+    "IncidentSignalPort",
+    "IncidentSignalPortError",
+    "IncidentSource",
+    "IncidentStatus",
+    "SignalSourceUnavailable",
+]

--- a/tests/agents/test_incident_response_agent.py
+++ b/tests/agents/test_incident_response_agent.py
@@ -1,0 +1,419 @@
+"""Tests for the ORG §2.7.4 / FCA SYSC 8.1 incident-response mask agent
+(services/agents/incident_response_agent.py).
+
+Covers every mask path in the §D2 gate-chain order: AUTO reads (list/inspect),
+non-critical triage AUTO + REVIEW (hold then proceed), the CRITICAL-escalation
+invariant (critical @ confidence 1.0 with no reviewer → HALT, forced step-up to
+CTO+CEO, ≤2h SLA, disposition never committed / incident never closed) and the
+critical-with-reviewer proceed path, HALT_UNRESOLVED_PROCESS, REJECT_OUT_OF_SCOPE
+(auto-close refused), HALT_REVIEW_DEFERRED, BLOCK_LOW_CONFIDENCE (critical +
+non-critical), HALT_COST_CAP_BREACH (per-request + per-window), HALT_COMPLIANCE_BLOCK,
+HALT_PROVIDER_ERROR (emit + reraise), invalid confidence → ValueError, R-SEC, and the
+one-lineage-record-per-action obligation (ADR-046). The port and recorder are fakes —
+the agent is exercised as pure governance logic with no live infra.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.agents.incident_response_agent import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    IncidentResponseAgent,
+    IncidentResponseMask,
+    InspectIncidentIntent,
+    ListIncidentsIntent,
+    ProcessRef,
+    RequestCost,
+    TriageIncidentIntent,
+)
+from services.incident_response.incident_signal_port import (
+    IncidentSeverity,
+    IncidentSource,
+    IncidentStatus,
+    InMemoryIncidentSignalPort,
+    SignalSourceUnavailable,
+)
+
+# ── Fakes / builders ───────────────────────────────────────────────────────────
+
+
+class FakeRecorder(DecisionRecorder):
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+def make_mask(**overrides) -> IncidentResponseMask:
+    base = {
+        "cost_cap": CostCap(
+            max_request_tokens=10_000,
+            max_request_cost=Decimal("1.00"),
+            max_window_tokens=100_000,
+            max_window_cost=Decimal("10.00"),
+        ),
+    }
+    base.update(overrides)
+    return IncidentResponseMask(**base)
+
+
+def make_agent(
+    *,
+    mask: IncidentResponseMask | None = None,
+    port: InMemoryIncidentSignalPort | None = None,
+    recorder: FakeRecorder | None = None,
+    cost_window: CostWindow | None = None,
+) -> tuple[IncidentResponseAgent, InMemoryIncidentSignalPort, FakeRecorder]:
+    port = port or InMemoryIncidentSignalPort()
+    recorder = recorder or FakeRecorder()
+    agent = IncidentResponseAgent(
+        signal_port=port,
+        recorder=recorder,
+        mask=mask or make_mask(),
+        cost_window=cost_window,
+    )
+    return agent, port, recorder
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    return (
+        ProcessRef(process_id="PROC-INCIDENT-TRIAGE", version="1")
+        if resolved
+        else ProcessRef(process_id="", version="")
+    )
+
+
+def make_list_intent(
+    *, confidence: float = 0.99, severity: IncidentSeverity | None = None
+) -> ListIncidentsIntent:
+    return ListIncidentsIntent(
+        intent_text="List open security incidents",
+        process_ref=_ref(),
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=RequestCost(tokens=50, cost=Decimal("0.01")),
+        severity=severity,
+    )
+
+
+def make_inspect_intent(*, confidence: float = 0.99) -> InspectIncidentIntent:
+    return InspectIncidentIntent(
+        intent_text="Inspect incident INC-1",
+        process_ref=_ref(),
+        incident_id="INC-1",
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=RequestCost(tokens=50, cost=Decimal("0.01")),
+    )
+
+
+def make_triage_intent(
+    *,
+    severity: IncidentSeverity = IncidentSeverity.MEDIUM,
+    confidence: float = 0.95,
+    cost: RequestCost | None = None,
+    resolved: bool = True,
+) -> TriageIncidentIntent:
+    return TriageIncidentIntent(
+        intent_text="Triage incident INC-1",
+        process_ref=_ref(resolved),
+        incident_id="INC-1",
+        severity=severity,
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=cost or RequestCost(tokens=400, cost=Decimal("0.04")),
+    )
+
+
+# ── AUTO reads (list / inspect) ────────────────────────────────────────────────
+
+
+async def test_list_incidents_auto_executes():
+    agent, port, recorder = make_agent()
+    port.add_incident("INC-1", signal_score=10)
+    outcome = await agent.list_incidents(make_list_intent(confidence=0.99))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert outcome.requires_hitl is False
+    assert port.get_incidents_calls == [None]
+    assert recorder.records[0].action_taken == "LIST_INCIDENTS"
+    assert len(recorder.records) == 1
+
+
+async def test_list_incidents_with_severity_filter_labels_event():
+    agent, port, recorder = make_agent()
+    port.add_incident("INC-CRIT", signal_score=90)
+    outcome = await agent.list_incidents(
+        make_list_intent(confidence=0.99, severity=IncidentSeverity.CRITICAL)
+    )
+    assert outcome.executed is True
+    assert recorder.records[0].triggering_event == "list_incidents:CRITICAL"
+
+
+async def test_inspect_incident_auto_executes():
+    agent, port, recorder = make_agent()
+    port.add_incident("INC-1", signal_score=88, source=IncidentSource.ANOMALY_DETECTOR)
+    outcome = await agent.inspect_incident(make_inspect_intent())
+
+    assert outcome.executed is True
+    assert outcome.result is not None
+    assert port.get_incident_calls == ["INC-1"]
+    assert recorder.records[0].action_taken == "INSPECT_INCIDENT"
+
+
+async def test_read_below_auto_band_halts_for_recheck():
+    agent, port, recorder = make_agent()
+    outcome = await agent.list_incidents(make_list_intent(confidence=0.80))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert port.get_incidents_calls == []
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+# ── Non-critical triage (AUTO / REVIEW hold + proceed) ─────────────────────────
+
+
+async def test_noncritical_triage_auto_executes():
+    agent, _, recorder = make_agent()
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.MEDIUM, confidence=0.95)
+    )
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert outcome.sla_hours is None  # non-critical carries no SLA
+    assert recorder.records[0].action_taken == "TRIAGE_INCIDENT"
+
+
+async def test_noncritical_triage_review_band_holds_for_hitl():
+    agent, _, recorder = make_agent()
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.HIGH, confidence=0.80)
+    )
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.requires_hitl is True
+    assert recorder.records[0].action_taken == "HOLD_FOR_REVIEW"
+
+
+async def test_noncritical_triage_review_with_reviewer_proceeds():
+    agent, _, recorder = make_agent()
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.HIGH, confidence=0.80),
+        human_reviewed_by="soc-lead@banxe",
+    )
+    assert outcome.executed is True
+    assert recorder.records[0].human_reviewed_by == "soc-lead@banxe"
+    assert recorder.records[0].action_taken == "TRIAGE_INCIDENT"
+
+
+# ── CRITICAL escalation invariant (FCA SYSC 8.1) ───────────────────────────────
+
+
+async def test_critical_at_full_confidence_no_reviewer_halts_and_escalates():
+    """The marquee invariant: a CRITICAL incident at confidence 1.0 with NO reviewer
+    can NEVER be auto-closed — it forces a CTO+CEO step-up with a ≤2h SLA and never
+    commits a disposition (the incident is left untouched / never closed)."""
+    agent, port, recorder = make_agent()
+    port.add_incident("INC-1", signal_score=99, status=IncidentStatus.OPEN)
+
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.CRITICAL, confidence=1.0)
+    )
+
+    assert outcome.executed is False  # disposition NEVER committed
+    assert outcome.requires_step_up is True
+    assert outcome.requires_hitl is True
+    assert outcome.escalated_to == "CTO+CEO"
+    assert outcome.sla_hours == 2
+    assert outcome.halt_reason == "critical_escalation_required"
+    assert recorder.records[0].action_taken == "HALT_CRITICAL_ESCALATION_REQUIRED"
+    assert recorder.records[0].escalated_to == "CTO+CEO"
+    assert "SYSC8.1-CRITICAL-CTO-CEO-step-up" in recorder.records[0].policies_evaluated
+    # close never called: the incident is left exactly as it was (no domain mutation).
+    assert (await port.get_incident("INC-1")).status is IncidentStatus.OPEN
+
+
+async def test_critical_with_reviewer_proceeds_under_signoff():
+    agent, _, recorder = make_agent()
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.CRITICAL, confidence=0.99),
+        human_reviewed_by="cto-ceo@banxe",
+    )
+    assert outcome.executed is True
+    assert outcome.sla_hours == 2  # SYSC 8.1 SLA surfaced even on the signed-off path
+    assert recorder.records[0].human_reviewed_by == "cto-ceo@banxe"
+    assert recorder.records[0].action_taken == "TRIAGE_INCIDENT"
+
+
+async def test_critical_low_confidence_blocks_and_escalates_with_sla():
+    agent, _, recorder = make_agent()
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.CRITICAL, confidence=0.50)
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert outcome.escalated_to == "CTO+CEO"
+    assert outcome.sla_hours == 2
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+async def test_critical_step_up_cannot_be_disabled_by_mask_config():
+    # The CRITICAL step-up is a regulatory floor — even a permissive mask cannot auto-close.
+    agent, _, recorder = make_agent(mask=make_mask(auto_threshold=0.0, review_floor=0.0))
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.CRITICAL, confidence=1.0)
+    )
+    assert outcome.executed is False
+    assert recorder.records[0].action_taken == "HALT_CRITICAL_ESCALATION_REQUIRED"
+
+
+# ── BLOCK / scope / process resolution ─────────────────────────────────────────
+
+
+async def test_noncritical_low_confidence_blocks_without_escalation():
+    agent, _, recorder = make_agent()
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.MEDIUM, confidence=0.40)
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.escalated_to is None
+    assert outcome.sla_hours is None
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+async def test_unresolved_process_ref_blocks():
+    agent, _, recorder = make_agent()
+    outcome = await agent.triage_incident(make_triage_intent(resolved=False))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+async def test_out_of_scope_op_refused_auto_close():
+    # An op not on the mask allow-list is refused outright — a close/suppress op is
+    # never on the list, so auto-close is structurally refused.
+    agent, _, recorder = make_agent(mask=make_mask(scope=("IncidentSignalPort.get_incidents",)))
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.MEDIUM, confidence=0.95)
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "out_of_scope"
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+
+
+# ── Cost-cap breach ────────────────────────────────────────────────────────────
+
+
+async def test_per_request_cost_cap_breach_blocks():
+    agent, _, recorder = make_agent()
+    intent = make_triage_intent(cost=RequestCost(tokens=999_999, cost=Decimal("0.01")))
+    outcome = await agent.triage_incident(intent)
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+    assert recorder.records[0].action_taken == "HALT_COST_CAP_BREACH"
+
+
+async def test_per_window_cost_cap_breach_blocks():
+    window = CostWindow(used_tokens=99_900, used_cost=Decimal("0.00"))
+    agent, _, _ = make_agent(cost_window=window)
+    outcome = await agent.triage_incident(
+        make_triage_intent(cost=RequestCost(tokens=200, cost=Decimal("0.01")))
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+
+
+async def test_window_accumulates_on_successful_action():
+    window = CostWindow()
+    agent, _, _ = make_agent(cost_window=window)
+    await agent.triage_incident(
+        make_triage_intent(confidence=0.95, cost=RequestCost(tokens=300, cost=Decimal("0.02")))
+    )
+    assert window.used_tokens == 300
+    assert window.used_cost == Decimal("0.02")
+
+
+# ── Compliance gate → CTO+CEO escalation ───────────────────────────────────────
+
+
+async def test_compliance_fail_blocks_and_escalates():
+    agent, _, recorder = make_agent()
+    outcome = await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.MEDIUM),
+        compliance_result=ComplianceResult.FAIL,
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.escalated_to == "CTO+CEO"
+    assert recorder.records[0].compliance_result is ComplianceResult.FAIL
+    assert recorder.records[0].action_taken == "HALT_COMPLIANCE_BLOCK"
+
+
+# ── Provider error (emit + reraise) ────────────────────────────────────────────
+
+
+async def test_provider_error_records_then_raises():
+    port = InMemoryIncidentSignalPort()
+    port.add_incident("INC-1", signal_score=10)
+    port.set_unavailable(SignalSourceUnavailable("siem down", correlation_id="corr-1"))
+    agent, port, recorder = make_agent(port=port)
+
+    with pytest.raises(SignalSourceUnavailable):
+        await agent.inspect_incident(make_inspect_intent())
+
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_PROVIDER_ERROR:SignalSourceUnavailable"
+
+
+# ── R-SEC + lineage obligation (ADR-046) ───────────────────────────────────────
+
+
+async def test_rsec_lineage_carries_opaque_metadata_only():
+    agent, _, recorder = make_agent()
+    await agent.triage_incident(
+        make_triage_intent(severity=IncidentSeverity.CRITICAL, confidence=1.0)
+    )
+    rec = recorder.records[0]
+    # Only incident_id/severity ride on the record — never raw security data or PII.
+    assert "INC-1" in rec.triggering_event
+    assert "CRITICAL" in rec.triggering_event
+    assert rec.agent_id == "incident_response_agent"
+
+
+async def test_lineage_record_emitted_per_action_with_adr046_fields():
+    agent, _, recorder = make_agent()
+    await agent.triage_incident(make_triage_intent(confidence=0.95))
+    await agent.triage_incident(make_triage_intent(confidence=0.40))  # a halt also records
+    assert len(recorder.records) == 2
+
+    rec = recorder.records[0]
+    assert rec.record_id
+    assert rec.timestamp.tzinfo is not None
+    assert rec.agent_id == "incident_response_agent"
+    assert rec.intent == "Triage incident INC-1"
+    assert rec.correlation_id == "corr-1"
+    assert rec.policies_evaluated
+    assert 0.0 <= rec.confidence_score <= 1.0
+    assert rec.cost_tokens == 400
+    assert rec.budget_window_ref == "incident_response_agent:default"
+
+
+async def test_invalid_confidence_raises():
+    agent, _, _ = make_agent()
+    with pytest.raises(ValueError):
+        await agent.triage_incident(make_triage_intent(confidence=1.5))

--- a/tests/test_incident_response/test_incident_signal_port.py
+++ b/tests/test_incident_response/test_incident_signal_port.py
@@ -1,0 +1,149 @@
+"""Tests for the read-only IncidentSignalPort
+(services/incident_response/incident_signal_port.py).
+
+Covers the full read + classify surface: get_incidents (all + severity filter +
+source unavailability), get_incident (found / not-found / unavailable), the
+classify_severity band helper across every band and its boundaries, the error
+hierarchy correlation_id, and the in-memory double's spies. The port exposes NO
+close/suppress seam — auto-closure is impossible by construction.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from services.incident_response.incident_signal_port import (
+    IncidentNotFound,
+    IncidentSeverity,
+    IncidentSignal,
+    IncidentSignalPortError,
+    IncidentSource,
+    IncidentStatus,
+    InMemoryIncidentSignalPort,
+    SignalSourceUnavailable,
+)
+
+
+def make_port() -> InMemoryIncidentSignalPort:
+    return InMemoryIncidentSignalPort()
+
+
+# ── classify_severity bands (pure read-only helper) ────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("score", "expected"),
+    [
+        (0, IncidentSeverity.LOW),
+        (39, IncidentSeverity.LOW),
+        (40, IncidentSeverity.MEDIUM),
+        (69, IncidentSeverity.MEDIUM),
+        (70, IncidentSeverity.HIGH),
+        (84, IncidentSeverity.HIGH),
+        (85, IncidentSeverity.CRITICAL),
+        (100, IncidentSeverity.CRITICAL),
+    ],
+)
+def test_classify_severity_bands(score, expected):
+    port = make_port()
+    assert port.classify_severity(score) is expected
+    assert port.classify_calls == [score]
+
+
+# ── get_incidents (read; filter; unavailability) ───────────────────────────────
+
+
+async def test_get_incidents_returns_all_unfiltered():
+    port = make_port()
+    port.add_incident("INC-1", signal_score=10)
+    port.add_incident("INC-2", signal_score=90)
+
+    incidents = await port.get_incidents()
+
+    assert {i.incident_id for i in incidents} == {"INC-1", "INC-2"}
+    assert port.get_incidents_calls == [None]
+
+
+async def test_get_incidents_filters_by_severity():
+    port = make_port()
+    port.add_incident("INC-LOW", signal_score=10)
+    port.add_incident("INC-CRIT", signal_score=92)
+
+    crit = await port.get_incidents(IncidentSeverity.CRITICAL)
+
+    assert [i.incident_id for i in crit] == ["INC-CRIT"]
+    assert crit[0].severity is IncidentSeverity.CRITICAL
+    assert port.get_incidents_calls == [IncidentSeverity.CRITICAL]
+
+
+async def test_get_incidents_raises_when_source_unavailable():
+    port = make_port()
+    port.set_unavailable(SignalSourceUnavailable("siem down", correlation_id="corr-1"))
+    with pytest.raises(SignalSourceUnavailable):
+        await port.get_incidents()
+
+
+# ── get_incident (read; not-found; unavailability) ─────────────────────────────
+
+
+async def test_get_incident_returns_signal():
+    port = make_port()
+    port.add_incident(
+        "INC-7",
+        signal_score=88,
+        source=IncidentSource.ATO_ENGINE,
+        status=IncidentStatus.OPEN,
+        detected_at=datetime(2026, 6, 12, tzinfo=UTC),
+    )
+    signal = await port.get_incident("INC-7")
+
+    assert isinstance(signal, IncidentSignal)
+    assert signal.severity is IncidentSeverity.CRITICAL
+    assert signal.source is IncidentSource.ATO_ENGINE
+    assert port.get_incident_calls == ["INC-7"]
+
+
+async def test_get_incident_not_found_raises_with_correlation_id():
+    port = make_port()
+    with pytest.raises(IncidentNotFound) as exc:
+        await port.get_incident("nope")
+    assert exc.value.correlation_id == "nope"
+
+
+async def test_get_incident_raises_when_source_unavailable():
+    port = make_port()
+    port.add_incident("INC-1", signal_score=10)
+    port.set_unavailable(SignalSourceUnavailable("transient", correlation_id="c"))
+    with pytest.raises(SignalSourceUnavailable):
+        await port.get_incident("INC-1")
+
+
+# ── add_incident: explicit severity bypasses classify ──────────────────────────
+
+
+def test_add_incident_explicit_severity_skips_classify():
+    port = make_port()
+    signal = port.add_incident("INC-X", signal_score=10, severity=IncidentSeverity.CRITICAL)
+    # Explicit severity is honoured even though the score would classify LOW.
+    assert signal.severity is IncidentSeverity.CRITICAL
+    assert port.classify_calls == []  # classify spy not polluted by add_incident
+
+
+def test_add_incident_default_severity_uses_classify_and_clears_spy():
+    port = make_port()
+    signal = port.add_incident("INC-Y", signal_score=72)
+    assert signal.severity is IncidentSeverity.HIGH
+    # add_incident clears the classify spy so caller-facing assertions stay clean.
+    assert port.classify_calls == []
+
+
+# ── error hierarchy ────────────────────────────────────────────────────────────
+
+
+def test_error_base_carries_correlation_id():
+    err = IncidentSignalPortError("boom", correlation_id="corr-9")
+    assert err.correlation_id == "corr-9"
+    assert isinstance(IncidentNotFound("x", correlation_id="c"), IncidentSignalPortError)
+    assert isinstance(SignalSourceUnavailable("x", correlation_id="c"), IncidentSignalPortError)


### PR DESCRIPTION
## Sprint-57 / IL-195 — IncidentResponseAgent (Tier-3, port-first, L2 with CRITICAL→CTO+CEO gate)

**Source:** ORG-STRUCTURE.md §2.7.4 — `IncidentResponseAgent` (L2; gate **CTO + CEO for CRITICAL**); line 430: `Security incident CRITICAL | CTO+CEO | 2h | NO`; FCA SYSC 8.1 (CEO notified within 2h).

### ETAP A — Port (`services/incident_response/incident_signal_port.py`)
`IncidentSignalPort` (abc.ABC): `get_incidents(severity)`, `get_incident(incident_id)`, `classify_severity(...)` read-only triage helper. `InMemoryIncidentSignalPort` double + `IncidentSignalPortError` hierarchy (`IncidentNotFound`, `SignalSourceUnavailable`); `IncidentSeverity` incl. **CRITICAL**. **READ + classify only** — there is intentionally **no** close/resolve/suppress seam, so auto-closure is impossible by construction. Signals are derived **read-only** from the existing `observability` / `device_fingerprint` / `ato_prevention` sources (those domains are **not** modified). No real SIEM/pager (I-10) — in-memory for tests.

### ETAP B — Agent (`services/agents/incident_response_agent.py`)
Triages incidents via the port under the full **§D2 gate-chain** (process_ref → scope → band → cost_cap → compliance → step-up → port call), one **ADR-046** record per action, R-SEC opaque (incident_id/severity only — never raw security data/PII).

**FCA SYSC 8.1 regulatory invariant (enforced in code AND test):** a **CRITICAL** incident can **NEVER** be auto-resolved/suppressed/closed — it forces a **mandatory CTO+CEO step-up regardless of confidence** with a **≤2h SLA**; with no reviewer it HALTS and the disposition is never committed. Non-critical → normal L2. Mirrors the `campaign_agent` / `kyc_onboarding_agent` mandatory-escalation pattern.

`_lineage.AgentOutcome` gains an additive `sla_hours` field (defaults `None`) to surface the SYSC 8.1 2h CRITICAL SLA; other masks are unaffected.

### Tests & gates
- `tests/test_incident_response/test_incident_signal_port.py` + `tests/agents/test_incident_response_agent.py` — **100% coverage on both new files**.
- Marquee invariant test: critical @ confidence=1.0, no reviewer → HALT, escalate→CTO+CEO, SLA=2h, disposition never committed (incident left OPEN); critical-with-reviewer proceeds.
- Full `tests/agents/` suite green (no regression from the `_lineage` change). `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added incident response agent for security incident triage with governance controls, cost caps, and configurable escalation thresholds
  * Incident signal reading capability to list, inspect, and classify security incidents without modification
  * SLA tracking support for managing escalation deadlines

* **Tests**
  * Comprehensive test coverage for incident response governance workflows and signal handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->