### PR TITLE
feat(hr): HRAgent + HRPort (LAST Tier-3, L1 Auto, mandatory CEO gate on SMF hires) [IL-198]

### DIFF
--- a/services/agents/hr_agent.py
+++ b/services/agents/hr_agent.py
@@ -1,0 +1,626 @@
+"""HRAgent — L1-Auto People/HR agent with a mandatory CEO gate on SMF hires
+(ORG-STRUCTURE §2.9, FCA SM&CR mask).
+
+WHY: ORG-STRUCTURE §2.9 (People / HR) specifies the ``HRAgent`` (L1 Auto; gate **CEO on
+hiring an SMF holder**). This module is the emi-stack analogue of the §D2 masks
+(``churn_prediction_agent.py`` for the L1-Auto routine path; ``credit_scoring_agent.py``
+for the mandatory-gate invariant): it implements the agent *logic* and *governance
+enforcement* of the HR mask over :class:`~services.hr.hr_port.HRPort`. It does NOT
+implement the port, any HRIS adapter, the LLM-orchestration/routing layer, or any lineage
+sink. The SM&CR registry (``services/compliance_automation``) is NOT touched — SMF/role
+data is read through the injected read-only :class:`~services.hr.hr_port.SMCRReadHandle`.
+
+THE REGULATORY INVARIANT (FCA SM&CR — enforced in code AND test)
+---------------------------------------------------------------
+Routine people-ops (training tracking, conduct-rule attestations, headcount reporting)
+are L1 AUTO. BUT hiring / appointing / changing a holder of a Senior Management Function
+(SMF) can NEVER be done autonomously: it MUST force a step-up to the **CEO regardless of
+confidence** (even at confidence 1.0). The appointment commits ONLY with a valid CEO
+authorization token; with no token the action HALTS, the appointment is NEVER applied
+(``apply_smf_appointment`` is never called), and the action escalates to the CEO. The port
+itself refuses an SMF appointment without a CEO token (it raises) — so auto-appointment is
+impossible by construction beneath this gate (defence-in-depth).
+
+The HR mask (ORG §2.9), enforced in the fixed §D2 chain order
+(process_ref → scope → band → cost_cap → compliance → CEO-step-up → port call):
+
+* ``scope``               — :class:`HRPort` ops only (the allow-list: get_training_status /
+                            record_conduct_attestation / apply_smf_appointment).
+* ``autonomy_level``      — AUTO (L1). Routine ops are AUTO-eligible within cap; a routine
+                            op below the AUTO band halts for a re-check (no HITL hold). An
+                            SMF appointment is a mandatory CEO step-up regardless of band.
+* ``confirmation_policy`` — AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70 (ADR-047).
+* ``cost_cap``            — per-request AND per-window hard caps, token AND monetary.
+* ``lineage_obligation``  — one ``AgentDecisionRecord`` per action (ADR-046), every exit.
+* ``compliance_gate``     — SM&CR + conduct; a non-PASS result halts AND escalates to CEO.
+* ``smf_step_up``         — SM&CR: an SMF appointment requires a CEO authorization token
+                            (mandatory step-up, never autonomous, regardless of band).
+
+Mask *values* (caps, thresholds, scope, gate, escalation role) are config-as-data, carried
+on :class:`HRMask`, never hardcoded in flow logic — EXCEPT the SM&CR CEO step-up, which is
+a hard regulatory floor mask config can only *strengthen*, never disable.
+
+R-SEC (ADR-021): the lineage record carries opaque metadata ONLY — ``employee_id`` /
+``role`` / ``candidate_id``, never names, salary, performance data, or any PII. The CEO
+authorization token is routed straight to the port and is NEVER recorded.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+import uuid
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    AgentOutcome,
+    BudgetBreach,
+    ComplianceResult,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    ProcessRef,
+    RequestCost,
+)
+from services.hr.hr_port import (
+    ConductRuleTier,
+    HRPort,
+    HRPortError,
+    SMCRReadHandle,
+)
+
+# ---------------------------------------------------------------------------
+# Mask vocabulary
+# ---------------------------------------------------------------------------
+
+
+class AutonomyLevel(StrEnum):
+    """Mask autonomy posture. HR routine ops are AUTO-biased (L1): within-cap ops are
+    AUTO-eligible; an SMF appointment is gated by the mandatory CEO step-up."""
+
+    AUTO_BIASED = "auto_biased"
+    REVIEW_BIASED = "review_biased"
+
+
+# ---------------------------------------------------------------------------
+# Value types — mask config (shared cost/lineage primitives live in ``_lineage``)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HRMask:
+    """Config-as-data HR mask (ORG §2.9). The SM&CR CEO step-up is a regulatory floor: an
+    SMF appointment ALWAYS forces a CEO sign-off (a valid ``ceo_token``) regardless of the
+    confidence band — config can strengthen the escalation role but can never disable the
+    step-up."""
+
+    cost_cap: CostCap
+    auto_threshold: float = 0.90
+    review_floor: float = 0.70
+    autonomy_level: AutonomyLevel = AutonomyLevel.AUTO_BIASED
+    lineage_obligation: bool = True
+    # The human authority an SMF appointment (and any compliance escalation) is forced up
+    # to — FCA SM&CR / ORG §2.9 line 361: the CEO (for hiring SMF holders).
+    ceo_escalation_role: str = "CEO"
+    agent_id: str = "hr_agent"
+
+    # The mask scope (ADR-049 §D3 allow-list): the only port ops this mask may reach. The
+    # token-less ``propose_smf_appointment`` is an internal prep step, not a gated commit —
+    # only the CEO-token-gated ``apply_smf_appointment`` appears here.
+    scope: tuple[str, ...] = (
+        "HRPort.get_training_status",
+        "HRPort.record_conduct_attestation",
+        "HRPort.apply_smf_appointment",
+    )
+
+    # Compliance contour required before any committing op.
+    compliance_gate: tuple[str, ...] = ("SMCR", "CONDUCT")
+
+
+@dataclass
+class CheckTrainingIntent:
+    """A resolved ROUTINE read intent (``get_training_status``) — L1 AUTO-eligible; a read
+    below the AUTO band halts for a re-check, not a HITL hold."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    employee_id: str
+    course_id: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class AttestConductIntent:
+    """A resolved ROUTINE conduct-attestation intent (``record_conduct_attestation``) — L1
+    AUTO bookkeeping (not an appointment), so it never trips the SMF gate."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    employee_id: str
+    tier: ConductRuleTier
+    attested: bool
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+
+
+@dataclass
+class AppointSMFIntent:
+    """A resolved intent to APPOINT an SMF holder — the regulated SM&CR path.
+
+    SM&CR mandatory step-up: an SMF appointment is NEVER autonomous — it forces a CEO
+    step-up regardless of the confidence band (even at confidence 1.0) and commits ONLY
+    with a valid ``ceo_token``. With no token the action HALTS, the appointment is never
+    applied, and the action escalates to the CEO. ``role`` is the FCA SMF function code
+    (e.g. ``"SMF1"``); ``candidate`` is an opaque person handle.
+
+    R-SEC: ``ceo_token`` is routed straight to the port and is NEVER recorded."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    role: str
+    candidate: str
+    correlation_id: str
+    confidence_score: float
+    request_cost: RequestCost
+    ceo_token: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Internal evaluation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ActionContext:
+    """All inputs a single masked action evaluates against."""
+
+    intent_text: str
+    process_ref: ProcessRef
+    correlation_id: str
+    confidence_score: float
+    triggering_event: str
+    success_action: str
+    op: str
+    request_cost: RequestCost
+    compliance_result: ComplianceResult
+    # SM&CR CEO step-up: True when this action appoints an SMF holder and therefore needs a
+    # valid CEO token to proceed (mandatory, regardless of band).
+    requires_smf_step_up: bool = False
+    ceo_token: str | None = None
+    human_reviewed_by: str | None = None
+
+
+@dataclass
+class _Evaluation:
+    decision: ConfirmationDecision
+    proceed: bool
+    action_taken: str
+    reasoning_summary: str
+    policies: list[str]
+    compliance_result: ComplianceResult
+    budget_breach: BudgetBreach
+    halt_reason: str | None = None
+    requires_step_up: bool = False
+    requires_hitl: bool = False
+    escalated_to: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class HRAgent:
+    """L1-Auto People/HR agent enforcing the ORG §2.9 / SM&CR mask.
+
+    The HR port, the read-only SM&CR handle, and the lineage recorder are injected as
+    interfaces; the agent contains pure governance logic and is unit-testable without any
+    live infra.
+    """
+
+    def __init__(
+        self,
+        *,
+        port: HRPort,
+        smcr_handle: SMCRReadHandle,
+        recorder: DecisionRecorder,
+        mask: HRMask,
+        cost_window: CostWindow | None = None,
+    ) -> None:
+        self._port = port
+        self._smcr = smcr_handle
+        self._recorder = recorder
+        self._mask = mask
+        self._window = cost_window or CostWindow(window_ref=f"{mask.agent_id}:default")
+
+    # -- public mask actions -------------------------------------------------
+
+    async def check_training(
+        self,
+        intent: CheckTrainingIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Routine training-status read via ``HRPort.get_training_status`` — L1 AUTO,
+        no HITL hold and no step-up (the mask's within-cap routine path)."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"check_training:{intent.employee_id}:{intent.course_id}",
+            success_action="CHECK_TRAINING",
+            op="HRPort.get_training_status",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(
+            ctx, lambda: self._port.get_training_status(intent.employee_id, intent.course_id)
+        )
+
+    async def attest_conduct(
+        self,
+        intent: AttestConductIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Routine conduct-rule attestation via ``HRPort.record_conduct_attestation`` — L1
+        AUTO bookkeeping; not an appointment, so the SMF gate never fires."""
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"attest_conduct:{intent.employee_id}:{intent.tier.value}",
+            success_action="ATTEST_CONDUCT",
+            op="HRPort.record_conduct_attestation",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+        )
+        return await self._run_action(
+            ctx,
+            lambda: self._port.record_conduct_attestation(
+                intent.employee_id, intent.tier, attested=intent.attested
+            ),
+        )
+
+    async def appoint_smf(
+        self,
+        intent: AppointSMFIntent,
+        *,
+        compliance_result: ComplianceResult = ComplianceResult.PASS,
+    ) -> AgentOutcome:
+        """Appoint an SMF holder — the regulated SM&CR path.
+
+        An SMF appointment is NEVER autonomous: it forces a step-up to the CEO and commits
+        ONLY with a valid ``ceo_token``, regardless of the confidence band (even at
+        confidence 1.0). With no token the action HALTS, the appointment is never applied
+        (``apply_smf_appointment`` is never called), and the action escalates to the CEO.
+
+        The current incumbent (if any) is read through the read-only SM&CR handle to label
+        the appointment new-vs-change for the audit trail (opaque: role / candidate only).
+        """
+        # Read SMF/role data through the read-only SM&CR handle — never mutates the
+        # registry; only reads the current holder to label the appointment.
+        incumbent = self._smcr.get_senior_manager(intent.candidate)
+        change_kind = "change" if incumbent is not None else "new"
+        ctx = _ActionContext(
+            intent_text=intent.intent_text,
+            process_ref=intent.process_ref,
+            correlation_id=intent.correlation_id,
+            confidence_score=intent.confidence_score,
+            triggering_event=f"appoint_smf:{intent.role}:{intent.candidate}:{change_kind}",
+            success_action="APPOINT_SMF",
+            op="HRPort.apply_smf_appointment",
+            request_cost=intent.request_cost,
+            compliance_result=compliance_result,
+            requires_smf_step_up=True,
+            ceo_token=intent.ceo_token,
+            # A valid CEO token IS the CEO sign-off; record the role (opaque), never the token.
+            human_reviewed_by=self._mask.ceo_escalation_role if intent.ceo_token else None,
+        )
+
+        async def _apply() -> object:
+            # Prepare-only proposal (no token), then commit with the CEO token. Reached
+            # only on the proceed path — never when the SMF gate HALTs.
+            proposal = self._port.propose_smf_appointment(
+                intent.role,
+                intent.candidate,
+                incumbent_id=getattr(incumbent, "person_id", None),
+            )
+            return self._port.apply_smf_appointment(proposal, intent.ceo_token or "")
+
+        return await self._run_action(ctx, _apply)
+
+    # -- governance engine ---------------------------------------------------
+
+    def _band(self, confidence: float) -> ConfirmationDecision:
+        if confidence > self._mask.auto_threshold:
+            return ConfirmationDecision.AUTO
+        if confidence >= self._mask.review_floor:
+            return ConfirmationDecision.REVIEW
+        return ConfirmationDecision.BLOCK
+
+    def _cost_breaches(self, cost: RequestCost) -> bool:
+        cap = self._mask.cost_cap
+        return (
+            cost.tokens > cap.max_request_tokens
+            or cost.cost > cap.max_request_cost
+            or self._window.used_tokens + cost.tokens > cap.max_window_tokens
+            or self._window.used_cost + cost.cost > cap.max_window_cost
+        )
+
+    def _evaluate(self, ctx: _ActionContext) -> _Evaluation:
+        if not 0.0 <= ctx.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be in [0.0, 1.0]")
+        policies = ["ADR-048-process-resolution"]
+
+        # 1. ADR-048 — no port call without a resolved process_ref.
+        if not ctx.process_ref.resolved:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_UNRESOLVED_PROCESS",
+                "Intent has no resolved process_ref; governance event, never improvised.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="unresolved_process_ref",
+                requires_hitl=True,
+            )
+
+        # 2. ADR-049 §D3 — mask scope allow-list; an off-list op is refused outright.
+        policies.append("ADR-049-scope-allow-list")
+        if ctx.op not in self._mask.scope:
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "REJECT_OUT_OF_SCOPE",
+                f"Operation {ctx.op} is not on the HR mask scope allow-list; refused.",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.NONE,
+                halt_reason="out_of_scope",
+            )
+
+        # 3. ADR-047 confidence band (AUTO > 0.90 / REVIEW 0.70–0.90 / BLOCK < 0.70).
+        policies.append("ADR-047-HITL-AUTO-REVIEW-BLOCK")
+        band = self._band(ctx.confidence_score)
+        if band is ConfirmationDecision.BLOCK:
+            # Low confidence on an SMF appointment still escalates to the CEO.
+            escalated = self._mask.ceo_escalation_role if ctx.requires_smf_step_up else None
+            return _Evaluation(
+                band,
+                False,
+                "BLOCK_LOW_CONFIDENCE",
+                "Confidence < 0.70: full stop, human confirmation mandatory.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="low_confidence",
+                requires_hitl=True,
+                escalated_to=escalated,
+            )
+        if band is ConfirmationDecision.REVIEW and not ctx.requires_smf_step_up:
+            # Routine L1 path: ops are AUTO-only, so a below-AUTO routine op halts for a
+            # re-check at higher confidence, not a HITL hold.
+            return _Evaluation(
+                band,
+                False,
+                "HALT_REVIEW_DEFERRED",
+                "Routine HR op below AUTO band; L1 ops are AUTO-only, no HITL hold.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="review_deferred",
+                requires_hitl=True,
+            )
+
+        # 4. ADR-047 — hard cost cap (per-request AND per-window).
+        policies.append("ADR-047-cost-cap")
+        if self._cost_breaches(ctx.request_cost):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COST_CAP_BREACH",
+                "Cost-cap breach (per-request or per-window); action refused (ADR-047).",
+                policies,
+                ComplianceResult.NA,
+                BudgetBreach.BREACH,
+                halt_reason="cost_cap_breach",
+            )
+
+        # 5. Compliance gate (SM&CR + conduct). A non-PASS result halts AND escalates to CEO.
+        policies.append("SMCR-compliance-gate:" + "+".join(self._mask.compliance_gate))
+        if ctx.compliance_result not in (ComplianceResult.PASS, ComplianceResult.NA):
+            return _Evaluation(
+                ConfirmationDecision.BLOCK,
+                False,
+                "HALT_COMPLIANCE_BLOCK",
+                f"Compliance gate returned {ctx.compliance_result}; action blocked and "
+                f"escalated to {self._mask.ceo_escalation_role}.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="compliance_block",
+                requires_hitl=True,
+                escalated_to=self._mask.ceo_escalation_role,
+            )
+
+        # 6. SM&CR MANDATORY CEO STEP-UP — an SMF appointment can NEVER be autonomous: it
+        #    requires a valid CEO authorization token regardless of the confidence band,
+        #    else HALT and escalate to the CEO (the appointment is never applied).
+        if ctx.requires_smf_step_up and not ctx.ceo_token:
+            policies.append("SMCR-SMF-CEO-step-up")
+            return _Evaluation(
+                band,
+                False,
+                "HALT_SMF_CEO_STEP_UP_REQUIRED",
+                "SMF appointment requires a CEO authorization token (FCA SM&CR): no token "
+                "— forced step-up, never autonomous, escalated to the CEO; not applied.",
+                policies,
+                ctx.compliance_result,
+                BudgetBreach.NONE,
+                halt_reason="smf_ceo_step_up_required",
+                requires_step_up=True,
+                requires_hitl=True,
+                escalated_to=self._mask.ceo_escalation_role,
+            )
+
+        # All gates satisfied — clear to commit within scope.
+        signoff = " (CEO sign-off via token)" if ctx.requires_smf_step_up else ""
+        return _Evaluation(
+            band,
+            True,
+            ctx.success_action,
+            f"All mask gates satisfied at {band.value} confidence{signoff}; committing within scope.",
+            policies,
+            ctx.compliance_result,
+            BudgetBreach.NONE,
+        )
+
+    async def _run_action(
+        self,
+        ctx: _ActionContext,
+        port_call: Callable[[], Awaitable[object]] | None,
+    ) -> AgentOutcome:
+        ev = self._evaluate(ctx)
+        result: object | None = None
+        executed = False
+        action_taken = ev.action_taken
+        compliance_result = ev.compliance_result
+        escalated_to = ev.escalated_to
+
+        if ev.proceed:
+            if port_call is not None:
+                try:
+                    result = await port_call()
+                except HRPortError as exc:
+                    action_taken = f"HALT_PROVIDER_ERROR:{type(exc).__name__}"
+                    await self._emit(
+                        ctx,
+                        ev,
+                        action_taken,
+                        executed=False,
+                        compliance_result=compliance_result,
+                        reasoning=f"HR port rejected the action: {exc}",
+                        escalated_to=escalated_to,
+                    )
+                    raise
+            executed = True
+            self._window.add(ctx.request_cost)
+
+        record = await self._emit(
+            ctx,
+            ev,
+            action_taken,
+            executed=executed,
+            compliance_result=compliance_result,
+            reasoning=ev.reasoning_summary,
+            escalated_to=escalated_to,
+        )
+        return AgentOutcome(
+            decision=ev.decision,
+            executed=executed,
+            record=record,
+            result=result,
+            halt_reason=ev.halt_reason,
+            requires_step_up=ev.requires_step_up,
+            requires_hitl=ev.requires_hitl,
+            escalated_to=escalated_to,
+        )
+
+    async def _emit(
+        self,
+        ctx: _ActionContext,
+        ev: _Evaluation,
+        action_taken: str,
+        *,
+        executed: bool,
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        return await self._record(
+            triggering_event=ctx.triggering_event,
+            intent=ctx.intent_text,
+            policies=ev.policies,
+            compliance_result=compliance_result,
+            reasoning=reasoning,
+            confidence_score=ctx.confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=ctx.human_reviewed_by,
+            correlation_id=ctx.correlation_id,
+            request_cost=ctx.request_cost,
+            budget_breach=ev.budget_breach,
+            escalated_to=escalated_to,
+        )
+
+    async def _record(
+        self,
+        *,
+        triggering_event: str,
+        intent: str,
+        policies: list[str],
+        compliance_result: ComplianceResult,
+        reasoning: str,
+        confidence_score: float,
+        action_taken: str,
+        human_reviewed_by: str | None,
+        correlation_id: str,
+        request_cost: RequestCost,
+        budget_breach: BudgetBreach,
+        escalated_to: str | None,
+    ) -> AgentDecisionRecord:
+        """Build, persist, and return exactly one ADR-046 lineage record (the single
+        producer→sink seam used by every exit path). R-SEC: opaque metadata only —
+        ``intent``/``triggering_event`` carry employee_id/role/candidate, never PII,
+        salary, or the CEO token."""
+        record = AgentDecisionRecord(
+            record_id=str(uuid.uuid4()),
+            timestamp=datetime.now(UTC),
+            agent_id=self._mask.agent_id,
+            triggering_event=triggering_event,
+            intent=intent,
+            policies_evaluated=policies,
+            compliance_result=compliance_result,
+            reasoning_summary=reasoning,
+            confidence_score=confidence_score,
+            action_taken=action_taken,
+            human_reviewed_by=human_reviewed_by,
+            correlation_id=correlation_id,
+            cost_tokens=request_cost.tokens,
+            cost_amount=request_cost.cost,
+            budget_window_ref=self._window.window_ref,
+            budget_breach_flag=budget_breach,
+            escalated_to=escalated_to,
+        )
+        await self._recorder.record(record)
+        return record
+
+
+__all__ = [
+    "AgentDecisionRecord",
+    "AgentOutcome",
+    "AppointSMFIntent",
+    "AttestConductIntent",
+    "AutonomyLevel",
+    "BudgetBreach",
+    "CheckTrainingIntent",
+    "ComplianceResult",
+    "ConductRuleTier",
+    "ConfirmationDecision",
+    "CostCap",
+    "CostWindow",
+    "DecisionRecorder",
+    "HRAgent",
+    "HRMask",
+    "ProcessRef",
+    "RequestCost",
+]

--- a/services/hr/__init__.py
+++ b/services/hr/__init__.py
@@ -1,0 +1,15 @@
+"""HR operations domain seam (read + bounded-write) — IL-197 / Sprint-58.
+
+Houses the :mod:`hr_port` hexagonal contract used by the ``HRAgent`` (ORG-STRUCTURE
+§2.9) to run routine people-operations (training tracking, conduct-rule attestations)
+and to prepare/apply Senior-Management-Function (SMF) appointments. Routine HR ops are
+L1 AUTO; an SMF appointment is NEVER autonomous — its application requires a CEO
+authorization token (SM&CR), enforced both at the port (``apply_smf_appointment`` raises
+without a token) and at the agent governance layer (forced CEO step-up, defence-in-depth).
+
+The mask reads SMF/role data from the existing SM&CR registry
+(``services/compliance_automation/smcr_registry.py``) through a read-only
+:class:`~services.hr.hr_port.SMCRReadHandle` Protocol — it never imports or mutates the
+compliance_automation domain. No real HRIS integration yet (I-10): the in-memory doubles
+here are unit-test scaffolding only.
+"""

--- a/services/hr/hr_port.py
+++ b/services/hr/hr_port.py
@@ -1,0 +1,353 @@
+"""hr_port.py — HRPort: people-operations contract (routine reads/writes + SMF appointment).
+
+ORG-STRUCTURE §2.9 (People / HR) — ``HRAgent`` (L1 Auto; gate **CEO on hiring an SMF
+holder**). This port isolates the HR-operations domain so adapters (a real HRIS, an
+SM&CR workflow tool) can be swapped without touching agent logic. It is the emi-stack
+analogue of ``incident_signal_port.py`` / ``churn_signal_port.py``.
+
+Referenced canon:
+  ORG §2.9          HRAgent — routine people-ops L1 Auto; SMF hires gated on CEO
+  FCA SM&CR         Appointing/changing an SMF (Senior Management Function) holder can
+                    NEVER be autonomous — it requires senior (CEO) sign-off
+  ADR-046 §D2       one AgentDecisionRecord per action
+  ADR-049 §D2/§D3   mask gate-chain + scope allow-list
+  ADR-021 / R-SEC   opaque metadata only — employee_id / role only, never PII or salary
+
+THE ROUTINE / SMF-APPOINTMENT BOUNDARY (enforced by construction)
+-----------------------------------------------------------------
+This port exposes four capabilities split across two consequence classes:
+
+* :meth:`get_training_status`, :meth:`record_conduct_attestation`  — ROUTINE people-ops.
+  Low-consequence, L1 AUTO-eligible: training tracking and conduct-rule attestations.
+* :meth:`propose_smf_appointment`  — PREPARE ONLY. Builds an :class:`SMFAppointmentProposal`
+  with NO token and applies nothing — it cannot, by itself, appoint anyone.
+* :meth:`apply_smf_appointment`  — the ONLY method that commits an SMF appointment, and it
+  raises :class:`HRPortError` unless a non-empty CEO authorization token is supplied. An
+  SMF holder therefore can never be appointed without a CEO token *at the port layer* —
+  defence-in-depth beneath the agent's forced-CEO-step-up governance gate.
+
+READ-ONLY SM&CR HANDLE (no domain mutation)
+-------------------------------------------
+SMF / role data is read through :class:`SMCRReadHandle` — a narrow read-only Protocol
+structurally compatible with ``InMemorySMCRRegistry``
+(``services/compliance_automation/smcr_registry.py``). This port does NOT import, own, or
+mutate the compliance_automation domain; it only *reads* the current SMF holder when
+preparing an appointment. A production adapter would poll a real HRIS / SM&CR tool — that
+integration is a LATER sprint (I-10: no fake integrations now).
+
+R-SEC (ADR-021): every value object carries opaque metadata ONLY — an ``employee_id`` /
+``role`` / ``candidate_id``, never names, salary, performance data, or any PII. The CEO
+authorization token is a port argument only; it is never stored on a value object.
+"""
+
+from __future__ import annotations
+
+import abc
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Protocol
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class ConductRuleTier(StrEnum):
+    """FCA Conduct-Rule tier an attestation covers (mirrors the SM&CR registry bands).
+
+    TIER_1 is every-staff Individual Conduct Rules; TIER_2 is the Senior-Manager
+    Conduct Rules. Attesting either is a ROUTINE L1 op — it is bookkeeping, not an
+    appointment, so it never trips the SMF gate.
+    """
+
+    TIER_1 = "TIER_1"  # Individual Conduct Rules (all staff)
+    TIER_2 = "TIER_2"  # Senior-Manager Conduct Rules (SMFs only)
+
+
+# ---------------------------------------------------------------------------
+# Value objects (R-SEC: opaque metadata only — employee_id / role, never PII/salary)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrainingStatus:
+    """Read-only training-completion status for one employee/course (opaque handles)."""
+
+    employee_id: str
+    course_id: str
+    completed: bool
+    completed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class ConductAttestation:
+    """A recorded conduct-rule attestation (routine L1 bookkeeping, no appointment)."""
+
+    employee_id: str
+    tier: ConductRuleTier
+    attested: bool
+    recorded_at: datetime
+
+
+@dataclass(frozen=True)
+class SMFAppointmentProposal:
+    """A PREPARED SMF-appointment proposal — prepare only, carries NO token and appoints
+    nothing. The ``role`` is the FCA SMF function code (e.g. ``"SMF1"``); ``candidate_id``
+    is an opaque person handle. Applying it requires :meth:`HRPort.apply_smf_appointment`
+    with a CEO authorization token."""
+
+    proposal_id: str
+    role: str
+    candidate_id: str
+    incumbent_id: str | None = None  # current holder (read via the SM&CR handle), if any
+    prepared_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass(frozen=True)
+class SMFAppointment:
+    """An APPLIED SMF appointment — only produced by :meth:`HRPort.apply_smf_appointment`
+    after a valid CEO token was supplied. ``authorized`` is always True on a returned
+    instance (the no-token path raises before one is built)."""
+
+    proposal_id: str
+    role: str
+    candidate_id: str
+    appointed_at: datetime
+    authorized: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Read-only SM&CR handle (Protocol) — reads SMF/role data, never mutates
+# ---------------------------------------------------------------------------
+
+
+class SMCRReadHandle(Protocol):
+    """Narrow read-only handle into the SM&CR registry
+    (``services/compliance_automation/smcr_registry.py``). Structurally compatible with
+    ``InMemorySMCRRegistry``: the HR mask reads the current SMF holder through this seam
+    and NEVER mutates the registry — there is intentionally no register/file method here.
+
+    Return type is ``object | None`` to avoid importing compliance_automation domain
+    models into this port (loose coupling)."""
+
+    def get_senior_manager(self, person_id: str) -> object | None: ...
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy (carries correlation_id for the audit trail)
+# ---------------------------------------------------------------------------
+
+
+class HRPortError(Exception):
+    """Base for all HR-port errors. Carries ``correlation_id`` so the adapter can write
+    an audit row before re-raising."""
+
+    def __init__(self, message: str, *, correlation_id: str) -> None:
+        super().__init__(message)
+        self.correlation_id: str = correlation_id
+
+
+class EmployeeNotFound(HRPortError):
+    """employee_id not present in the HR store."""
+
+
+class HRSourceUnavailable(HRPortError):
+    """The HR source is down or returned a transient error (caller retries)."""
+
+
+class CEOAuthorizationRequired(HRPortError):
+    """An SMF appointment was applied without a CEO authorization token. The port refuses
+    to appoint an SMF holder without senior sign-off (SM&CR) — defence-in-depth beneath
+    the agent's forced CEO step-up."""
+
+
+# ---------------------------------------------------------------------------
+# Abstract port
+# ---------------------------------------------------------------------------
+
+
+class HRPort(abc.ABC):
+    """Abstract contract for people-operations.
+
+    Boundary: routine HR ops (training status, conduct attestations) are free L1 ops;
+    an SMF appointment is split into a token-less :meth:`propose_smf_appointment`
+    (prepare only) and a CEO-token-gated :meth:`apply_smf_appointment` (the only commit
+    seam, which raises without a token). An SMF holder can never be appointed
+    autonomously through this port.
+    """
+
+    @abstractmethod
+    async def get_training_status(self, employee_id: str, course_id: str) -> TrainingStatus:
+        """Return an employee's training-completion status (ROUTINE L1 read).
+
+        Raises:
+            EmployeeNotFound: no training record for that employee/course.
+            HRSourceUnavailable: the HR source is transiently unavailable.
+        """
+        ...
+
+    @abstractmethod
+    async def record_conduct_attestation(
+        self, employee_id: str, tier: ConductRuleTier, *, attested: bool
+    ) -> ConductAttestation:
+        """Record a conduct-rule attestation (ROUTINE L1 bookkeeping — not an appointment).
+
+        Raises:
+            HRSourceUnavailable: the HR source is transiently unavailable.
+        """
+        ...
+
+    @abstractmethod
+    def propose_smf_appointment(
+        self, role: str, candidate: str, *, incumbent_id: str | None = None
+    ) -> SMFAppointmentProposal:
+        """PREPARE an SMF-appointment proposal — prepare only, no token, appoints nothing.
+
+        Returns a token-less :class:`SMFAppointmentProposal`. Applying it is a separate,
+        CEO-token-gated step (:meth:`apply_smf_appointment`)."""
+        ...
+
+    @abstractmethod
+    def apply_smf_appointment(
+        self, proposal: SMFAppointmentProposal, ceo_token: str
+    ) -> SMFAppointment:
+        """COMMIT an SMF appointment — requires a non-empty CEO authorization token.
+
+        Raises:
+            CEOAuthorizationRequired: ``ceo_token`` is empty/None — an SMF holder is
+                never appointed without senior (CEO) sign-off (SM&CR)."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-memory implementation (unit-test double — I-10: no real HRIS yet)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryHRPort(HRPort):
+    """In-memory :class:`HRPort` for unit tests. Holds training/attestation state in
+    dicts, records calls for assertions, and exposes a transient-failure switch so the
+    agent's provider-error path can be exercised.
+
+    Its :meth:`apply_smf_appointment` mirrors the abstract boundary: it raises
+    :class:`CEOAuthorizationRequired` without a token, so a test can prove no SMF holder
+    is ever appointed through the port without CEO sign-off."""
+
+    def __init__(self, *, unavailable: HRSourceUnavailable | None = None) -> None:
+        self._training: dict[tuple[str, str], TrainingStatus] = {}
+        self._unavailable = unavailable
+        self.get_training_status_calls: list[tuple[str, str]] = []
+        self.conduct_attestation_calls: list[tuple[str, ConductRuleTier, bool]] = []
+        self.propose_calls: list[tuple[str, str]] = []
+        self.apply_calls: list[tuple[str, str]] = []
+
+    # -- test configuration --------------------------------------------------
+
+    def add_training(
+        self,
+        employee_id: str,
+        course_id: str,
+        *,
+        completed: bool,
+        completed_at: datetime | None = None,
+    ) -> TrainingStatus:
+        status = TrainingStatus(
+            employee_id=employee_id,
+            course_id=course_id,
+            completed=completed,
+            completed_at=completed_at,
+        )
+        self._training[(employee_id, course_id)] = status
+        return status
+
+    def set_unavailable(self, exc: HRSourceUnavailable) -> None:
+        self._unavailable = exc
+
+    # -- routine ops (L1) ----------------------------------------------------
+
+    async def get_training_status(self, employee_id: str, course_id: str) -> TrainingStatus:
+        self.get_training_status_calls.append((employee_id, course_id))
+        if self._unavailable is not None:
+            raise self._unavailable
+        status = self._training.get((employee_id, course_id))
+        if status is None:
+            raise EmployeeNotFound(
+                f"No training record for {employee_id}/{course_id}",
+                correlation_id=employee_id,
+            )
+        return status
+
+    async def record_conduct_attestation(
+        self, employee_id: str, tier: ConductRuleTier, *, attested: bool
+    ) -> ConductAttestation:
+        self.conduct_attestation_calls.append((employee_id, tier, attested))
+        if self._unavailable is not None:
+            raise self._unavailable
+        return ConductAttestation(
+            employee_id=employee_id,
+            tier=tier,
+            attested=attested,
+            recorded_at=datetime.now(UTC),
+        )
+
+    # -- SMF appointment (prepare-only / CEO-token-gated commit) --------------
+
+    def propose_smf_appointment(
+        self, role: str, candidate: str, *, incumbent_id: str | None = None
+    ) -> SMFAppointmentProposal:
+        self.propose_calls.append((role, candidate))
+        return SMFAppointmentProposal(
+            proposal_id=f"SMF-PROP-{role}-{candidate}",
+            role=role,
+            candidate_id=candidate,
+            incumbent_id=incumbent_id,
+        )
+
+    def apply_smf_appointment(
+        self, proposal: SMFAppointmentProposal, ceo_token: str
+    ) -> SMFAppointment:
+        if not ceo_token:
+            raise CEOAuthorizationRequired(
+                "SMF appointment requires a CEO authorization token (SM&CR); refused.",
+                correlation_id=proposal.proposal_id,
+            )
+        self.apply_calls.append((proposal.proposal_id, proposal.candidate_id))
+        return SMFAppointment(
+            proposal_id=proposal.proposal_id,
+            role=proposal.role,
+            candidate_id=proposal.candidate_id,
+            appointed_at=datetime.now(UTC),
+        )
+
+
+class InMemorySMCRReadHandle:
+    """In-memory :class:`SMCRReadHandle` for unit tests — reads SMF holders from a dict
+    and records lookups for assertions. Holds ``object`` values so tests are not coupled
+    to compliance_automation domain models (any structural stand-in works)."""
+
+    def __init__(self, *, senior_managers: dict[str, object] | None = None) -> None:
+        self._sm: dict[str, object] = dict(senior_managers or {})
+        self.get_senior_manager_calls: list[str] = []
+
+    def get_senior_manager(self, person_id: str) -> object | None:
+        self.get_senior_manager_calls.append(person_id)
+        return self._sm.get(person_id)
+
+
+__all__ = [
+    "CEOAuthorizationRequired",
+    "ConductAttestation",
+    "ConductRuleTier",
+    "EmployeeNotFound",
+    "HRPort",
+    "HRPortError",
+    "HRSourceUnavailable",
+    "InMemoryHRPort",
+    "InMemorySMCRReadHandle",
+    "SMCRReadHandle",
+    "SMFAppointment",
+    "SMFAppointmentProposal",
+    "TrainingStatus",
+]

--- a/tests/agents/test_hr_agent.py
+++ b/tests/agents/test_hr_agent.py
@@ -1,0 +1,430 @@
+"""Tests for the ORG §2.9 / FCA SM&CR HR mask agent (services/agents/hr_agent.py).
+
+Covers every mask path in the §D2 gate-chain order: routine AUTO ops (training read,
+conduct attestation), the routine below-AUTO re-check halt, the SMF-CEO-gate invariant
+(appoint-SMF @ confidence 1.0 with NO CEO token → HALT, forced step-up to CEO, appointment
+never applied) and the appoint-with-CEO-token proceed path (incl. a REVIEW-band proceed
+and a new-vs-change incumbent read), HALT_UNRESOLVED_PROCESS, REJECT_OUT_OF_SCOPE,
+HALT_REVIEW_DEFERRED, BLOCK_LOW_CONFIDENCE (routine + SMF), HALT_COST_CAP_BREACH
+(per-request + per-window), HALT_COMPLIANCE_BLOCK, HALT_PROVIDER_ERROR (emit + reraise),
+invalid confidence → ValueError, R-SEC, and the one-lineage-record-per-action obligation
+(ADR-046). The port, SM&CR handle, and recorder are fakes — the agent is exercised as pure
+governance logic with no live infra.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+import pytest
+
+from services.agents.hr_agent import (
+    AgentDecisionRecord,
+    AppointSMFIntent,
+    AttestConductIntent,
+    BudgetBreach,
+    CheckTrainingIntent,
+    ComplianceResult,
+    ConductRuleTier,
+    ConfirmationDecision,
+    CostCap,
+    CostWindow,
+    DecisionRecorder,
+    HRAgent,
+    HRMask,
+    ProcessRef,
+    RequestCost,
+)
+from services.hr.hr_port import (
+    HRSourceUnavailable,
+    InMemoryHRPort,
+    InMemorySMCRReadHandle,
+)
+
+# ── Fakes / builders ───────────────────────────────────────────────────────────
+
+
+class FakeRecorder(DecisionRecorder):
+    def __init__(self) -> None:
+        self.records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self.records.append(record)
+
+
+@dataclass
+class _SM:
+    """A structural stand-in for a registered senior manager (has ``person_id``)."""
+
+    person_id: str
+
+
+def make_mask(**overrides) -> HRMask:
+    base = {
+        "cost_cap": CostCap(
+            max_request_tokens=10_000,
+            max_request_cost=Decimal("1.00"),
+            max_window_tokens=100_000,
+            max_window_cost=Decimal("10.00"),
+        ),
+    }
+    base.update(overrides)
+    return HRMask(**base)
+
+
+def make_agent(
+    *,
+    mask: HRMask | None = None,
+    port: InMemoryHRPort | None = None,
+    smcr: InMemorySMCRReadHandle | None = None,
+    recorder: FakeRecorder | None = None,
+    cost_window: CostWindow | None = None,
+) -> tuple[HRAgent, InMemoryHRPort, InMemorySMCRReadHandle, FakeRecorder]:
+    port = port or InMemoryHRPort()
+    smcr = smcr or InMemorySMCRReadHandle()
+    recorder = recorder or FakeRecorder()
+    agent = HRAgent(
+        port=port,
+        smcr_handle=smcr,
+        recorder=recorder,
+        mask=mask or make_mask(),
+        cost_window=cost_window,
+    )
+    return agent, port, smcr, recorder
+
+
+def _ref(resolved: bool = True) -> ProcessRef:
+    return (
+        ProcessRef(process_id="PROC-HR", version="1")
+        if resolved
+        else ProcessRef(process_id="", version="")
+    )
+
+
+def make_training_intent(*, confidence: float = 0.99) -> CheckTrainingIntent:
+    return CheckTrainingIntent(
+        intent_text="Check AML training for EMP-1",
+        process_ref=_ref(),
+        employee_id="EMP-1",
+        course_id="AML-101",
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=RequestCost(tokens=50, cost=Decimal("0.01")),
+    )
+
+
+def make_conduct_intent(*, confidence: float = 0.99) -> AttestConductIntent:
+    return AttestConductIntent(
+        intent_text="Record conduct attestation for EMP-1",
+        process_ref=_ref(),
+        employee_id="EMP-1",
+        tier=ConductRuleTier.TIER_1,
+        attested=True,
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=RequestCost(tokens=50, cost=Decimal("0.01")),
+    )
+
+
+def make_appoint_intent(
+    *,
+    confidence: float = 0.99,
+    ceo_token: str | None = None,
+    cost: RequestCost | None = None,
+    resolved: bool = True,
+    role: str = "SMF1",
+    candidate: str = "CAND-1",
+) -> AppointSMFIntent:
+    return AppointSMFIntent(
+        intent_text=f"Appoint {candidate} to {role}",
+        process_ref=_ref(resolved),
+        role=role,
+        candidate=candidate,
+        correlation_id="corr-1",
+        confidence_score=confidence,
+        request_cost=cost or RequestCost(tokens=400, cost=Decimal("0.04")),
+        ceo_token=ceo_token,
+    )
+
+
+# ── Routine AUTO ops (training read / conduct attestation) ─────────────────────
+
+
+async def test_check_training_auto_executes():
+    agent, port, _, recorder = make_agent()
+    port.add_training("EMP-1", "AML-101", completed=True)
+    outcome = await agent.check_training(make_training_intent(confidence=0.99))
+
+    assert outcome.decision is ConfirmationDecision.AUTO
+    assert outcome.executed is True
+    assert outcome.requires_hitl is False
+    assert outcome.result is not None
+    assert port.get_training_status_calls == [("EMP-1", "AML-101")]
+    assert recorder.records[0].action_taken == "CHECK_TRAINING"
+    assert len(recorder.records) == 1
+
+
+async def test_attest_conduct_auto_executes():
+    agent, port, _, recorder = make_agent()
+    outcome = await agent.attest_conduct(make_conduct_intent(confidence=0.95))
+
+    assert outcome.executed is True
+    assert outcome.requires_step_up is False
+    assert port.conduct_attestation_calls == [("EMP-1", ConductRuleTier.TIER_1, True)]
+    assert recorder.records[0].action_taken == "ATTEST_CONDUCT"
+    assert recorder.records[0].triggering_event == "attest_conduct:EMP-1:TIER_1"
+
+
+async def test_routine_below_auto_band_halts_for_recheck():
+    agent, port, _, recorder = make_agent()
+    outcome = await agent.check_training(make_training_intent(confidence=0.80))
+
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is False
+    assert outcome.halt_reason == "review_deferred"
+    assert port.get_training_status_calls == []
+    assert recorder.records[0].action_taken == "HALT_REVIEW_DEFERRED"
+
+
+async def test_routine_low_confidence_blocks_without_escalation():
+    agent, _, _, recorder = make_agent()
+    outcome = await agent.check_training(make_training_intent(confidence=0.40))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.escalated_to is None
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+# ── SMF-CEO-gate invariant (FCA SM&CR) ─────────────────────────────────────────
+
+
+async def test_appoint_smf_full_confidence_no_token_halts_and_escalates():
+    """The marquee invariant: an SMF appointment at confidence 1.0 with NO CEO token can
+    NEVER be autonomous — it forces a CEO step-up and never applies the appointment
+    (``apply_smf_appointment`` is never called)."""
+    agent, port, _, recorder = make_agent()
+
+    outcome = await agent.appoint_smf(make_appoint_intent(confidence=1.0, ceo_token=None))
+
+    assert outcome.executed is False  # appointment NEVER applied
+    assert outcome.requires_step_up is True
+    assert outcome.requires_hitl is True
+    assert outcome.escalated_to == "CEO"
+    assert outcome.halt_reason == "smf_ceo_step_up_required"
+    assert recorder.records[0].action_taken == "HALT_SMF_CEO_STEP_UP_REQUIRED"
+    assert recorder.records[0].escalated_to == "CEO"
+    assert "SMCR-SMF-CEO-step-up" in recorder.records[0].policies_evaluated
+    # apply never called — no SMF holder appointed.
+    assert port.apply_calls == []
+    assert port.propose_calls == []
+    # the CEO token is never recorded (R-SEC) — and there was none here anyway.
+    assert recorder.records[0].human_reviewed_by is None
+
+
+async def test_appoint_smf_with_ceo_token_proceeds_new_appointment():
+    agent, port, smcr, recorder = make_agent()
+    outcome = await agent.appoint_smf(
+        make_appoint_intent(confidence=0.99, ceo_token="ceo-sig-abc")  # noqa: S106
+    )
+
+    assert outcome.executed is True
+    assert outcome.result is not None
+    # propose (prepare) then apply (commit) both ran, in order.
+    assert port.propose_calls == [("SMF1", "CAND-1")]
+    assert port.apply_calls == [("SMF-PROP-SMF1-CAND-1", "CAND-1")]
+    # incumbent read through the read-only SM&CR handle (new appointment → no incumbent).
+    assert smcr.get_senior_manager_calls == ["CAND-1"]
+    assert recorder.records[0].triggering_event == "appoint_smf:SMF1:CAND-1:new"
+    assert recorder.records[0].action_taken == "APPOINT_SMF"
+    # CEO sign-off recorded as the opaque role — never the token value (R-SEC).
+    assert recorder.records[0].human_reviewed_by == "CEO"
+
+
+async def test_appoint_smf_change_reads_incumbent_via_handle():
+    smcr = InMemorySMCRReadHandle(senior_managers={"CAND-1": _SM(person_id="CAND-1")})
+    agent, _, _, recorder = make_agent(smcr=smcr)
+    outcome = await agent.appoint_smf(
+        make_appoint_intent(confidence=0.99, ceo_token="ceo-sig-abc")  # noqa: S106
+    )
+    assert outcome.executed is True
+    assert recorder.records[0].triggering_event == "appoint_smf:SMF1:CAND-1:change"
+
+
+async def test_appoint_smf_review_band_with_token_proceeds():
+    # An SMF appointment in the REVIEW band still proceeds with a valid CEO token — the
+    # SMF gate (not the routine read-deferred path) governs the SMF action.
+    agent, port, _, _ = make_agent()
+    outcome = await agent.appoint_smf(
+        make_appoint_intent(confidence=0.80, ceo_token="ceo-sig-abc")  # noqa: S106
+    )
+    assert outcome.decision is ConfirmationDecision.REVIEW
+    assert outcome.executed is True
+    assert port.apply_calls == [("SMF-PROP-SMF1-CAND-1", "CAND-1")]
+
+
+async def test_appoint_smf_empty_token_treated_as_no_token():
+    # An empty-string token is not a valid CEO authorization → HALT (defence-in-depth).
+    agent, port, _, recorder = make_agent()
+    outcome = await agent.appoint_smf(make_appoint_intent(confidence=1.0, ceo_token=""))
+    assert outcome.executed is False
+    assert recorder.records[0].action_taken == "HALT_SMF_CEO_STEP_UP_REQUIRED"
+    assert port.apply_calls == []
+
+
+async def test_appoint_smf_low_confidence_blocks_and_escalates():
+    agent, _, _, recorder = make_agent()
+    outcome = await agent.appoint_smf(make_appoint_intent(confidence=0.50, ceo_token=None))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.executed is False
+    assert outcome.escalated_to == "CEO"
+    assert recorder.records[0].action_taken == "BLOCK_LOW_CONFIDENCE"
+
+
+async def test_smf_step_up_cannot_be_disabled_by_mask_config():
+    # The CEO step-up is a regulatory floor — even a permissive mask cannot auto-appoint.
+    agent, port, _, recorder = make_agent(mask=make_mask(auto_threshold=0.0, review_floor=0.0))
+    outcome = await agent.appoint_smf(make_appoint_intent(confidence=1.0, ceo_token=None))
+    assert outcome.executed is False
+    assert recorder.records[0].action_taken == "HALT_SMF_CEO_STEP_UP_REQUIRED"
+    assert port.apply_calls == []
+
+
+# ── process resolution / scope ─────────────────────────────────────────────────
+
+
+async def test_unresolved_process_ref_blocks():
+    agent, _, _, recorder = make_agent()
+    outcome = await agent.appoint_smf(make_appoint_intent(resolved=False))
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "unresolved_process_ref"
+    assert recorder.records[0].action_taken == "HALT_UNRESOLVED_PROCESS"
+
+
+async def test_out_of_scope_op_refused():
+    # An op not on the mask allow-list is refused outright.
+    agent, port, _, recorder = make_agent(mask=make_mask(scope=("HRPort.get_training_status",)))
+    outcome = await agent.appoint_smf(
+        make_appoint_intent(confidence=0.99, ceo_token="ceo-sig-abc")  # noqa: S106
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "out_of_scope"
+    assert recorder.records[0].action_taken == "REJECT_OUT_OF_SCOPE"
+    assert port.apply_calls == []
+
+
+# ── Cost-cap breach ────────────────────────────────────────────────────────────
+
+
+async def test_per_request_cost_cap_breach_blocks():
+    agent, _, _, recorder = make_agent()
+    intent = make_appoint_intent(
+        confidence=1.0,
+        ceo_token="ceo-sig-abc",  # noqa: S106
+        cost=RequestCost(tokens=999_999, cost=Decimal("0.01")),
+    )
+    outcome = await agent.appoint_smf(intent)
+
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert recorder.records[0].budget_breach_flag is BudgetBreach.BREACH
+    assert recorder.records[0].action_taken == "HALT_COST_CAP_BREACH"
+
+
+async def test_per_window_cost_cap_breach_blocks():
+    window = CostWindow(used_tokens=99_900, used_cost=Decimal("0.00"))
+    agent, port, _, recorder = make_agent(cost_window=window)
+    # the 400-token appoint pushes the window past its 100_000 cap → breach.
+    outcome = await agent.appoint_smf(
+        make_appoint_intent(confidence=1.0, ceo_token="ceo-sig-abc")  # noqa: S106
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.halt_reason == "cost_cap_breach"
+    assert recorder.records[0].action_taken == "HALT_COST_CAP_BREACH"
+    assert port.apply_calls == []
+
+
+async def test_window_accumulates_on_successful_action():
+    window = CostWindow()
+    agent, port, _, _ = make_agent(cost_window=window)
+    port.add_training("EMP-1", "AML-101", completed=True)
+    await agent.check_training(make_training_intent(confidence=0.99))
+    assert window.used_tokens == 50
+    assert window.used_cost == Decimal("0.01")
+
+
+# ── Compliance gate → CEO escalation ───────────────────────────────────────────
+
+
+async def test_compliance_fail_blocks_and_escalates():
+    agent, port, _, recorder = make_agent()
+    outcome = await agent.appoint_smf(
+        make_appoint_intent(confidence=0.99, ceo_token="ceo-sig-abc"),  # noqa: S106
+        compliance_result=ComplianceResult.FAIL,
+    )
+    assert outcome.decision is ConfirmationDecision.BLOCK
+    assert outcome.escalated_to == "CEO"
+    assert recorder.records[0].compliance_result is ComplianceResult.FAIL
+    assert recorder.records[0].action_taken == "HALT_COMPLIANCE_BLOCK"
+    assert port.apply_calls == []  # compliance halt → appointment never applied
+
+
+# ── Provider error (emit + reraise) ────────────────────────────────────────────
+
+
+async def test_provider_error_records_then_raises():
+    port = InMemoryHRPort()
+    port.add_training("EMP-1", "AML-101", completed=True)
+    port.set_unavailable(HRSourceUnavailable("hris down", correlation_id="corr-1"))
+    agent, port, _, recorder = make_agent(port=port)
+
+    with pytest.raises(HRSourceUnavailable):
+        await agent.check_training(make_training_intent(confidence=0.99))
+
+    assert len(recorder.records) == 1
+    assert recorder.records[0].action_taken == "HALT_PROVIDER_ERROR:HRSourceUnavailable"
+
+
+# ── R-SEC + lineage obligation (ADR-046) ───────────────────────────────────────
+
+
+async def test_rsec_lineage_carries_opaque_metadata_only():
+    agent, _, _, recorder = make_agent()
+    await agent.appoint_smf(
+        make_appoint_intent(confidence=0.99, ceo_token="ceo-secret-xyz")  # noqa: S106
+    )
+    rec = recorder.records[0]
+    # Only role / candidate ride on the record — never the CEO token, names, or salary.
+    assert "SMF1" in rec.triggering_event
+    assert "CAND-1" in rec.triggering_event
+    assert "ceo-secret-xyz" not in rec.triggering_event
+    assert "ceo-secret-xyz" not in rec.reasoning_summary
+    assert rec.human_reviewed_by == "CEO"  # opaque role, not the token
+    assert rec.agent_id == "hr_agent"
+
+
+async def test_lineage_record_emitted_per_action_with_adr046_fields():
+    agent, port, _, recorder = make_agent()
+    port.add_training("EMP-1", "AML-101", completed=True)
+    await agent.check_training(make_training_intent(confidence=0.99))
+    await agent.check_training(make_training_intent(confidence=0.40))  # a halt also records
+    assert len(recorder.records) == 2
+
+    rec = recorder.records[0]
+    assert rec.record_id
+    assert rec.timestamp.tzinfo is not None
+    assert rec.agent_id == "hr_agent"
+    assert rec.intent == "Check AML training for EMP-1"
+    assert rec.correlation_id == "corr-1"
+    assert rec.policies_evaluated
+    assert 0.0 <= rec.confidence_score <= 1.0
+    assert rec.cost_tokens == 50
+    assert rec.budget_window_ref == "hr_agent:default"
+
+
+async def test_invalid_confidence_raises():
+    agent, _, _, _ = make_agent()
+    with pytest.raises(ValueError):
+        await agent.appoint_smf(make_appoint_intent(confidence=1.5))

--- a/tests/test_hr/test_hr_port.py
+++ b/tests/test_hr/test_hr_port.py
@@ -1,0 +1,137 @@
+"""Tests for the HR domain port (services/hr/hr_port.py).
+
+Covers the routine read/write ops (training status, conduct attestation), the
+prepare-only SMF proposal, and the CEO-token-gated SMF appointment commit — including
+the structural guarantee that ``apply_smf_appointment`` REFUSES to appoint an SMF holder
+without a CEO token (defence-in-depth beneath the agent gate), plus the not-found and
+transient-failure error paths and the read-only SM&CR handle double. 100% coverage.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from services.hr.hr_port import (
+    CEOAuthorizationRequired,
+    ConductAttestation,
+    ConductRuleTier,
+    EmployeeNotFound,
+    HRSourceUnavailable,
+    InMemoryHRPort,
+    InMemorySMCRReadHandle,
+    SMFAppointment,
+    SMFAppointmentProposal,
+    TrainingStatus,
+)
+
+
+def make_port() -> InMemoryHRPort:
+    return InMemoryHRPort()
+
+
+# ── Routine reads (training) ────────────────────────────────────────────────────
+
+
+async def test_get_training_status_returns_record():
+    port = make_port()
+    when = datetime(2026, 6, 12, tzinfo=UTC)
+    port.add_training("EMP-1", "AML-101", completed=True, completed_at=when)
+
+    status = await port.get_training_status("EMP-1", "AML-101")
+
+    assert isinstance(status, TrainingStatus)
+    assert status.completed is True
+    assert status.completed_at == when
+    assert port.get_training_status_calls == [("EMP-1", "AML-101")]
+
+
+async def test_get_training_status_unknown_employee_raises():
+    port = make_port()
+    with pytest.raises(EmployeeNotFound) as ei:
+        await port.get_training_status("EMP-X", "AML-101")
+    assert ei.value.correlation_id == "EMP-X"
+
+
+async def test_get_training_status_source_unavailable_raises():
+    port = make_port()
+    port.set_unavailable(HRSourceUnavailable("hris down", correlation_id="corr-1"))
+    with pytest.raises(HRSourceUnavailable):
+        await port.get_training_status("EMP-1", "AML-101")
+
+
+# ── Routine writes (conduct attestation) ────────────────────────────────────────
+
+
+async def test_record_conduct_attestation_returns_record():
+    port = make_port()
+    att = await port.record_conduct_attestation("EMP-1", ConductRuleTier.TIER_1, attested=True)
+
+    assert isinstance(att, ConductAttestation)
+    assert att.attested is True
+    assert att.tier is ConductRuleTier.TIER_1
+    assert att.recorded_at.tzinfo is not None
+    assert port.conduct_attestation_calls == [("EMP-1", ConductRuleTier.TIER_1, True)]
+
+
+async def test_record_conduct_attestation_source_unavailable_raises():
+    port = make_port()
+    port.set_unavailable(HRSourceUnavailable("hris down", correlation_id="corr-1"))
+    with pytest.raises(HRSourceUnavailable):
+        await port.record_conduct_attestation("EMP-1", ConductRuleTier.TIER_2, attested=False)
+
+
+# ── SMF proposal (prepare only — no token, appoints nothing) ────────────────────
+
+
+async def test_propose_smf_appointment_prepares_token_less_proposal():
+    port = make_port()
+    proposal = port.propose_smf_appointment("SMF1", "CAND-1", incumbent_id="OLD-CEO")
+
+    assert isinstance(proposal, SMFAppointmentProposal)
+    assert proposal.role == "SMF1"
+    assert proposal.candidate_id == "CAND-1"
+    assert proposal.incumbent_id == "OLD-CEO"
+    assert proposal.prepared_at.tzinfo is not None
+    assert port.propose_calls == [("SMF1", "CAND-1")]
+    # prepare-only: nothing was appointed.
+    assert port.apply_calls == []
+
+
+# ── SMF appointment commit (CEO-token-gated) ────────────────────────────────────
+
+
+async def test_apply_smf_appointment_with_token_commits():
+    port = make_port()
+    proposal = port.propose_smf_appointment("SMF1", "CAND-1")
+    appointment = port.apply_smf_appointment(proposal, "ceo-sig-abc")  # noqa: S106
+
+    assert isinstance(appointment, SMFAppointment)
+    assert appointment.authorized is True
+    assert appointment.role == "SMF1"
+    assert appointment.candidate_id == "CAND-1"
+    assert appointment.appointed_at.tzinfo is not None
+    assert port.apply_calls == [("SMF-PROP-SMF1-CAND-1", "CAND-1")]
+
+
+async def test_apply_smf_appointment_without_token_refuses():
+    # Structural guarantee: no SMF holder is appointed without a CEO token (SM&CR).
+    port = make_port()
+    proposal = port.propose_smf_appointment("SMF1", "CAND-1")
+    with pytest.raises(CEOAuthorizationRequired) as ei:
+        port.apply_smf_appointment(proposal, "")
+    assert ei.value.correlation_id == "SMF-PROP-SMF1-CAND-1"
+    assert port.apply_calls == []  # never applied
+
+
+# ── Read-only SM&CR handle double ───────────────────────────────────────────────
+
+
+async def test_smcr_read_handle_reads_and_records_lookups():
+    sentinel = object()
+    handle = InMemorySMCRReadHandle(senior_managers={"CAND-1": sentinel})
+
+    assert handle.get_senior_manager("CAND-1") is sentinel
+    assert handle.get_senior_manager("UNKNOWN") is None
+    assert handle.get_senior_manager_calls == ["CAND-1", "UNKNOWN"]


### PR DESCRIPTION
## IL-198 — HRAgent (ORG §2.9, LAST Tier-3 BUILD)

ORG-STRUCTURE §2.9 `HRAgent` (PROPOSED → IMPLEMENTED). The **LAST** Tier-3 BUILD of the audit IL-176 remainder — Churn + Lead + Campaign + Incident + **HR** now all done.

### Regulatory invariant (FCA SM&CR — enforced in code AND test)
Routine people-ops (training tracking, conduct-rule attestations) are **L1 AUTO**. BUT appointing/changing an **SMF** (Senior Management Function) holder can **NEVER** be autonomous — it forces a **step-up to CEO regardless of confidence** (even 1.0) and commits **ONLY** with a valid CEO token. With no token the action **HALTS** (`HALT_SMF_CEO_STEP_UP_REQUIRED`), the appointment is **never applied**, and it escalates → CEO. Defence-in-depth: `HRPort.apply_smf_appointment` itself raises (`CEOAuthorizationRequired`) without a token.

Proven by dedicated tests: appoint-SMF @ confidence=1.0, no CEO token → HALT + `requires_step_up` + escalate→CEO + `apply_smf_appointment` never called; appoint-with-CEO-token proceeds; a config-floor test (permissive `auto_threshold=0` mask cannot waive the step-up).

### ETAP A — port (`services/hr/hr_port.py`)
`HRPort` (`abc.ABC`): `get_training_status` / `record_conduct_attestation` (routine L1) / `propose_smf_appointment` (prepare only, no token) / `apply_smf_appointment(proposal, ceo_token)` (CEO-token-gated commit, raises without it). `InMemoryHRPort` + `HRPortError`/`EmployeeNotFound`/`HRSourceUnavailable`/`CEOAuthorizationRequired`. SMF/role data read via a **read-only** `SMCRReadHandle` Protocol (structurally compatible with `InMemorySMCRRegistry`) — `compliance_automation` **NOT** touched. No real HRIS (I-10).

### ETAP B — agent (`services/agents/hr_agent.py`)
L1 `HRAgent`, full ADR-049 §D2 chain (process_ref → scope → band → cost_cap → compliance → **CEO SMF step-up** → port); 1 ADR-046 `AgentDecisionRecord`/action on every exit; port + read-only SM&CR handle + `DecisionRecorder` injected. Routine ops AUTO-only (below-AUTO → `HALT_REVIEW_DEFERRED`); compliance non-PASS → BLOCK + escalate→CEO; `HRPortError` → emit(executed=False) + reraise (`HALT_PROVIDER_ERROR`); invalid confidence → `ValueError`. **R-SEC**: opaque handles only (employee_id/role/candidate); never PII, salary, or the CEO token.

### Proof
- **100% coverage on BOTH new modules** (`services/hr/hr_port.py` + `services/agents/hr_agent.py`).
- Full `tests/agents/` suite green: **710 passed** — 15 existing agents intact; `_lineage.py` **NOT** modified.
- ruff check + ruff format --check clean.

### Doc-sync (companion arch PR)
ORG §2.9 `(PROPOSED)` removed on `HRAgent` only; root `INSTRUCTION-LEDGER.md` IL-198 block; `instruction-ledger/sprint-58/IL-HR-01-*.md`; MEMORY sprint-58 block. No new ADR (fits the existing §D2 mandatory-step-up mask pattern — Campaign/Incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HR agent now supports automated execution of employee operations including training status verification, conduct rule attestations, and senior manager role appointments
  * CEO authorization token required for all senior manager appointments with automatic escalation if missing
  * Governance controls including compliance gates, cost caps, and confidence thresholds

* **Tests**
  * Comprehensive test coverage for HR agent governance rules and operational workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->