### PR TITLE
FU-2: Intent Layer dark-mode tests and dry-run harness

### DIFF
--- a/docs/intent-layer-dev.md
+++ b/docs/intent-layer-dev.md
@@ -1,0 +1,110 @@
+# Intent Layer — developer guide (dark-mode testing & dry-run)
+
+> **Status (FU-2 Phase 3):** the ADR-049 L1 Intent Layer ships **inert**.
+> `INTENT_LAYER_ENABLED` is **`false` in every environment** and this phase does
+> **not** activate it for real traffic. The work here is tests + tooling only:
+> a way to exercise classification/routing/lineage end-to-end while the layer stays dark.
+
+## What "dark mode" means
+
+With `INTENT_LAYER_ENABLED=false` (the default):
+
+| Stage | Behaviour while dark |
+| --- | --- |
+| HTTP `POST /v1/intent` | Accepts the request, returns `{"enabled": false, "disposition": "NOT_ENABLED"}` |
+| `IntentRouter.route()` | Returns `NOT_ENABLED` **before** any dispatch — the flag gate is checked first |
+| `IntentClassifier` | Deterministic match still runs; the **LLM fuzzy fallback is suppressed** |
+| `AgentDispatchPort` | **Never called** — no L2 mask, no payment-core adapter, no outbound call |
+| Lineage sink | **Nothing recorded** — neither in-memory nor ClickHouse, even with `DECISION_RECORDER=clickhouse` |
+
+The flag is distinct from ADR-021's `AGENT_ROUTING_ENABLED` (the internal
+compliance task-router) — the two layers must never share a flag.
+
+## Running the dark-mode tests
+
+```bash
+# The dedicated dark-mode module (pure layer + HTTP entrypoint):
+pytest tests/test_intent_layer/test_intent_layer_dark_mode.py -v
+
+# The whole Intent Layer suite (classifier, router, composition, e2e, dark mode):
+pytest tests/test_intent_layer/ -v
+```
+
+The tests inject **exploding doubles** — an `AgentDispatchPort`, an `LLMClassifierPort`
+and a `ClickHouseClient` that each raise if ever called — so any external side effect
+in dark mode fails the test loudly instead of happening silently.
+
+### ClickHouse-dependent tests (opt-in)
+
+Lineage tests that need a live ClickHouse are **skipped** unless a DSN is provided, so
+CI stays green without ClickHouse:
+
+```bash
+# Opt in to the live ClickHouse round-trip + dark-mode "records nothing" check:
+DECISION_RECORDER_TEST_DSN=clickhouse://localhost:9000/banxe \
+  pytest tests/test_intent_layer/test_intent_layer_dark_mode.py tests/agents/test_recorders.py -v
+```
+
+`DECISION_RECORDER=clickhouse` only *selects* the durable sink — it does **not** enable
+the Intent Layer. `INTENT_LAYER_ENABLED` stays `false`.
+
+## Dry-run CLI (`scripts/intent_layer_dryrun.py`)
+
+A **developer-only** tool (not a production entrypoint) to explore how an intent
+classifies and routes, while the layer stays dark. It drives the *same* internal
+entrypoint the HTTP handler uses, with an **inert simulating dispatcher** that never
+touches a real mask, adapter, the network, or ClickHouse.
+
+```bash
+# Pipe a JSON payload:
+echo '{"intent_text": "send money"}' | python scripts/intent_layer_dryrun.py
+
+# Or pass the text directly:
+python scripts/intent_layer_dryrun.py --intent "freeze my card"
+
+# Read what WOULD happen if the layer were enabled (report only — still no real dispatch):
+python scripts/intent_layer_dryrun.py --intent "exchange" --force-simulate
+
+# Machine-readable output:
+python scripts/intent_layer_dryrun.py --intent "notifications" --json
+```
+
+Example (dark, default):
+
+```
+=== Intent Layer dry-run (DEV TOOL — no real dispatch) ===
+intent_text          : 'send money'
+correlation_id       : 9f3c…
+INTENT_LAYER_ENABLED : false  (actual env flag)
+mode                 : DARK
+-- classification --
+  status             : RESOLVED
+  matched_intent     : pay
+  capability / mask  : Payments
+  confidence / band  : 1.00 / AUTO
+  match_source       : ALIAS
+  process_refs       : payment-processing-process@1.0.0
+-- routing --
+  disposition        : NOT_ENABLED
+  would dispatch if enabled : yes
+  real dispatch performed   : NO (dry-run never touches a mask/adapter/ClickHouse)
+```
+
+> Classification is deterministic (exact/alias match against the intent→process map).
+> Free-form phrasing like `"send money to Alice"` resolves to `UNRESOLVED` until the
+> S1 LLM fuzzy fallback is wired — and that fallback is itself suppressed while dark.
+
+- **`--force-simulate`** only changes the *report* (it lets the classifier/router
+  reason as if enabled); the dispatcher remains a no-op simulator, so no live mask,
+  adapter, network call, or ClickHouse write ever happens.
+- The catalogue is loaded from the live S3 files when `INTENT_PROCESS_MAP_PATH` +
+  `INTENT_PROCESS_REGISTRY_PATH` are set, otherwise from the embedded snapshot.
+
+## What this phase does NOT do
+
+- It does **not** set `INTENT_LAYER_ENABLED=true` anywhere.
+- It does **not** change any production env default or public API contract.
+- It does **not** touch `banxe-architecture` or `banxe-payment-core`.
+
+Real activation (live cross-repo masks, real L3, the S1 LLM gateway, the ClickHouse
+sink in production) is a later, separate operator step.

