### PR TITLE
FU-1 validation: docs-only PR

### DIFF
--- a/docs/ARCHITECTURE-RECON.md
+++ b/docs/ARCHITECTURE-RECON.md
@@ -192,3 +192,5 @@ The enhanced shortfall alert includes: Slack #compliance-alerts, Email CEO+CTIO,
 2. BreachDetector.check_and_escalate()
 3. ReconAnalysisSkill.analyze()
 4. BreachPredictionSkill.predict() per DISCREPANCY account
+
+<!-- FU-1 validation: docs-only PR sentinel (2026-06-14). Verifies docs-only short-circuit under the 9-gate regime. -->


### PR DESCRIPTION
Synthetic validation PR (FU-1 Phase 3). Changes only docs/ARCHITECTURE-RECON.md to verify the **docs-only** classification short-circuits Semgrep OSS + Semgrep security rules to success while all 9 required gates still report. Will be closed without merge after checks confirm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with internal validation notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->