### PR TITLE
FU-2: ClickHouseDecisionRecorder for agent lineage (flagged)

### DIFF
--- a/docs/clickhouse-dev-setup.md
+++ b/docs/clickhouse-dev-setup.md
@@ -93,3 +93,69 @@ docker ps --filter name=clickhouse
 ```bash
 docker compose -p ch-dev -f docker/docker-compose.master.yml down
 ```
+
+## `ClickHouseDecisionRecorder` (FU-2 step 2) — flagged, OFF by default
+
+> ⚠️ **The Intent Layer stays dark.** `INTENT_LAYER_ENABLED` MUST remain `false`
+> until a later, explicit activation FU. The recorder below is a durable lineage
+> *sink* only — selecting it does **not** enable the Intent Layer and does not
+> change any live client dispatch.
+
+The decision-lineage sink is selected by the `DECISION_RECORDER` env var:
+
+| `DECISION_RECORDER` | Sink                            | Default |
+| ------------------- | ------------------------------- | ------- |
+| unset / `inmemory`  | `InMemoryDecisionRecorder`      | ✅ yes  |
+| `clickhouse`        | `ClickHouseDecisionRecorder`    | no      |
+
+With the var unset (or `inmemory`) the system behaves exactly as before — an
+in-process, append-only list. Any other value fails closed (raises), so a typo
+can never silently downgrade durability.
+
+### 1. Apply the schema
+
+Create `banxe.decision_records` (additive — no existing table is touched):
+
+```bash
+# native client (port 9000 / 19000 on Legion — see above)
+clickhouse-client --multiquery < infra/clickhouse/migrations/006_create_decision_records.sql
+# …or over HTTP
+curl -sf 'http://localhost:8123/' --data-binary @infra/clickhouse/migrations/006_create_decision_records.sql
+```
+
+### 2. Enable it locally
+
+```bash
+export DECISION_RECORDER=clickhouse
+export CLICKHOUSE_HOST=localhost
+export CLICKHOUSE_PORT=9000        # 19000 under the Legion override
+export CLICKHOUSE_DB=banxe
+export CLICKHOUSE_USER=default
+export CLICKHOUSE_PASSWORD=        # set if a non-localhost user is configured
+pip install clickhouse-driver      # only needed for the clickhouse sink
+```
+
+`get_decision_recorder()` (in `services/agents/recorders.py`) is the composition
+seam: it reads `DECISION_RECORDER` and returns the chosen
+[`DecisionRecorder`](../services/agents/_lineage.py). The driver client is built
+lazily from the `CLICKHOUSE_*` config, so no socket is opened until the first
+`record()`/`query()`.
+
+### 3. Run the tests
+
+The recorder unit tests use an in-process fake client and need **no** ClickHouse:
+
+```bash
+pytest tests/agents/test_recorders.py -q
+```
+
+To exercise a real round-trip (insert + read-back) against a dev ClickHouse,
+apply migration 006, then set the opt-in DSN marker and run:
+
+```bash
+export DECISION_RECORDER_TEST_DSN=1   # any truthy value un-skips the live test
+pytest tests/agents/test_recorders.py::test_clickhouse_live_round_trip -q
+```
+
+Without `DECISION_RECORDER_TEST_DSN` the live test is **skipped**, so CI stays
+green on environments without ClickHouse.

