### PR TITLE
FU-2: LLM gateway smoke wiring (no activation)

### DIFF
--- a/.github/workflows/smoke-gate-full.yml
+++ b/.github/workflows/smoke-gate-full.yml
@@ -35,6 +35,9 @@ jobs:
       CLICKHOUSE_HOST: localhost
       CLICKHOUSE_DB: banxe
       FRANKFURTER_BASE_URL: http://localhost:8087
+      # Optional LLM gateway target (FU-2). Set the `LLM_GATEWAY_URL` repo variable
+      # to enable the healthcheck below; empty/unset => the step is skipped, CI stays green.
+      LLM_GATEWAY_URL: ${{ vars.LLM_GATEWAY_URL }}
 
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +71,23 @@ jobs:
           echo "Waiting for frankfurter..."
           until curl -sf http://localhost:8087/health; do sleep 2; done
           echo "All infra services healthy."
+
+      - name: LLM gateway healthcheck (optional, FU-2)
+        # Only runs when the LLM_GATEWAY_URL repo variable is set; otherwise skipped
+        # (not failed) so CI stays green when no gateway is wired. See docs/llm-gateway-dev.md.
+        if: ${{ env.LLM_GATEWAY_URL != '' }}
+        run: |
+          echo "Pinging LLM gateway at ${LLM_GATEWAY_URL}/health/liveliness ..."
+          for i in $(seq 1 5); do
+            if curl -fsS -m 10 "${LLM_GATEWAY_URL}/health/liveliness"; then
+              echo " — LLM gateway live"
+              exit 0
+            fi
+            echo "attempt ${i}: no response yet, retrying..."
+            sleep 3
+          done
+          echo "::error::LLM gateway did not respond at ${LLM_GATEWAY_URL}" >&2
+          exit 1
 
       - name: Run smoke suite (full tier)
         run: |

--- a/docs/llm-gateway-dev.md
+++ b/docs/llm-gateway-dev.md
@@ -1,0 +1,72 @@
+# LLM Gateway — local dev + CI healthcheck (FU-2 Phase 4)
+
+**Status:** prep only. This document records how to start the LiteLLM LAN
+gateway locally and how the nightly smoke gate optionally pings it. It is the
+core dependency for any *future* Intent Layer activation.
+
+> **Not implemented / out of scope (unchanged by this PR):**
+> - `INTENT_LAYER_ENABLED` and any activation flags (still off).
+> - Any live HTTP wiring between emi-stack and `banxe-payment-core`.
+> - Any client-facing API behaviour.
+>
+> This PR is documentation + optional CI wiring only. The gateway healthcheck
+> in `smoke-gate-full.yml` is **skipped** unless `LLM_GATEWAY_URL` is set, so CI
+> stays green when no gateway is configured.
+
+## Where the gateway lives
+
+The gateway is a LiteLLM proxy maintained in the **MetaClaw** repo under
+`litellm/` (config, `.env.example`, `docker-compose.yml`) plus
+`scripts/litellm-local-startup.sh`. It exposes an OpenAI-compatible API on
+`:4000` in front of the LAN model backends.
+
+## Start it locally
+
+From a MetaClaw checkout:
+
+```bash
+cp litellm/.env.example litellm/.env   # fill in real values (gitignored)
+scripts/litellm-local-startup.sh       # docker compose up + healthcheck
+```
+
+Alternative modes:
+
+```bash
+scripts/litellm-local-startup.sh --mode systemd   # use the systemd user unit
+scripts/litellm-local-startup.sh --no-start        # healthcheck only
+scripts/litellm-local-startup.sh --profile db      # also start optional Postgres
+```
+
+See `litellm/README.md` in MetaClaw for the full topology (ports/backends).
+
+## Healthcheck (manual)
+
+`/health/liveliness` and `/health/readiness` are unauthenticated; `/v1/models`
+requires the master key.
+
+```bash
+# liveliness (no auth):
+curl -fsS http://127.0.0.1:4000/health/liveliness && echo " gateway live"
+
+# authenticated model list:
+curl -fsS -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  http://127.0.0.1:4000/v1/models
+```
+
+## CI wiring (smoke-gate-full)
+
+The nightly [`smoke-gate-full.yml`](../.github/workflows/smoke-gate-full.yml)
+includes an **optional** step *"LLM gateway healthcheck (optional, FU-2)"*:
+
+- Reads the `LLM_GATEWAY_URL` repo variable into the job env.
+- If unset/empty → the step is **skipped** (`if: env.LLM_GATEWAY_URL != ''`),
+  and the workflow stays green.
+- If set → it polls `${LLM_GATEWAY_URL}/health/liveliness` (5 attempts) and
+  fails the job only if a *configured* gateway is unreachable.
+
+To enable it, set the repo variable (no secrets needed for the liveliness probe):
+
+```bash
+gh variable set LLM_GATEWAY_URL --body "http://<gateway-host>:4000" \
+  --repo CarmiBanxe/banxe-emi-stack
+```


### PR DESCRIPTION
## FU-2 Phase 4 — LLM gateway smoke wiring + dev doc

Wires the LiteLLM LAN gateway into the nightly smoke gate as an **optional** healthcheck and adds a docs-only runbook. **No activation** — no `INTENT_LAYER_ENABLED` change, no client-facing API change.

### Changed
- `.github/workflows/smoke-gate-full.yml`
  - Adds `LLM_GATEWAY_URL: ${{ vars.LLM_GATEWAY_URL }}` to the job env.
  - Adds an optional step **"LLM gateway healthcheck (optional, FU-2)"** gated on `if: env.LLM_GATEWAY_URL != ''`.
  - **Skipped (not failed)** when the variable is unset → CI stays green without a gateway. When set, polls `${LLM_GATEWAY_URL}/health/liveliness` (5 attempts) and fails only if a configured gateway is unreachable.
- `docs/llm-gateway-dev.md` (new, docs-only)
  - How to start the gateway locally (MetaClaw `scripts/litellm-local-startup.sh` + compose).
  - How to run the healthcheck manually.
  - How to enable the CI probe (`gh variable set LLM_GATEWAY_URL ...`).

### Safety
- Default behaviour unchanged: with no `LLM_GATEWAY_URL` set, the new step is skipped and the workflow behaves exactly as before.
- No required-check change (`smoke-gate-full` is nightly, not a PR gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)