### PR TITLE
FU-1 validation: code PR

### DIFF
--- a/services/database.py
+++ b/services/database.py
@@ -66,3 +66,4 @@ async def create_all_tables() -> None:
         from api.db import models as _  # noqa: F401 — register ORM models
 
         await conn.run_sync(Base.metadata.create_all)
+# FU-1 validation: code-path PR sentinel (comment-only; no behaviour change).

--- a/services/database.py
+++ b/services/database.py
@@ -66,4 +66,6 @@ async def create_all_tables() -> None:
         from api.db import models as _  # noqa: F401 — register ORM models
 
         await conn.run_sync(Base.metadata.create_all)
+
+
 # FU-1 validation: code-path PR sentinel (comment-only; no behaviour change).


### PR DESCRIPTION
Synthetic validation PR (FU-1 Phase 3). Comment-only change to services/database.py to exercise the full 9-gate regime on a **code-path** PR (no docs-only short-circuit). Will be closed without merge after checks confirm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal comment marker with no impact to user-facing functionality.

---

**Note:** This release contains only internal code maintenance with no user-visible changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->