--- a/infra/clickhouse/migrations/006_create_decision_records.sql
+++ b/infra/clickhouse/migrations/006_create_decision_records.sql
@@ -1,0 +1,55 @@
+-- Migration 006: Agent decision-lineage records table (ADR-046)
+-- FU-2 | banxe-emi-stack | 2026-06-14
+-- Purpose: Durable, queryable sink for AgentDecisionRecord emitted by the L2
+--          client-facing agent masks (services/agents/_lineage.py). This is the
+--          ClickHouse backing store for ClickHouseDecisionRecorder.
+-- Scope:   ADDITIVE only — creates one new append-only table. No existing table
+--          is dropped or altered. The Intent Layer stays dark (INTENT_LAYER_ENABLED
+--          remains false); this table is written only when DECISION_RECORDER=clickhouse.
+-- TTL:     5 years (I-08 / FCA audit-trail minimum retention).
+--
+-- R-SEC (ADR-021): rows carry opaque governance metadata ONLY — never
+--          seed/entropy/key/password/plaintext/ciphertext. Secret material is
+--          never recorded (see _lineage.py R-SEC note).
+
+CREATE TABLE IF NOT EXISTS banxe.decision_records
+(
+    -- ── Identity (AgentDecisionRecord.record_id / .timestamp / .agent_id) ──────
+    record_id           String          COMMENT 'AgentDecisionRecord.record_id (unique per decision)',
+    timestamp           DateTime64(3)   COMMENT 'UTC decision time (ADR-046)',
+    agent_id            LowCardinality(String) COMMENT 'Emitting mask agent id',
+
+    -- ── Decision context (ADR-046 schema) ────────────────────────────────────
+    triggering_event    String          COMMENT 'What triggered the masked action',
+    intent              LowCardinality(String) COMMENT 'Resolved mask intent (scope)',
+    policies_evaluated  Array(String)   COMMENT 'L3 policies evaluated for this decision',
+    compliance_result   LowCardinality(String) COMMENT 'PASS | FAIL | ESCALATE | N/A (band)',
+    reasoning_summary   String          COMMENT 'Opaque human-readable rationale',
+    confidence_score    Float64         COMMENT 'Decision confidence [0,1]',
+    action_taken        String          COMMENT 'The action the mask performed',
+    correlation_id      String          COMMENT 'Process/run correlation handle',
+
+    -- ── Human-in-the-loop (ADR-046) ──────────────────────────────────────────
+    human_reviewed_by   Nullable(String) COMMENT 'Reviewer id when HITL applied, else NULL',
+    human_override_flag UInt8           COMMENT '1 when a human reviewed/overrode, else 0',
+    escalated_to        Nullable(String) COMMENT 'Role escalated to (MLRO/DPO/AML), else NULL',
+
+    -- ── Cost lineage (ADR-047) — never float for money; Decimal only ──────────
+    cost_tokens         UInt64          COMMENT 'Total tokens for this invocation',
+    cost_amount         Decimal(38, 18) COMMENT 'Monetary cost (Decimal — never float)',
+    budget_window_ref   LowCardinality(String) COMMENT 'Rolling cost-window ref',
+    budget_breach_flag  LowCardinality(String) COMMENT 'NONE | WARN | BREACH',
+    input_tokens        Nullable(UInt64) COMMENT 'Prompt-token split (refines cost_tokens)',
+    output_tokens       Nullable(UInt64) COMMENT 'Completion-token split (refines cost_tokens)',
+
+    -- ── WORM / immutable storage handle (ADR-046 §D5) ─────────────────────────
+    immutable_storage_ref Nullable(String) COMMENT 'WORM storage handle for the record',
+
+    -- ── Audit insertion stamp (immutable) ─────────────────────────────────────
+    inserted_at         DateTime DEFAULT now() COMMENT 'Row insertion timestamp (immutable)'
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (timestamp, agent_id, record_id)
+TTL toDateTime(timestamp) + INTERVAL 1825 DAY  -- 5 years (I-08: FCA minimum retention) -- nosemgrep: banxe-clickhouse-ttl-reduce
+SETTINGS index_granularity = 8192;

--- a/infra/clickhouse/migrations/README.md
+++ b/infra/clickhouse/migrations/README.md
@@ -14,6 +14,8 @@ All tables use MergeTree engine with 5-year TTL (FCA I-08 invariant).
 | `002_create_safeguarding_breaches.sql` | `banxe.safeguarding_breaches` | FCA CASS 15.12 breach records |
 | `003_create_recon_summary_mv.sql` | `banxe.recon_daily_summary` | Daily summary materialized view |
 | `004_create_fca_notifications.sql` | `banxe.fca_notifications` | FCA RegData submission audit |
+| `005_create_mcp_tool_events.sql` | `banxe.mcp_tool_events` | MCP tool-call metrics (IL-MCP-01) |
+| `006_create_decision_records.sql` | `banxe.decision_records` | Agent decision-lineage sink (ADR-046, FU-2; written only when `DECISION_RECORDER=clickhouse`) |
 
 ## How to Apply
 

--- a/services/agents/__init__.py
+++ b/services/agents/__init__.py
@@ -64,6 +64,11 @@ from services.agents.notification_agent import (
     NotificationMask,
     NotificationSendIntent,
 )
+from services.agents.recorders import (
+    ClickHouseDecisionRecorder,
+    InMemoryDecisionRecorder,
+    get_decision_recorder,
+)
 from services.agents.statement_agent import (
     DeliverStatementIntent,
     GenerateStatementIntent,
@@ -94,6 +99,7 @@ __all__ = [
     "CardsMask",
     "ChangeLimitIntent",
     "ChannelCheckIntent",
+    "ClickHouseDecisionRecorder",
     "ComplianceOverlay",
     "ComplianceResult",
     "ConfirmationDecision",
@@ -106,6 +112,7 @@ __all__ = [
     "GetReportIntent",
     "GetStatementIntent",
     "GetUserIntent",
+    "InMemoryDecisionRecorder",
     "IssueCardIntent",
     "ListReportsIntent",
     "ListStatementsIntent",
@@ -125,4 +132,5 @@ __all__ = [
     "StatementMask",
     "UnfreezeIntent",
     "UpdateTierIntent",
+    "get_decision_recorder",
 ]

--- a/services/agents/recorders.py
+++ b/services/agents/recorders.py
@@ -218,9 +218,7 @@ class ClickHouseDecisionRecorder(DecisionRecorder):
 
     def __init__(self, client: ClickHouseClient | None = None) -> None:
         self._client = client
-        self._insert_sql = (
-            f"INSERT INTO {_TABLE} (" + ", ".join(_COLUMNS) + ") VALUES"
-        )
+        self._insert_sql = f"INSERT INTO {_TABLE} (" + ", ".join(_COLUMNS) + ") VALUES"
 
     def _ch(self) -> ClickHouseClient:
         if self._client is None:
@@ -229,7 +227,9 @@ class ClickHouseDecisionRecorder(DecisionRecorder):
 
     async def record(self, record: AgentDecisionRecord) -> None:
         self._ch().insert(self._insert_sql, _to_row(record))
-        logger.debug("decision_records insert: record_id=%s agent=%s", record.record_id, record.agent_id)
+        logger.debug(
+            "decision_records insert: record_id=%s agent=%s", record.record_id, record.agent_id
+        )
 
     def query(
         self,

--- a/services/agents/recorders.py
+++ b/services/agents/recorders.py
@@ -1,0 +1,288 @@
+"""Concrete :class:`DecisionRecorder` sinks + the selection seam (ADR-046).
+
+WHY: ``services/agents/_lineage.py`` defines the :class:`DecisionRecorder` ABC
+(the producer→sink seam) but deliberately leaves the sink unimplemented — the
+masks depend only on the interface. This module supplies the two concrete sinks
+and the composition seam that chooses between them:
+
+* :class:`InMemoryDecisionRecorder` — the default. Append-only in-process list;
+  exactly the behaviour the system has today (no ClickHouse dependency).
+* :class:`ClickHouseDecisionRecorder` — a durable, queryable, regulatory-grade
+  store backed by ``banxe.decision_records`` (infra/clickhouse/migrations/006).
+  Strictly additive and OFF unless ``DECISION_RECORDER=clickhouse``.
+
+* :func:`get_decision_recorder` — the selection factory. With no env var (or
+  ``DECISION_RECORDER=inmemory``) it returns the in-memory sink, so the system
+  behaves exactly as before. This is the composition seam the Intent Layer will
+  call when it is later activated; INTENT_LAYER_ENABLED stays false for now.
+
+R-SEC (ADR-021): only opaque governance metadata is persisted — never
+seed/entropy/key/password/plaintext/ciphertext (see ``_lineage.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Protocol, runtime_checkable
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    DecisionRecorder,
+)
+
+logger = logging.getLogger(__name__)
+
+# Column order shared by INSERT and SELECT — keep in lockstep with migration 006
+# and with the AgentDecisionRecord → row mapping below.
+_COLUMNS: tuple[str, ...] = (
+    "record_id",
+    "timestamp",
+    "agent_id",
+    "triggering_event",
+    "intent",
+    "policies_evaluated",
+    "compliance_result",
+    "reasoning_summary",
+    "confidence_score",
+    "action_taken",
+    "correlation_id",
+    "human_reviewed_by",
+    "human_override_flag",
+    "escalated_to",
+    "cost_tokens",
+    "cost_amount",
+    "budget_window_ref",
+    "budget_breach_flag",
+    "input_tokens",
+    "output_tokens",
+    "immutable_storage_ref",
+)
+
+_TABLE = "banxe.decision_records"
+
+
+# ── In-memory sink (default — behaviour unchanged) ────────────────────────────
+
+
+class InMemoryDecisionRecorder(DecisionRecorder):
+    """Append-only in-process sink (the system's current default behaviour).
+
+    Records are kept in insertion order; :meth:`query` offers the same minimal
+    read surface as the ClickHouse sink so callers can switch sinks transparently.
+    """
+
+    def __init__(self) -> None:
+        self._records: list[AgentDecisionRecord] = []
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self._records.append(record)
+
+    def query(
+        self,
+        *,
+        agent_id: str | None = None,
+        correlation_id: str | None = None,
+        limit: int | None = None,
+    ) -> list[AgentDecisionRecord]:
+        """Return recorded records, newest first, optionally filtered."""
+        rows = [
+            r
+            for r in reversed(self._records)
+            if (agent_id is None or r.agent_id == agent_id)
+            and (correlation_id is None or r.correlation_id == correlation_id)
+        ]
+        return rows[:limit] if limit is not None else rows
+
+
+# ── ClickHouse sink (flagged, additive) ───────────────────────────────────────
+
+
+@runtime_checkable
+class ClickHouseClient(Protocol):
+    """Minimal seam over the ClickHouse driver (mirrors recon's client).
+
+    Two operations are enough for an append-only lineage store: a row insert and
+    a parameterised read. The default implementation wraps ``clickhouse_driver``;
+    tests inject a fake conforming to this Protocol (no live ClickHouse needed).
+    """
+
+    def insert(self, query: str, row: dict[str, object]) -> None: ...
+
+    def query(self, query: str, params: dict[str, object] | None = None) -> list[tuple]: ...
+
+
+class _DriverClickHouseClient:
+    """Production :class:`ClickHouseClient` over ``clickhouse_driver`` (lazy import).
+
+    Connection details come from ``services.config`` (CLICKHOUSE_HOST/PORT/DB/
+    USER/PASSWORD), exactly like ``services.recon.clickhouse_client`` — no
+    connection logic is duplicated beyond constructing the shared driver client.
+    """
+
+    def __init__(self) -> None:
+        from services.config import (
+            CLICKHOUSE_DB,
+            CLICKHOUSE_HOST,
+            CLICKHOUSE_PASSWORD,
+            CLICKHOUSE_PORT,
+            CLICKHOUSE_USER,
+        )
+
+        try:
+            import clickhouse_driver  # type: ignore[import-untyped]
+        except ImportError as exc:  # pragma: no cover - exercised only without the driver
+            raise RuntimeError(
+                "clickhouse-driver is not installed. Run: pip install clickhouse-driver"
+            ) from exc
+
+        self._client = clickhouse_driver.Client(
+            host=CLICKHOUSE_HOST,
+            port=CLICKHOUSE_PORT,
+            database=CLICKHOUSE_DB,
+            user=CLICKHOUSE_USER,
+            password=CLICKHOUSE_PASSWORD,
+        )
+
+    def insert(self, query: str, row: dict[str, object]) -> None:
+        self._client.execute(query, [row])
+
+    def query(self, query: str, params: dict[str, object] | None = None) -> list[tuple]:
+        return self._client.execute(query, params or {})
+
+
+def _to_row(record: AgentDecisionRecord) -> dict[str, object]:
+    """Serialise an AgentDecisionRecord into a ``decision_records`` row dict."""
+    return {
+        "record_id": record.record_id,
+        "timestamp": record.timestamp,
+        "agent_id": record.agent_id,
+        "triggering_event": record.triggering_event,
+        "intent": record.intent,
+        "policies_evaluated": list(record.policies_evaluated),
+        "compliance_result": str(record.compliance_result),
+        "reasoning_summary": record.reasoning_summary,
+        "confidence_score": record.confidence_score,
+        "action_taken": record.action_taken,
+        "correlation_id": record.correlation_id,
+        "human_reviewed_by": record.human_reviewed_by,
+        "human_override_flag": 1 if record.human_reviewed_by else 0,
+        "escalated_to": record.escalated_to,
+        "cost_tokens": record.cost_tokens,
+        "cost_amount": record.cost_amount,
+        "budget_window_ref": record.budget_window_ref,
+        "budget_breach_flag": str(record.budget_breach_flag),
+        "input_tokens": record.input_tokens,
+        "output_tokens": record.output_tokens,
+        "immutable_storage_ref": record.immutable_storage_ref,
+    }
+
+
+def _from_row(row: tuple) -> AgentDecisionRecord:
+    """Rebuild an AgentDecisionRecord from a SELECT row (columns in _COLUMNS order)."""
+    v = dict(zip(_COLUMNS, row, strict=True))
+    return AgentDecisionRecord(
+        record_id=v["record_id"],
+        timestamp=v["timestamp"],
+        agent_id=v["agent_id"],
+        triggering_event=v["triggering_event"],
+        intent=v["intent"],
+        policies_evaluated=list(v["policies_evaluated"]),
+        compliance_result=ComplianceResult(v["compliance_result"]),
+        reasoning_summary=v["reasoning_summary"],
+        confidence_score=v["confidence_score"],
+        action_taken=v["action_taken"],
+        human_reviewed_by=v["human_reviewed_by"],
+        correlation_id=v["correlation_id"],
+        cost_tokens=v["cost_tokens"],
+        cost_amount=v["cost_amount"],
+        budget_window_ref=v["budget_window_ref"],
+        budget_breach_flag=BudgetBreach(v["budget_breach_flag"]),
+        escalated_to=v["escalated_to"],
+        immutable_storage_ref=v["immutable_storage_ref"],
+        input_tokens=v["input_tokens"],
+        output_tokens=v["output_tokens"],
+    )
+
+
+class ClickHouseDecisionRecorder(DecisionRecorder):
+    """Durable, queryable lineage sink backed by ``banxe.decision_records``.
+
+    The client is injected for testability; when omitted, a lazily-built
+    :class:`_DriverClickHouseClient` reads connection details from the shared
+    ClickHouse env/config. Construction never opens a socket until the first
+    insert/query, so the failure mode is a clear runtime error at first use.
+    """
+
+    def __init__(self, client: ClickHouseClient | None = None) -> None:
+        self._client = client
+        self._insert_sql = (
+            f"INSERT INTO {_TABLE} (" + ", ".join(_COLUMNS) + ") VALUES"
+        )
+
+    def _ch(self) -> ClickHouseClient:
+        if self._client is None:
+            self._client = _DriverClickHouseClient()
+        return self._client
+
+    async def record(self, record: AgentDecisionRecord) -> None:
+        self._ch().insert(self._insert_sql, _to_row(record))
+        logger.debug("decision_records insert: record_id=%s agent=%s", record.record_id, record.agent_id)
+
+    def query(
+        self,
+        *,
+        agent_id: str | None = None,
+        correlation_id: str | None = None,
+        limit: int = 100,
+    ) -> list[AgentDecisionRecord]:
+        """Read lineage back, newest first, filtered by agent_id and/or correlation_id."""
+        where: list[str] = []
+        params: dict[str, object] = {}
+        if agent_id is not None:
+            where.append("agent_id = %(agent_id)s")
+            params["agent_id"] = agent_id
+        if correlation_id is not None:
+            where.append("correlation_id = %(correlation_id)s")
+            params["correlation_id"] = correlation_id
+        clause = (" WHERE " + " AND ".join(where)) if where else ""
+        cols = ", ".join(_COLUMNS)
+        # nosec B608 — every interpolated part is a module constant (_COLUMNS,
+        # _TABLE, fixed WHERE fragments) or an int-cast; row values are bound via
+        # named params, never interpolated.
+        sql = f"SELECT {cols} FROM {_TABLE}{clause} ORDER BY timestamp DESC LIMIT {int(limit)}"  # noqa: S608, E501
+        return [_from_row(r) for r in self._ch().query(sql, params)]
+
+
+# ── Selection seam ────────────────────────────────────────────────────────────
+
+
+def get_decision_recorder(client: ClickHouseClient | None = None) -> DecisionRecorder:
+    """Select the lineage sink from the ``DECISION_RECORDER`` env var.
+
+    ``inmemory`` (default, or unset) → :class:`InMemoryDecisionRecorder`; the
+    system behaves exactly as today. ``clickhouse`` →
+    :class:`ClickHouseDecisionRecorder`. Any other value raises (fail-closed) so
+    a typo can never silently fall back to a different durability guarantee.
+
+    NOTE: this is the composition seam only — selecting the sink does NOT enable
+    the Intent Layer. INTENT_LAYER_ENABLED stays false until a later FU.
+    """
+    choice = os.environ.get("DECISION_RECORDER", "inmemory").strip().lower()
+    if choice == "inmemory":
+        return InMemoryDecisionRecorder()
+    if choice == "clickhouse":
+        return ClickHouseDecisionRecorder(client=client)
+    raise ValueError(
+        f"DECISION_RECORDER={choice!r} is invalid; expected 'inmemory' or 'clickhouse'"
+    )
+
+
+__all__ = [
+    "ClickHouseClient",
+    "ClickHouseDecisionRecorder",
+    "InMemoryDecisionRecorder",
+    "get_decision_recorder",
+]

--- a/tests/agents/test_recorders.py
+++ b/tests/agents/test_recorders.py
@@ -136,7 +136,10 @@ class _FakeClickHouseClient:
             r
             for r in self.rows
             if ("agent_id" not in params or r[idx["agent_id"]] == params["agent_id"])
-            and ("correlation_id" not in params or r[idx["correlation_id"]] == params["correlation_id"])
+            and (
+                "correlation_id" not in params
+                or r[idx["correlation_id"]] == params["correlation_id"]
+            )
         ]
         return list(reversed(out))
 

--- a/tests/agents/test_recorders.py
+++ b/tests/agents/test_recorders.py
@@ -1,0 +1,208 @@
+"""Tests for the concrete DecisionRecorder sinks + the selection seam (FU-2).
+
+Covers:
+* ``InMemoryDecisionRecorder`` — record + query (the unchanged default).
+* ``get_decision_recorder`` — default/inmemory/clickhouse/invalid selection.
+* ``ClickHouseDecisionRecorder`` — serialise → insert and query → deserialise
+  round-trip against an in-process fake client (no live ClickHouse needed).
+* A live ClickHouse round-trip gated on ``DECISION_RECORDER_TEST_DSN`` so CI
+  stays green where ClickHouse is not configured.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+import os
+
+import pytest
+
+from services.agents._lineage import (
+    AgentDecisionRecord,
+    BudgetBreach,
+    ComplianceResult,
+    DecisionRecorder,
+)
+from services.agents.recorders import (
+    _COLUMNS,
+    ClickHouseDecisionRecorder,
+    InMemoryDecisionRecorder,
+    _from_row,
+    _to_row,
+    get_decision_recorder,
+)
+
+
+def _record(**overrides: object) -> AgentDecisionRecord:
+    base: dict[str, object] = {
+        "record_id": "r-1",
+        "timestamp": datetime(2026, 6, 14, 12, 0, 0, tzinfo=UTC),
+        "agent_id": "kyc-onboarding",
+        "triggering_event": "client.kyc.submitted",
+        "intent": "verify_identity",
+        "policies_evaluated": ["MLR-2017-18", "ADR-046"],
+        "compliance_result": ComplianceResult.PASS,
+        "reasoning_summary": "all checks passed",
+        "confidence_score": 0.97,
+        "action_taken": "approve",
+        "human_reviewed_by": None,
+        "correlation_id": "corr-abc",
+        "cost_tokens": 1200,
+        "cost_amount": Decimal("0.004200000000000000"),
+        "budget_window_ref": "kyc-onboarding:default",
+        "budget_breach_flag": BudgetBreach.NONE,
+    }
+    base.update(overrides)
+    return AgentDecisionRecord(**base)  # type: ignore[arg-type]
+
+
+# ── InMemoryDecisionRecorder (the unchanged default) ──────────────────────────
+
+
+async def test_inmemory_records_and_queries_newest_first() -> None:
+    rec = InMemoryDecisionRecorder()
+    await rec.record(_record(record_id="r-1"))
+    await rec.record(_record(record_id="r-2"))
+    out = rec.query()
+    assert [r.record_id for r in out] == ["r-2", "r-1"]
+
+
+async def test_inmemory_query_filters_and_limit() -> None:
+    rec = InMemoryDecisionRecorder()
+    await rec.record(_record(record_id="r-1", agent_id="a", correlation_id="c1"))
+    await rec.record(_record(record_id="r-2", agent_id="b", correlation_id="c2"))
+    await rec.record(_record(record_id="r-3", agent_id="a", correlation_id="c2"))
+    assert [r.record_id for r in rec.query(agent_id="a")] == ["r-3", "r-1"]
+    assert [r.record_id for r in rec.query(correlation_id="c2")] == ["r-3", "r-2"]
+    assert [r.record_id for r in rec.query(agent_id="a", limit=1)] == ["r-3"]
+
+
+def test_inmemory_is_a_decision_recorder() -> None:
+    assert isinstance(InMemoryDecisionRecorder(), DecisionRecorder)
+
+
+# ── Selection seam ────────────────────────────────────────────────────────────
+
+
+def test_get_decision_recorder_defaults_to_inmemory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DECISION_RECORDER", raising=False)
+    assert isinstance(get_decision_recorder(), InMemoryDecisionRecorder)
+
+
+@pytest.mark.parametrize("value", ["inmemory", "InMemory", "  inmemory  "])
+def test_get_decision_recorder_inmemory(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DECISION_RECORDER", value)
+    assert isinstance(get_decision_recorder(), InMemoryDecisionRecorder)
+
+
+def test_get_decision_recorder_clickhouse(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DECISION_RECORDER", "clickhouse")
+    # Inject a fake client so no driver/socket is touched at selection time.
+    rec = get_decision_recorder(client=_FakeClickHouseClient())
+    assert isinstance(rec, ClickHouseDecisionRecorder)
+
+
+def test_get_decision_recorder_invalid_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DECISION_RECORDER", "postgres")
+    with pytest.raises(ValueError, match="invalid"):
+        get_decision_recorder()
+
+
+# ── ClickHouseDecisionRecorder against a fake client ──────────────────────────
+
+
+class _FakeClickHouseClient:
+    """In-process stand-in for the ClickHouse driver client.
+
+    Stores inserted rows as tuples in ``_COLUMNS`` order and serves ``query`` by
+    applying the named params the recorder passes — enough to exercise the full
+    serialise → insert and query → deserialise round-trip without ClickHouse.
+    """
+
+    def __init__(self) -> None:
+        self.rows: list[tuple] = []
+        self.last_insert_sql: str | None = None
+        self.last_query_sql: str | None = None
+
+    def insert(self, query: str, row: dict[str, object]) -> None:
+        self.last_insert_sql = query
+        self.rows.append(tuple(row[c] for c in _COLUMNS))
+
+    def query(self, query: str, params: dict[str, object] | None = None) -> list[tuple]:
+        self.last_query_sql = query
+        params = params or {}
+        idx = {c: i for i, c in enumerate(_COLUMNS)}
+        out = [
+            r
+            for r in self.rows
+            if ("agent_id" not in params or r[idx["agent_id"]] == params["agent_id"])
+            and ("correlation_id" not in params or r[idx["correlation_id"]] == params["correlation_id"])
+        ]
+        return list(reversed(out))
+
+
+async def test_clickhouse_insert_serialises_record() -> None:
+    client = _FakeClickHouseClient()
+    rec = ClickHouseDecisionRecorder(client=client)
+    await rec.record(_record(record_id="r-1", human_reviewed_by="MLRO-7"))
+    assert client.last_insert_sql is not None
+    assert client.last_insert_sql.startswith("INSERT INTO banxe.decision_records")
+    stored = dict(zip(_COLUMNS, client.rows[0], strict=True))
+    assert stored["record_id"] == "r-1"
+    assert stored["human_reviewed_by"] == "MLRO-7"
+    assert stored["human_override_flag"] == 1  # derived from human_reviewed_by
+    assert stored["compliance_result"] == "PASS"
+    assert stored["budget_breach_flag"] == "NONE"
+    assert stored["policies_evaluated"] == ["MLR-2017-18", "ADR-046"]
+
+
+async def test_clickhouse_round_trip_query() -> None:
+    client = _FakeClickHouseClient()
+    rec = ClickHouseDecisionRecorder(client=client)
+    await rec.record(_record(record_id="r-1", agent_id="a", correlation_id="c1"))
+    await rec.record(_record(record_id="r-2", agent_id="b", correlation_id="c1"))
+
+    by_agent = rec.query(agent_id="a")
+    assert [r.record_id for r in by_agent] == ["r-1"]
+    assert isinstance(by_agent[0], AgentDecisionRecord)
+    assert by_agent[0].compliance_result is ComplianceResult.PASS
+    assert by_agent[0].budget_breach_flag is BudgetBreach.NONE
+    assert by_agent[0].cost_amount == Decimal("0.004200000000000000")
+
+    by_corr = rec.query(correlation_id="c1")
+    assert {r.record_id for r in by_corr} == {"r-1", "r-2"}
+
+
+def test_to_from_row_round_trip_preserves_fields() -> None:
+    rec = _record(
+        human_reviewed_by="DPO-2",
+        escalated_to="MLRO",
+        immutable_storage_ref="worm://lineage/r-1",
+        input_tokens=800,
+        output_tokens=400,
+        budget_breach_flag=BudgetBreach.WARN,
+        compliance_result=ComplianceResult.ESCALATE,
+    )
+    row = tuple(_to_row(rec)[c] for c in _COLUMNS)
+    back = _from_row(row)
+    assert back == rec
+
+
+# ── Live ClickHouse round-trip (opt-in) ───────────────────────────────────────
+
+_LIVE_DSN = os.environ.get("DECISION_RECORDER_TEST_DSN")
+
+
+@pytest.mark.skipif(
+    not _LIVE_DSN,
+    reason="Set DECISION_RECORDER_TEST_DSN to run the live ClickHouse round-trip",
+)
+async def test_clickhouse_live_round_trip() -> None:  # pragma: no cover - opt-in only
+    from services.agents.recorders import _DriverClickHouseClient
+
+    client = _DriverClickHouseClient()
+    rec = ClickHouseDecisionRecorder(client=client)
+    unique = _record(record_id="live-" + datetime.now(UTC).isoformat(), correlation_id="live-corr")
+    await rec.record(unique)
+    out = rec.query(correlation_id="live-corr", limit=10)
+    assert any(r.record_id == unique.record_id for r in out)


### PR DESCRIPTION
## Summary

FU-2 step 2 — turns agent decision-lineage from an in-memory-only seam into a durable, queryable, regulatory-grade store, **behind a feature flag**, with the default behaviour completely unchanged.

- **New table** — `infra/clickhouse/migrations/006_create_decision_records.sql`: additive `banxe.decision_records` (MergeTree, `PARTITION BY toYYYYMM(timestamp)`, 5-year TTL per I-08). Maps `AgentDecisionRecord` 1:1 — `Decimal(38,18)` for cost (never float), `Array(String)` policies, `LowCardinality` bands, `Nullable` HITL/WORM/token-split fields. No existing table is dropped or altered.
- **New recorder** — `services/agents/recorders.py`:
  - `InMemoryDecisionRecorder` — the current default (append-only in-process list) with a minimal `query()`.
  - `ClickHouseDecisionRecorder` — serialise → insert and `query()` → deserialise round-trip against `decision_records`. Client is injected for testability; the default `clickhouse_driver` client is **lazily** built from the existing `CLICKHOUSE_*` config (`services/config`), mirroring `services/recon/clickhouse_client.py` — no connection logic duplicated, no socket opened until first use.
- **Flag-based selection** — `get_decision_recorder()` reads `DECISION_RECORDER` (`inmemory` default / `clickhouse`); any other value **fails closed** (raises) so a typo can't silently downgrade durability. This is the composition seam the Intent Layer will call when later activated. Conforms to the existing `DecisionRecorder` ABC — no API change.
- **Tests** — `tests/agents/test_recorders.py`: in-memory record/query, selection matrix, ClickHouse serialise/insert + query/deserialise round-trip via an in-process fake client (no live CH), and a `_to_row`/`_from_row` field-preservation check. A live round-trip is gated on `DECISION_RECORDER_TEST_DSN` and **skipped** otherwise, so CI stays green without ClickHouse.
- **Docs** — `docs/clickhouse-dev-setup.md`: how to apply migration 006, set `DECISION_RECORDER=clickhouse` locally, and run the tests — with an explicit warning.

## Safety / scope

- **`INTENT_LAYER_ENABLED` remains false** — unchanged by this PR. Selecting the sink does **not** enable the Intent Layer; **no live client dispatch is affected**.
- Default path (env unset) behaves exactly as today (in-memory only).
- Only `CarmiBanxe/banxe-emi-stack` is touched — no `banxe-architecture` / `banxe-payment-core` changes, no new HTTP surfaces.
- `InMemoryDecisionRecorder` is preserved; the ClickHouse path is strictly additive and behind the flag.

## Verification

- `ruff check` clean on all changed files.
- Full suite: **11089 passed, 6 skipped** (`pytest`), coverage **91.7%** (gate 35%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)