--- a/scripts/intent_layer_dryrun.py
+++ b/scripts/intent_layer_dryrun.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+scripts/intent_layer_dryrun.py — DEVELOPER TOOL (NOT a production entrypoint).
+
+Dry-run harness for the ADR-049 L1 Intent Layer. It drives a single client intent
+through the SAME internal entrypoint the HTTP handler uses (catalog → classifier →
+router) and reports what L1 would do — WITHOUT performing any real dispatch.
+
+Safety contract (FU-2 Phase 3 — dark mode):
+  * Respects ``INTENT_LAYER_ENABLED`` (default false). While false the report shows the
+    inert ``NOT_ENABLED`` disposition exactly as the live layer returns it.
+  * ``--force-simulate`` flips the *report* to show what WOULD happen if the layer were
+    enabled — but the dispatcher is an inert simulator that NEVER calls a real L2 mask,
+    a payment-core adapter, the network, or ClickHouse. No external side effect, ever.
+  * No new public endpoint, no live infra — a local CLI only.
+
+Usage::
+
+    echo '{"intent_text": "send money to Alice"}' | python scripts/intent_layer_dryrun.py
+    python scripts/intent_layer_dryrun.py --intent "freeze my card"
+    python scripts/intent_layer_dryrun.py --file intent.json --force-simulate --json
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import sys
+
+# Allow running as a bare script (``python scripts/intent_layer_dryrun.py``) by
+# putting the repo root on the path before importing the services package.
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent))
+
+from services.intent_layer.catalog_snapshot import load_catalog  # noqa: E402
+from services.intent_layer.classifier import IntentClassifier  # noqa: E402
+from services.intent_layer.config import intent_layer_enabled  # noqa: E402
+from services.intent_layer.models import DispositionKind, ResolvedIntent  # noqa: E402
+from services.intent_layer.ports import DispatchReceipt, DispatchRequest  # noqa: E402
+from services.intent_layer.router import IntentRouter  # noqa: E402
+
+
+class _SimulatingDispatcher:
+    """Inert ``AgentDispatchPort`` for the dry-run: it performs NO work — no L2 mask,
+    no adapter, no network, no ClickHouse — and returns an honest 'simulated' receipt.
+    This keeps the real router/gate logic on the code path while guaranteeing zero
+    external side effects, even under ``--force-simulate``."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def dispatch(self, request: DispatchRequest) -> DispatchReceipt:
+        self.calls += 1
+        return DispatchReceipt(
+            accepted=False,
+            agent="(dry-run-simulated)",
+            detail="dry-run: no real dispatch performed",
+            metadata={"simulated": "true", "capability": request.capability},
+        )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="intent_layer_dryrun",
+        description="DEV TOOL: dry-run the L1 Intent Layer with no real dispatch.",
+    )
+    src = parser.add_mutually_exclusive_group()
+    src.add_argument("--intent", help="Free-form client intent text.")
+    src.add_argument("--file", help="Path to a JSON file: {intent_text, correlation_id?}.")
+    parser.add_argument("--correlation-id", help="Optional trace id (generated when absent).")
+    parser.add_argument(
+        "--force-simulate",
+        action="store_true",
+        help="Report what WOULD happen if enabled. Still performs NO real dispatch.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON.")
+    return parser.parse_args(argv)
+
+
+def _read_intent(args: argparse.Namespace) -> tuple[str, str | None]:
+    """Resolve the intent text + optional correlation id from --intent / --file / stdin."""
+    if args.intent is not None:
+        return args.intent, args.correlation_id
+    if args.file is not None:
+        with open(args.file, encoding="utf-8") as handle:
+            payload = json.load(handle)
+        return payload["intent_text"], payload.get("correlation_id", args.correlation_id)
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise SystemExit("no intent supplied (use --intent, --file, or pipe JSON/text on stdin)")
+    if raw.startswith("{"):
+        payload = json.loads(raw)
+        return payload["intent_text"], payload.get("correlation_id", args.correlation_id)
+    return raw, args.correlation_id
+
+
+@dataclass(frozen=True)
+class _Report:
+    intent_text: str
+    correlation_id: str
+    flag_enabled: bool
+    force_simulate: bool
+    resolved: ResolvedIntent
+    disposition_kind: DispositionKind
+
+
+def _build_report(intent_text: str, correlation_id: str | None, *, force_simulate: bool) -> _Report:
+    """Run classify → route through the real layer with an inert dispatcher."""
+    flag_enabled = intent_layer_enabled()
+    effective = flag_enabled or force_simulate
+    catalog = load_catalog()
+    classifier = IntentClassifier(catalog, enabled=effective)  # NullLLM → no live LLM
+    router = IntentRouter(_SimulatingDispatcher(), enabled=effective)
+    resolved = classifier.classify(intent_text, correlation_id=correlation_id)
+    disposition = router.route(resolved)
+    return _Report(
+        intent_text=intent_text,
+        correlation_id=resolved.correlation_id,
+        flag_enabled=flag_enabled,
+        force_simulate=force_simulate,
+        resolved=resolved,
+        disposition_kind=disposition.kind,
+    )
+
+
+def _report_dict(report: _Report) -> dict[str, object]:
+    r = report.resolved
+    return {
+        "intent_text": report.intent_text,
+        "correlation_id": report.correlation_id,
+        "INTENT_LAYER_ENABLED": report.flag_enabled,
+        "mode": "SIMULATE"
+        if (report.force_simulate and not report.flag_enabled)
+        else ("ENABLED" if report.flag_enabled else "DARK"),
+        "classification": {
+            "status": r.status.value,
+            "matched_intent": r.matched_intent,
+            "capability": r.capability,
+            "confidence": r.confidence,
+            "band": r.band.value,
+            "match_source": r.match_source.value,
+            "process_refs": [f"{p.process_id}@{p.version}" for p in r.process_refs],
+        },
+        "disposition": report.disposition_kind.value,
+        "would_dispatch_if_enabled": r.is_resolved,
+        "real_dispatch_performed": False,
+    }
+
+
+def _render_human(report: _Report) -> str:
+    d = _report_dict(report)
+    c = d["classification"]
+    refs = ", ".join(c["process_refs"]) or "—"  # type: ignore[arg-type]
+    return "\n".join(
+        [
+            "=== Intent Layer dry-run (DEV TOOL — no real dispatch) ===",
+            f"intent_text          : {d['intent_text']!r}",
+            f"correlation_id       : {d['correlation_id']}",
+            f"INTENT_LAYER_ENABLED : {str(d['INTENT_LAYER_ENABLED']).lower()}  (actual env flag)",
+            f"mode                 : {d['mode']}",
+            "-- classification --",
+            f"  status             : {c['status']}",
+            f"  matched_intent     : {c['matched_intent']}",
+            f"  capability / mask  : {c['capability']}",
+            f"  confidence / band  : {c['confidence']:.2f} / {c['band']}",
+            f"  match_source       : {c['match_source']}",
+            f"  process_refs       : {refs}",
+            "-- routing --",
+            f"  disposition        : {d['disposition']}",
+            f"  would dispatch if enabled : {'yes' if d['would_dispatch_if_enabled'] else 'no'}",
+            "  real dispatch performed   : NO (dry-run never touches a mask/adapter/ClickHouse)",
+        ]
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    intent_text, correlation_id = _read_intent(args)
+    report = _build_report(intent_text, correlation_id, force_simulate=args.force_simulate)
+    if args.json:
+        print(json.dumps(_report_dict(report), indent=2))
+    else:
+        print(_render_human(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_intent_layer/test_intent_layer_dark_mode.py
+++ b/tests/test_intent_layer/test_intent_layer_dark_mode.py
@@ -1,0 +1,262 @@
+"""
+tests/test_intent_layer/test_intent_layer_dark_mode.py — FU-2 Phase 3 DARK-MODE proof.
+
+Exercises the ADR-049 L1 Intent Layer end-to-end with ``INTENT_LAYER_ENABLED=false``
+(the default in every environment) and proves it is genuinely INERT:
+
+  * every typical client intent (payments, FX, wallet, notifications, KYC, …) routes
+    to ``NOT_ENABLED`` — never DISPATCHED, never a governance event;
+  * NO external side effect fires: the injected ``AgentDispatchPort`` is an exploding
+    double that fails the test if ``dispatch()`` is ever called — proving no outbound
+    HTTP, no payment-core adapter, no L2 mask invocation;
+  * the LLM fuzzy fallback is suppressed — an exploding ``LLMClassifierPort`` is never
+    consulted while disabled;
+  * NO lineage record is emitted — neither to the in-memory sink nor (even when
+    ``DECISION_RECORDER=clickhouse`` is selected) to the durable ClickHouse sink, which
+    is wired with an exploding client that fails on any insert/query.
+
+The HTTP entrypoint (POST /v1/intent) is also driven through FastAPI's TestClient for
+the same intents, asserting the dark ``NOT_ENABLED`` envelope and that nothing is
+retrievable by ``correlation_id`` afterwards.
+
+This phase does NOT activate the Intent Layer for real traffic — it only verifies the
+safe pre-activation contract. The live ClickHouse round-trip stays opt-in behind
+``DECISION_RECORDER_TEST_DSN`` so CI is green without ClickHouse.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from services.agents.recorders import ClickHouseDecisionRecorder
+from services.intent_layer.classifier import IntentClassifier
+from services.intent_layer.composition import (
+    CapabilityDispatcher,
+    InMemoryDecisionRecorder,
+)
+from services.intent_layer.config import (
+    INTENT_LAYER_ENABLED_ENV,
+    intent_layer_enabled,
+)
+from services.intent_layer.models import DispositionKind
+from services.intent_layer.ports import (
+    DispatchReceipt,
+    DispatchRequest,
+    IntentDefinition,
+    LLMClassification,
+)
+from services.intent_layer.router import IntentRouter
+from services.producers.bundle import ProducerBundle
+
+# Typical client intents across the 9 capabilities (mix of canonical tokens + aliases).
+DARK_INTENTS = [
+    "pay",
+    "send money",
+    "exchange",
+    "convert currency",
+    "view-balance",
+    "freeze-card",
+    "onboard-kyc",
+    "get-statement",
+    "notifications",
+    "alerts",
+]
+
+
+# ── Exploding doubles: any side effect in dark mode is a test failure ────────────
+
+
+class ExplodingDispatcher:
+    """``AgentDispatchPort`` that MUST NOT be called while disabled. Any dispatch is a
+    forbidden external side effect (an L2 mask / payment-core adapter / outbound call),
+    so it fails the test loudly instead of silently performing it."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def dispatch(self, request: DispatchRequest) -> DispatchReceipt:
+        self.calls += 1
+        raise AssertionError(
+            "AgentDispatchPort.dispatch() called while INTENT_LAYER_ENABLED=false "
+            "— forbidden side effect in dark mode"
+        )
+
+
+class ExplodingLLM:
+    """``LLMClassifierPort`` that MUST NOT be consulted while disabled — the fuzzy LLM
+    fallback is suppressed in dark mode (config.py gating semantics)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def classify(
+        self, intent_text: str, candidates: list[IntentDefinition]
+    ) -> LLMClassification | None:
+        self.calls += 1
+        raise AssertionError(
+            "LLM fuzzy fallback consulted while INTENT_LAYER_ENABLED=false — forbidden"
+        )
+
+
+class ExplodingClickHouseClient:
+    """``ClickHouseClient`` that fails on any insert/query — proves the durable lineage
+    sink is never touched while dark, even when ``DECISION_RECORDER=clickhouse``."""
+
+    def insert(self, query: str, row: dict[str, object]) -> None:
+        raise AssertionError("ClickHouse insert while INTENT_LAYER_ENABLED=false — forbidden")
+
+    def query(self, query: str, params: dict[str, object] | None = None) -> list[tuple]:
+        raise AssertionError("ClickHouse query while INTENT_LAYER_ENABLED=false — forbidden")
+
+
+def _exploding_handler(request: DispatchRequest, outputs, recorder) -> None:
+    raise AssertionError("L2 mask invoked while INTENT_LAYER_ENABLED=false — forbidden")
+
+
+# ── Pure-layer dark mode: classify → route, every intent inert ───────────────────
+
+
+@pytest.mark.parametrize("text", DARK_INTENTS)
+def test_dark_mode_intent_is_inert_no_dispatch(catalog, text):
+    """Each typical intent → NOT_ENABLED, no dispatch, LLM fallback never consulted."""
+    dispatcher = ExplodingDispatcher()
+    llm = ExplodingLLM()
+    classifier = IntentClassifier(catalog, enabled=False, llm=llm)
+    router = IntentRouter(dispatcher, enabled=False)
+
+    resolved = classifier.classify(text, correlation_id=f"dark-{text}")
+    disposition = router.route(resolved)
+
+    assert disposition.kind is DispositionKind.NOT_ENABLED
+    assert disposition.receipt is None
+    assert dispatcher.calls == 0  # no L2 mask / adapter / outbound call
+    assert llm.calls == 0  # fuzzy fallback suppressed while dark
+
+
+def test_dark_mode_unresolved_short_circuits_to_not_enabled(catalog):
+    """The flag gate precedes the governance-event branch: even an UNRESOLVED intent
+    yields NOT_ENABLED while dark (no governance event, no dispatch)."""
+    dispatcher = ExplodingDispatcher()
+    classifier = IntentClassifier(catalog, enabled=False, llm=ExplodingLLM())
+    router = IntentRouter(dispatcher, enabled=False)
+
+    resolved = classifier.classify("zxqw gibberish nonsense", correlation_id="dark-unres")
+    disposition = router.route(resolved)
+
+    assert disposition.kind is DispositionKind.NOT_ENABLED
+    assert dispatcher.calls == 0
+
+
+# ── Lineage: nothing recorded while dark (in-memory + ClickHouse sinks) ───────────
+
+
+def test_dark_mode_emits_no_inmemory_lineage_record(catalog):
+    """With a real CapabilityDispatcher wired to an in-memory sink, a disabled router
+    never dispatches, so no AgentDecisionRecord is ever emitted."""
+    recorder = InMemoryDecisionRecorder()
+    dispatcher = CapabilityDispatcher(
+        handlers={"Notifications": _exploding_handler},
+        producers=ProducerBundle.null(),
+        recorder=recorder,
+    )
+    router = IntentRouter(dispatcher, enabled=False)
+    classifier = IntentClassifier(catalog, enabled=False)
+
+    disposition = router.route(classifier.classify("notifications", correlation_id="dark-notif"))
+
+    assert disposition.kind is DispositionKind.NOT_ENABLED
+    assert recorder.records == []
+    assert recorder.get_by_correlation("dark-notif") is None
+
+
+def test_dark_mode_clickhouse_sink_is_never_touched(catalog, monkeypatch):
+    """Even with DECISION_RECORDER=clickhouse selected, dark mode records NOTHING: the
+    durable sink's client raises on any insert/query and is proven never reached."""
+    monkeypatch.setenv("DECISION_RECORDER", "clickhouse")
+    recorder = ClickHouseDecisionRecorder(client=ExplodingClickHouseClient())
+    dispatcher = CapabilityDispatcher(
+        handlers={"Notifications": _exploding_handler},
+        producers=ProducerBundle.null(),
+        recorder=recorder,
+    )
+    router = IntentRouter(dispatcher, enabled=False)
+    classifier = IntentClassifier(catalog, enabled=False)
+
+    disposition = router.route(classifier.classify("alerts", correlation_id="dark-ch"))
+
+    # ExplodingClickHouseClient would have raised if insert/query were ever called.
+    assert disposition.kind is DispositionKind.NOT_ENABLED
+
+
+# ── Flag default: dark in every environment ──────────────────────────────────────
+
+
+def test_flag_defaults_to_dark_when_unset(monkeypatch):
+    """INTENT_LAYER_ENABLED is false by default (the guardrail for every env)."""
+    monkeypatch.delenv(INTENT_LAYER_ENABLED_ENV, raising=False)
+    assert intent_layer_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["false", "False", "  FALSE  ", "0", "no", ""])
+def test_flag_non_true_values_stay_dark(value):
+    """Only an explicit, case-insensitive 'true' enables the layer; everything else is dark."""
+    assert intent_layer_enabled(env={INTENT_LAYER_ENABLED_ENV: value}) is False
+
+
+# ── HTTP entrypoint dark mode (POST /v1/intent through TestClient) ───────────────
+
+
+@pytest.mark.parametrize(
+    "intent_text", ["pay", "exchange", "view-balance", "onboard-kyc", "notifications"]
+)
+def test_http_dark_mode_not_enabled_no_record(intent_text, monkeypatch):
+    """The HTTP surface returns the inert NOT_ENABLED envelope and persists no record."""
+    monkeypatch.setenv(INTENT_LAYER_ENABLED_ENV, "false")
+    from fastapi.testclient import TestClient
+
+    from api.main import app
+
+    client = TestClient(app)
+    cid = f"http-dark-{intent_text}"
+    resp = client.post("/v1/intent", json={"intent_text": intent_text, "correlation_id": cid})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is False
+    assert body["disposition"] == "NOT_ENABLED"
+    assert body["decision_record"] is None
+    assert body["governance_event"] is None
+    # Nothing was recorded → the lineage GET is a 404.
+    assert client.get(f"/v1/intent/decision/{cid}").status_code == 404
+
+
+# ── Live ClickHouse dark-mode check (opt-in) ─────────────────────────────────────
+
+_LIVE_DSN = os.environ.get("DECISION_RECORDER_TEST_DSN")
+
+
+@pytest.mark.skipif(
+    not _LIVE_DSN,
+    reason="Set DECISION_RECORDER_TEST_DSN to run the live ClickHouse dark-mode check",
+)
+def test_dark_mode_live_clickhouse_records_nothing(catalog):  # pragma: no cover - opt-in only
+    """Wired to a LIVE ClickHouse sink, a disabled router still writes nothing: a fresh
+    correlation id has no rows after routing a dark intent."""
+    from services.agents.recorders import _DriverClickHouseClient
+
+    recorder = ClickHouseDecisionRecorder(client=_DriverClickHouseClient())
+    dispatcher = CapabilityDispatcher(
+        handlers={"Notifications": _exploding_handler},
+        producers=ProducerBundle.null(),
+        recorder=recorder,
+    )
+    router = IntentRouter(dispatcher, enabled=False)
+    classifier = IntentClassifier(catalog, enabled=False)
+
+    cid = "dark-live-" + os.urandom(8).hex()
+    disposition = router.route(classifier.classify("notifications", correlation_id=cid))
+
+    assert disposition.kind is DispositionKind.NOT_ENABLED
+    assert recorder.query(correlation_id=cid) == []


### PR DESCRIPTION
## What

FU-2 Phase 3 — exercises the ADR-049 **L1 Intent Layer end-to-end while it stays dark**
(`INTENT_LAYER_ENABLED=false`). **Tests + tooling + docs only.** No production behaviour,
no env defaults, and no public API contract are changed; `INTENT_LAYER_ENABLED` stays
`false` by default in every environment.

## Why

`ClickHouseDecisionRecorder` is merged (behind `DECISION_RECORDER`, #187). The safest next
step is to drive intents through L1→L4 and (optionally) record them, **without any
client-facing activation** — proving the safe pre-activation contract holds.

## Changes

- **`tests/test_intent_layer/test_intent_layer_dark_mode.py`** — drives typical intents
  (payments, FX, wallet, notifications, KYC, …) through `classify → route` and through the
  HTTP entrypoint `POST /v1/intent`, all with the flag `false`. Injected **exploding
  doubles** (an `AgentDispatchPort`, an `LLMClassifierPort`, and a `ClickHouseClient`) fail
  the test if ever called, proving:
  - every intent → `NOT_ENABLED`, **no dispatch** (no L2 mask / payment-core adapter / outbound call);
  - the **LLM fuzzy fallback is suppressed**;
  - **no lineage record** is emitted — neither in-memory nor (even with
    `DECISION_RECORDER=clickhouse` selected) to the durable ClickHouse sink.
  - The live ClickHouse round-trip stays **opt-in** behind `DECISION_RECORDER_TEST_DSN`, so CI is green without ClickHouse.
- **`scripts/intent_layer_dryrun.py`** — a **developer-only** CLI (clearly marked, not a
  production entrypoint) that runs the *same* internal entrypoint the HTTP handler uses,
  with an **inert simulating dispatcher** that never touches a real mask, adapter, the
  network, or ClickHouse. Respects `INTENT_LAYER_ENABLED` (default `false`); `--force-simulate`
  only changes the *report*, never performs a real dispatch.
- **`docs/intent-layer-dev.md`** — how to run the dark-mode tests and the dry-run CLI;
  explicit note that this phase does **not** activate the Intent Layer for real traffic.

## Guardrails honoured

- `INTENT_LAYER_ENABLED` remains `false` by default in all envs (a test asserts this).
- `DECISION_RECORDER` default unchanged; ClickHouse tests skip without a DSN.
- No changes to `banxe-architecture` or `banxe-payment-core`.
- No new public HTTP endpoint and no changes to existing external API contracts.

## Test

```bash
pytest tests/test_intent_layer/test_intent_layer_dark_mode.py -v   # 24 passed, 1 skipped (live DSN)
echo '{"intent_text": "send money"}' | python scripts/intent_layer_dryrun.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)