### PR TITLE
FU-2: Intent Layer canary activation in staging (notifications only)

### DIFF
--- a/api/routers/intent.py
+++ b/api/routers/intent.py
@@ -41,6 +41,12 @@ from services.agents.notification_agent import (
     NotificationAgent,
     NotificationMask,
 )
+from services.intent_layer.canary import canary_policy_from_env
+from services.intent_layer.canary_metrics import (
+    CounterCanaryObserver,
+    FanOutCanaryObserver,
+    LoggingCanaryObserver,
+)
 from services.intent_layer.catalog import IntentCatalog
 from services.intent_layer.classifier import IntentClassifier
 from services.intent_layer.composition import (
@@ -176,6 +182,12 @@ _LIVE_HANDLERS = {"Notifications": _notifications_handler}
 # correlation_id the POST returned (a per-request recorder would lose it).
 _RECORDER = InMemoryDecisionRecorder()
 
+# Stable singleton canary observer (FU-2 Phase 5): structured logs for alerting +
+# in-process counters the /canary/metrics probe reads. Accumulates across requests so
+# the canary's volume / withhold / error signal is monitorable for the whole process.
+_CANARY_METRICS = CounterCanaryObserver()
+_CANARY_OBSERVER = FanOutCanaryObserver((LoggingCanaryObserver(), _CANARY_METRICS))
+
 
 @dataclass(frozen=True)
 class _Composition:
@@ -204,9 +216,12 @@ def get_composition() -> _Composition:
         producers=ProducerBundle.null(),
         recorder=_RECORDER,
     )
+    # Canary gate (FU-2 Phase 5): an enabled layer auto-dispatches ONLY allowlisted,
+    # non-high-risk capabilities. Policy is read fresh each call (safe toggling).
+    canary = canary_policy_from_env()
     return _Composition(
         classifier=IntentClassifier(_catalog(), enabled=enabled),
-        router=IntentRouter(dispatcher, enabled=enabled),
+        router=IntentRouter(dispatcher, enabled=enabled, canary=canary, observer=_CANARY_OBSERVER),
         recorder=_RECORDER,
         enabled=enabled,
     )
@@ -289,3 +304,11 @@ def get_decision(correlation_id: str) -> DecisionRecordModel:
     if record is None:
         raise HTTPException(status_code=404, detail="no decision record for correlation_id")
     return _to_record_model(record)
+
+
+@router.get("/intent/canary/metrics")
+def get_canary_metrics() -> dict[str, int]:
+    """Read-only canary monitoring counters (FU-2 Phase 5): canary intents seen,
+    dispatched, withheld (not-canary / high-risk) and error totals. Backs canary
+    observation in staging; no PII, just decision counts."""
+    return _CANARY_METRICS.snapshot()

--- a/docs/intent-layer-canary.md
+++ b/docs/intent-layer-canary.md
@@ -1,0 +1,95 @@
+# Intent Layer — staging canary (FU-2 Phase 5)
+
+> **Status (FU-2 Phase 5):** the ADR-049 L1 Intent Layer moves from **dark mode**
+> (Phase 3) to a **tightly-scoped, observable canary** — enabled **in staging only**,
+> for **one low-risk capability** (Notifications). Production stays dark. There is **no**
+> activation for payments / FX / wallet / KYC / SAR / sanctions in this phase, and a
+> single flag change reverts to dark mode. See [`intent-layer-dev.md`](./intent-layer-dev.md)
+> for the dark-mode baseline.
+
+## What the canary does
+
+When the layer is enabled for an environment, an **auto-dispatch gate** decides which
+resolved capabilities may actually flow to an L2 mask. Two mechanistic checks — in code,
+never via prompt — run in safety order:
+
+1. **High-risk denylist (hard, non-configurable).** Any capability touching money
+   movement, FX, wallet/balance, cards, KYC/onboarding, SAR or sanctions/AML screening
+   is **never** auto-dispatched. It is routed to the human/manual (governance) flow.
+   The denylist wins **even if such a capability is mistakenly added to the allowlist.**
+   It matches on an explicit capability-key set **and** a token scan over the capability
+   label + matched intent, so a newly-added or mislabelled high-risk capability is still
+   caught. (`services/intent_layer/canary.py`)
+2. **Canary allowlist (default-deny).** `INTENT_LAYER_CANARY_CAPABILITIES` lists the
+   capability keys allowed to auto-dispatch. **Empty by default**, so an enabled-but-
+   unconfigured layer dispatches nothing — a leaked global flag in prod stays
+   mechanically dark.
+
+Anything withheld degrades to the **current behaviour**: high-risk → governance event;
+not-in-canary → the same `NOT_ENABLED` no-op shape as dark mode. The HTTP response schema
+is unchanged, so there is no customer-facing SLA change.
+
+## Flags
+
+| Flag | Where defined | Default | Purpose |
+| --- | --- | --- | --- |
+| `INTENT_LAYER_ENABLED` | `services/intent_layer/config.py` | `false` | Global master flag (legacy/back-compat) |
+| `APP_ENV` (or `ENVIRONMENT`) | `services/intent_layer/config.py` | `production` | Names the deployment environment |
+| `INTENT_LAYER_ENABLED_<ENV>` | `services/intent_layer/config.py` | unset | Per-env override (e.g. `INTENT_LAYER_ENABLED_STAGING`); wins over the global flag for that env only |
+| `INTENT_LAYER_CANARY_CAPABILITIES` | `services/intent_layer/canary.py` | empty | Comma-separated allowlist of capability keys permitted to auto-dispatch |
+
+The high-risk denylist is **not** a flag — it is hard-coded in `canary.py`
+(`HIGH_RISK_CAPABILITY_KEYS` + `HIGH_RISK_TOKENS`) and cannot be relaxed by config.
+
+## Enable / disable in staging (env changes only)
+
+**Enable the canary in staging:**
+
+```bash
+APP_ENV=staging
+INTENT_LAYER_ENABLED_STAGING=true
+INTENT_LAYER_CANARY_CAPABILITIES=Notifications
+# (optional) durable lineage:
+DECISION_RECORDER=clickhouse
+```
+
+**Roll back to dark mode (instant):** flip the per-env flag back —
+
+```bash
+INTENT_LAYER_ENABLED_STAGING=false   # or unset it
+```
+
+No code change, no deploy: the flag is read fresh on each request, so the next request
+returns to the dark-mode `NOT_ENABLED` behaviour. Production is unaffected throughout —
+it never sets `INTENT_LAYER_ENABLED_PRODUCTION` and the staging override does not leak
+across environments.
+
+## Monitoring
+
+* **Structured logs** (`LoggingCanaryObserver`, logger `banxe.intent_layer.canary`): one
+  record per gate decision — `decision`, `capability_key`, `correlation_id`. High-risk
+  withholds log at **WARNING** for alerting. No intent text or PII is logged.
+* **Counters** (`CounterCanaryObserver`), exposed read-only at
+  `GET /v1/intent/canary/metrics`:
+
+  ```json
+  {
+    "canary_intents_total": 0,
+    "canary_dispatched": 0,
+    "canary_withheld_not_canary": 0,
+    "canary_withheld_high_risk": 0,
+    "canary_errors": 0
+  }
+  ```
+
+  These give canary volume, dispatch vs withhold split, and the error count.
+
+## Tests
+
+```bash
+pytest tests/test_intent_layer/test_canary.py \
+       tests/test_intent_layer/test_canary_metrics.py \
+       tests/test_intent_layer/test_config.py \
+       tests/test_intent_layer/test_router.py \
+       tests/test_canary_api.py -v
+```

--- a/services/intent_layer/canary.py
+++ b/services/intent_layer/canary.py
@@ -1,0 +1,185 @@
+"""
+services/intent_layer/canary.py — L1 Intent Layer canary auto-dispatch policy
+FU-2 Phase 5 — staging canary (notifications only) | banxe-emi-stack
+
+When the Intent Layer is enabled (see ``config.intent_layer_enabled``), this policy
+decides — MECHANISTICALLY, in code, never via prompt — which resolved capabilities may
+actually be auto-dispatched. It is the tightly-scoped gate that turns "the layer is on"
+into "exactly one low-risk capability flows end-to-end" for the Phase-5 canary.
+
+Two independent gates, checked in safety order:
+
+  1. HIGH-RISK DENYLIST (hard, unconditional, non-configurable).
+     Any capability touching money movement, FX, wallet/balance, cards, KYC/onboarding,
+     SAR or sanctions/AML screening can NEVER be auto-dispatched in this phase. The
+     denylist is matched on BOTH an explicit capability-key set AND a token scan over
+     the capability label + matched intent, so a *newly added* or *mislabelled*
+     high-risk capability is still caught. This gate wins even if such a capability is
+     mistakenly added to the allowlist — it routes to the human/manual (governance)
+     flow instead. (Guardrail: payments/FX/KYC/SAR/sanctions are never canary-dispatched.)
+
+  2. CANARY ALLOWLIST (default-deny).
+     ``INTENT_LAYER_CANARY_CAPABILITIES`` is a comma-separated list of capability keys
+     permitted to auto-dispatch. EMPTY BY DEFAULT — so an enabled-but-unconfigured
+     layer dispatches nothing (a leaked global flag in prod stays mechanically dark).
+     For the staging canary it is set to ``Notifications`` only.
+
+The policy is a pure value object: built from env at the composition root, then injected
+into the router. It holds no I/O and is fully unit-testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import os
+
+CANARY_CAPABILITIES_ENV = "INTENT_LAYER_CANARY_CAPABILITIES"
+
+
+class CanaryDecision(str, Enum):
+    """What the canary policy ruled for one resolved capability."""
+
+    DISPATCH = "DISPATCH"  # allowlisted + not high-risk → auto-dispatch
+    WITHHELD_NOT_CANARY = "WITHHELD_NOT_CANARY"  # enabled but not allowlisted → dark no-op
+    WITHHELD_HIGH_RISK = "WITHHELD_HIGH_RISK"  # high-risk denylist → manual/governance flow
+
+
+@dataclass(frozen=True)
+class CanaryOutcome:
+    """A canary decision plus an audit-legible reason (carried into logs/lineage)."""
+
+    decision: CanaryDecision
+    reason: str
+
+
+def normalise_capability(capability: str) -> str:
+    """Stable capability key: the lowercased lead token before any ``/`` or ``(``.
+
+    Mirrors ``composition._cap_key`` so the allowlist/denylist key a capability the
+    same way the dispatcher resolves its handler — ``"Notifications"`` → ``notifications``,
+    ``"FX / Exchange"`` → ``fx``, ``"Analytics / Reporting (ADR-054)"`` → ``analytics``.
+    """
+    head = capability.split("(")[0].split("/")[0]
+    return " ".join(head.lower().split())
+
+
+# Explicit high-risk capability keys (normalised) — the canonical client capabilities
+# that move money, touch wallets/cards, or run KYC/sanctions. Auto-dispatch of any of
+# these is forbidden in the Phase-5 canary.
+HIGH_RISK_CAPABILITY_KEYS: frozenset[str] = frozenset(
+    {
+        "payments",
+        "fx",
+        "wallet",
+        "card",
+        "kyc onboarding",
+        "kyc",
+        "sanctions",
+        "sar",
+        "aml",
+    }
+)
+
+# Defence-in-depth token scan over (capability label + matched intent). Catches a NEW
+# or mislabelled high-risk capability whose key is not yet in the explicit set above —
+# e.g. "Cross-border payment", "Wire transfer", "Sanctions screening". Withholding is
+# the safe direction, so an over-match merely routes to the manual flow.
+HIGH_RISK_TOKENS: frozenset[str] = frozenset(
+    {
+        "payment",
+        "fx",
+        "exchange",
+        "wallet",
+        "balance",
+        "transfer",
+        "remit",
+        "withdraw",
+        "deposit",
+        "card",
+        "kyc",
+        "onboard",
+        "sanction",
+        "screening",
+        "sar",
+        "aml",
+        "swift",
+        "sepa",
+        "iban",
+    }
+)
+
+
+def is_high_risk(capability: str, matched_intent: str | None = None) -> bool:
+    """True if a capability must never be auto-dispatched in the canary phase.
+
+    Belt-and-suspenders: an explicit normalised-key hit OR any high-risk token found in
+    the capability label / matched intent. False-positives are safe (they withhold).
+    """
+    if normalise_capability(capability) in HIGH_RISK_CAPABILITY_KEYS:
+        return True
+    haystack = f"{capability} {matched_intent or ''}".lower()
+    return any(token in haystack for token in HIGH_RISK_TOKENS)
+
+
+def _parse_allowlist(raw: str) -> frozenset[str]:
+    """Parse the comma-separated allowlist into normalised capability keys."""
+    return frozenset(normalise_capability(item) for item in raw.split(",") if item.strip())
+
+
+@dataclass(frozen=True)
+class CanaryPolicy:
+    """Pure policy object: decides auto-dispatch for one resolved capability.
+
+    ``allowed_capabilities`` is the (already normalised) allowlist. The high-risk
+    denylist is NOT a field — it is hard-coded module state, so it cannot be relaxed
+    by configuration.
+    """
+
+    allowed_capabilities: frozenset[str]
+
+    def decide(self, capability: str, matched_intent: str | None = None) -> CanaryOutcome:
+        """Rule on one resolved capability. Assumes the layer is already enabled —
+        the router checks enablement first; this gate only narrows *which* capabilities
+        an enabled layer may dispatch."""
+        if is_high_risk(capability, matched_intent):
+            return CanaryOutcome(
+                CanaryDecision.WITHHELD_HIGH_RISK,
+                reason=(
+                    f"capability {capability!r} is high-risk (money/FX/wallet/card/KYC/"
+                    "SAR/sanctions) — never canary-dispatched; routed to human/manual flow"
+                ),
+            )
+        if normalise_capability(capability) not in self.allowed_capabilities:
+            return CanaryOutcome(
+                CanaryDecision.WITHHELD_NOT_CANARY,
+                reason=(
+                    f"capability {capability!r} not in {CANARY_CAPABILITIES_ENV} allowlist "
+                    "— no dispatch (dark-mode behaviour)"
+                ),
+            )
+        return CanaryOutcome(
+            CanaryDecision.DISPATCH,
+            reason=f"capability {capability!r} is an allowlisted low-risk canary capability",
+        )
+
+
+def canary_policy_from_env(env: dict[str, str] | None = None) -> CanaryPolicy:
+    """Build the canary policy from ``INTENT_LAYER_CANARY_CAPABILITIES`` (default empty)."""
+    source = env if env is not None else os.environ
+    return CanaryPolicy(
+        allowed_capabilities=_parse_allowlist(source.get(CANARY_CAPABILITIES_ENV, ""))
+    )
+
+
+__all__ = [
+    "CANARY_CAPABILITIES_ENV",
+    "CanaryDecision",
+    "CanaryOutcome",
+    "CanaryPolicy",
+    "HIGH_RISK_CAPABILITY_KEYS",
+    "HIGH_RISK_TOKENS",
+    "canary_policy_from_env",
+    "is_high_risk",
+    "normalise_capability",
+]

--- a/services/intent_layer/canary_metrics.py
+++ b/services/intent_layer/canary_metrics.py
@@ -1,0 +1,163 @@
+"""
+services/intent_layer/canary_metrics.py — canary observability hooks
+FU-2 Phase 5 — staging canary (notifications only) | banxe-emi-stack
+
+A canary is only safe if it is observable. This module supplies the monitoring seam the
+router calls on every gated decision, so an operator can watch the Phase-5 canary:
+
+  • total canary intents seen (enabled-path resolutions reaching the gate),
+  • how many were dispatched vs withheld (not-canary) vs withheld (high-risk),
+  • and the dispatch error rate.
+
+The router depends only on the :class:`CanaryObserver` Protocol (consistent with the
+layer's injected-port design). Three implementations are provided:
+
+  • :class:`NullCanaryObserver`  — default no-op (zero overhead, no behaviour change).
+  • :class:`CounterCanaryObserver` — in-process counters for tests / a /metrics probe.
+  • :class:`LoggingCanaryObserver` — structured ``logging`` records for log-based
+    monitoring + alerting; carries only the correlation id + capability key + decision
+    (R-SEC: never raw intent text or PII).
+
+A :class:`FanOutCanaryObserver` composes several observers (e.g. log + counter) so a
+deployment can both emit logs and expose counters.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+import logging
+from typing import Protocol, runtime_checkable
+
+from services.intent_layer.canary import CanaryDecision, normalise_capability
+
+logger = logging.getLogger("banxe.intent_layer.canary")
+
+
+@runtime_checkable
+class CanaryObserver(Protocol):
+    """Sink for canary gate outcomes. Implementations MUST be side-effect-only —
+    a misbehaving observer must never change routing behaviour."""
+
+    def observe(
+        self, *, decision: CanaryDecision, capability: str, correlation_id: str
+    ) -> None: ...
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None: ...
+
+
+class NullCanaryObserver:
+    """Default observer: records nothing. Keeps the router's behaviour unchanged when
+    no monitoring is wired."""
+
+    def observe(self, *, decision: CanaryDecision, capability: str, correlation_id: str) -> None:
+        return None
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None:
+        return None
+
+
+@dataclass
+class CounterCanaryObserver:
+    """In-process counters — the read surface for a /metrics probe or a test assertion.
+
+    ``decisions`` counts gate outcomes by :class:`CanaryDecision`; ``errors`` counts
+    dispatch failures. ``total`` is every gate hit (the canary-intent volume).
+    """
+
+    decisions: Counter[CanaryDecision] = field(default_factory=Counter)
+    errors: int = 0
+
+    def observe(self, *, decision: CanaryDecision, capability: str, correlation_id: str) -> None:
+        self.decisions[decision] += 1
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None:
+        self.errors += 1
+
+    @property
+    def total(self) -> int:
+        """Total gated canary intents seen."""
+        return sum(self.decisions.values())
+
+    @property
+    def dispatched(self) -> int:
+        return self.decisions[CanaryDecision.DISPATCH]
+
+    @property
+    def withheld(self) -> int:
+        """Intents withheld for any reason (not-canary + high-risk)."""
+        return (
+            self.decisions[CanaryDecision.WITHHELD_NOT_CANARY]
+            + self.decisions[CanaryDecision.WITHHELD_HIGH_RISK]
+        )
+
+    def snapshot(self) -> dict[str, int]:
+        """A flat, JSON-friendly view for a metrics endpoint."""
+        return {
+            "canary_intents_total": self.total,
+            "canary_dispatched": self.dispatched,
+            "canary_withheld_not_canary": self.decisions[CanaryDecision.WITHHELD_NOT_CANARY],
+            "canary_withheld_high_risk": self.decisions[CanaryDecision.WITHHELD_HIGH_RISK],
+            "canary_errors": self.errors,
+        }
+
+
+class LoggingCanaryObserver:
+    """Emits one structured log record per gate decision (and per dispatch error).
+
+    R-SEC: only the correlation id, normalised capability key and decision are logged —
+    never the free-form intent text or any PII. High-risk withholds log at WARNING so
+    they surface in alerting; everything else is INFO/ERROR.
+    """
+
+    def observe(self, *, decision: CanaryDecision, capability: str, correlation_id: str) -> None:
+        level = logging.WARNING if decision is CanaryDecision.WITHHELD_HIGH_RISK else logging.INFO
+        logger.log(
+            level,
+            "intent_layer.canary decision=%s capability=%s correlation_id=%s",
+            decision.value,
+            normalise_capability(capability),
+            correlation_id,
+            extra={
+                "event": "intent_layer.canary.decision",
+                "decision": decision.value,
+                "capability_key": normalise_capability(capability),
+                "correlation_id": correlation_id,
+            },
+        )
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None:
+        logger.error(
+            "intent_layer.canary dispatch_error capability=%s correlation_id=%s",
+            normalise_capability(capability),
+            correlation_id,
+            extra={
+                "event": "intent_layer.canary.error",
+                "capability_key": normalise_capability(capability),
+                "correlation_id": correlation_id,
+            },
+        )
+
+
+@dataclass
+class FanOutCanaryObserver:
+    """Composes several observers — e.g. log + counter — behind one port."""
+
+    observers: tuple[CanaryObserver, ...]
+
+    def observe(self, *, decision: CanaryDecision, capability: str, correlation_id: str) -> None:
+        for obs in self.observers:
+            obs.observe(decision=decision, capability=capability, correlation_id=correlation_id)
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None:
+        for obs in self.observers:
+            obs.observe_error(capability=capability, correlation_id=correlation_id)
+
+
+__all__ = [
+    "CanaryObserver",
+    "CounterCanaryObserver",
+    "FanOutCanaryObserver",
+    "LoggingCanaryObserver",
+    "NullCanaryObserver",
+]

--- a/services/intent_layer/config.py
+++ b/services/intent_layer/config.py
@@ -12,6 +12,21 @@ Gating semantics:
             fallback in IntentClassifier is also suppressed.
   - true  → deterministic classification dispatches; LLM fallback is consulted when a
             non-Null LLMClassifierPort is injected (S1 gateway).
+
+Environment scoping (FU-2 Phase 5 canary):
+  Enablement is resolved PER ENVIRONMENT so the layer can be lit in staging without
+  touching production. ``APP_ENV`` (or ``ENVIRONMENT``) names the environment; an
+  ``INTENT_LAYER_ENABLED_<ENV>`` override, when present, takes precedence over the
+  global ``INTENT_LAYER_ENABLED`` for that environment ONLY. A staging override never
+  leaks into production:
+
+      APP_ENV=staging  INTENT_LAYER_ENABLED_STAGING=true   → enabled in staging
+      APP_ENV=production (no override, global false)        → stays dark
+
+  Note: enablement alone does NOT auto-dispatch anything — the canary allowlist +
+  hard-coded high-risk denylist in ``canary.py`` gate which capabilities may actually
+  be dispatched. With no allowlist configured, even an enabled layer dispatches
+  nothing (default-deny), so a leaked global flag in prod is still mechanically safe.
 """
 
 from __future__ import annotations
@@ -19,9 +34,45 @@ from __future__ import annotations
 import os
 
 INTENT_LAYER_ENABLED_ENV = "INTENT_LAYER_ENABLED"
+APP_ENV_KEYS = ("APP_ENV", "ENVIRONMENT")
+DEFAULT_ENVIRONMENT = "production"  # fail-safe: an unlabelled env is treated as prod
+
+
+def _truthy(value: str) -> bool:
+    """Conservative parse: only the literal ``true`` (case/space-insensitive) is on."""
+    return value.strip().lower() == "true"
+
+
+def current_environment(env: dict[str, str] | None = None) -> str:
+    """Resolve the deployment environment from ``APP_ENV``/``ENVIRONMENT``.
+
+    Defaults to ``production`` when unset — the most restrictive choice, so an
+    unlabelled deployment never accidentally inherits a non-prod override.
+    """
+    source = env if env is not None else os.environ
+    for key in APP_ENV_KEYS:
+        value = source.get(key)
+        if value and value.strip():
+            return value.strip().lower()
+    return DEFAULT_ENVIRONMENT
+
+
+def per_env_flag_name(environment: str) -> str:
+    """The ``INTENT_LAYER_ENABLED_<ENV>`` override key for an environment."""
+    return f"{INTENT_LAYER_ENABLED_ENV}_{environment.upper()}"
 
 
 def intent_layer_enabled(env: dict[str, str] | None = None) -> bool:
-    """Read the INTENT_LAYER_ENABLED flag. Injectable env for deterministic tests."""
+    """Read the effective INTENT_LAYER_ENABLED flag for the current environment.
+
+    Resolution order (injectable env for deterministic tests):
+      1. ``INTENT_LAYER_ENABLED_<ENV>`` for the current environment, when present —
+         a per-env override scoped to exactly that environment; or
+      2. the global ``INTENT_LAYER_ENABLED`` (default false).
+    """
     source = env if env is not None else os.environ
-    return source.get(INTENT_LAYER_ENABLED_ENV, "false").strip().lower() == "true"
+    environment = current_environment(source)
+    override = source.get(per_env_flag_name(environment))
+    if override is not None:
+        return _truthy(override)
+    return _truthy(source.get(INTENT_LAYER_ENABLED_ENV, "false"))

--- a/services/intent_layer/router.py
+++ b/services/intent_layer/router.py
@@ -8,7 +8,15 @@ Ordered guards (ADR-049 D2 invariants):
   1. INTENT_LAYER_ENABLED false  → NOT_ENABLED, NO dispatch (safe pre-activation).
   2. UNRESOLVED intent           → GOVERNANCE_EVENT (HITL / process-gap), NO dispatch,
                                     never improvised (ADR-048 D3.3).
-  3. otherwise                   → select the client-facing mask by capability and
+  3. CANARY GATE (FU-2 Phase 5)  → when a CanaryPolicy is injected, a resolved intent
+                                    must clear the canary gate before dispatch:
+                                      • high-risk capability  → GOVERNANCE_EVENT (manual
+                                        flow); never auto-dispatched, even if allowlisted.
+                                      • not in the allowlist   → NOT_ENABLED-shaped no-op
+                                        (identical to dark-mode: no dispatch).
+                                    With no policy injected, this guard is inert and the
+                                    router behaves exactly as before (dispatch all).
+  4. otherwise                   → select the client-facing mask by capability and
                                     dispatch via the injected AgentDispatchPort, passing
                                     the resolved process_ref(s) so the L2 agent's §D2
                                     chain has its process_ref gate already satisfied.
@@ -19,6 +27,8 @@ injected AgentDispatchPort (cross-repo: payment-core + emi-stack).
 
 from __future__ import annotations
 
+from services.intent_layer.canary import CanaryDecision, CanaryPolicy
+from services.intent_layer.canary_metrics import CanaryObserver, NullCanaryObserver
 from services.intent_layer.models import Disposition, DispositionKind, ResolvedIntent
 from services.intent_layer.ports import AgentDispatchPort, DispatchRequest
 
@@ -26,9 +36,18 @@ from services.intent_layer.ports import AgentDispatchPort, DispatchRequest
 class IntentRouter:
     """Dispatches a ResolvedIntent to its client-facing agent under the feature flag."""
 
-    def __init__(self, dispatcher: AgentDispatchPort, *, enabled: bool = False) -> None:
+    def __init__(
+        self,
+        dispatcher: AgentDispatchPort,
+        *,
+        enabled: bool = False,
+        canary: CanaryPolicy | None = None,
+        observer: CanaryObserver | None = None,
+    ) -> None:
         self._dispatcher = dispatcher
         self._enabled = enabled
+        self._canary = canary
+        self._observer: CanaryObserver = observer or NullCanaryObserver()
 
     def route(self, resolved: ResolvedIntent) -> Disposition:
         if not self._enabled:
@@ -45,6 +64,10 @@ class IntentRouter:
                 reason="intent resolved to no canonical process — HITL / process-gap (ADR-048 D3.3)",
             )
 
+        gated = self._apply_canary(resolved)
+        if gated is not None:
+            return gated
+
         request = DispatchRequest(
             capability=resolved.capability,  # type: ignore[arg-type]  # resolved ⇒ non-None
             process_refs=resolved.process_refs,
@@ -59,3 +82,36 @@ class IntentRouter:
             process_refs=resolved.process_refs,
             receipt=receipt,
         )
+
+    def _apply_canary(self, resolved: ResolvedIntent) -> Disposition | None:
+        """Canary gate (guard 3). Returns a withholding Disposition when the policy
+        denies dispatch, or None to let the dispatch proceed. Inert without a policy."""
+        if self._canary is None:
+            return None
+
+        capability = resolved.capability or ""
+        outcome = self._canary.decide(capability, resolved.matched_intent)
+        self._observer.observe(
+            decision=outcome.decision,
+            capability=capability,
+            correlation_id=resolved.correlation_id,
+        )
+
+        if outcome.decision is CanaryDecision.WITHHELD_HIGH_RISK:
+            # Mechanistic high-risk guardrail: route to the human/manual flow, never
+            # auto-dispatch — same response shape as a governance event.
+            return Disposition(
+                kind=DispositionKind.GOVERNANCE_EVENT,
+                correlation_id=resolved.correlation_id,
+                capability=resolved.capability,
+                reason=outcome.reason,
+            )
+        if outcome.decision is CanaryDecision.WITHHELD_NOT_CANARY:
+            # Outside the canary scope: degrade safely to dark-mode (no dispatch).
+            return Disposition(
+                kind=DispositionKind.NOT_ENABLED,
+                correlation_id=resolved.correlation_id,
+                capability=resolved.capability,
+                reason=outcome.reason,
+            )
+        return None

--- a/tests/test_api_intent.py
+++ b/tests/test_api_intent.py
@@ -20,12 +20,16 @@ client = TestClient(app)
 
 @pytest.fixture()
 def enabled(monkeypatch) -> None:
+    # The realistic FU-2 Phase-5 canary config: layer on + Notifications allowlisted.
+    # Without the allowlist the (default-deny) gate would withhold every capability.
     monkeypatch.setenv("INTENT_LAYER_ENABLED", "true")
+    monkeypatch.setenv("INTENT_LAYER_CANARY_CAPABILITIES", "Notifications")
 
 
 @pytest.fixture()
 def disabled(monkeypatch) -> None:
     monkeypatch.setenv("INTENT_LAYER_ENABLED", "false")
+    monkeypatch.delenv("INTENT_LAYER_CANARY_CAPABILITIES", raising=False)
 
 
 def test_disabled_returns_not_enabled_no_dispatch(disabled):
@@ -76,14 +80,17 @@ def test_unresolved_intent_returns_governance_event(enabled):
     assert body["governance_event"]["status"] == "UNRESOLVED"
 
 
-def test_payments_is_unrouted_in_process(enabled):
-    """Payments is owned by banxe-payment-core — honestly unrouted in-process, no record."""
+def test_payments_is_withheld_high_risk(enabled):
+    """Payments is high-risk: the canary denylist withholds it (manual/governance flow),
+    never auto-dispatched — even though the layer is enabled. No record is emitted."""
     resp = client.post("/v1/intent", json={"intent_text": "pay", "correlation_id": "c-pay-1"})
     assert resp.status_code == 200
     body = resp.json()
-    assert body["disposition"] == "DISPATCHED"
+    assert body["disposition"] == "GOVERNANCE_EVENT"
     assert body["decision_record"] is None
-    assert "no in-process L2 mask" in body["detail"]
+    assert "high-risk" in body["governance_event"]["reason"]
+    # Nothing was dispatched, so no lineage record exists for it.
+    assert client.get("/v1/intent/decision/c-pay-1").status_code == 404
 
 
 def test_get_decision_missing_returns_404(enabled):

--- a/tests/test_canary_api.py
+++ b/tests/test_canary_api.py
@@ -1,0 +1,104 @@
+"""
+tests/test_canary_api.py — FU-2 Phase 5 canary, end-to-end over the HTTP surface.
+
+Exercises the staging canary through POST /v1/intent + GET /v1/intent/canary/metrics:
+  • a staging-like config (APP_ENV=staging + per-env enable + Notifications allowlist)
+    routes Notifications through the layer and records a decision,
+  • no other capability is auto-dispatched (high-risk → governance, others → dark),
+  • enabled-but-no-allowlist (a leaked global flag) dispatches NOTHING (default-deny),
+  • a staging override never enables the layer in production,
+  • the canary metrics counters move.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import pytest
+
+from api.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture()
+def staging_canary(monkeypatch) -> None:
+    """The exact env an operator sets to light the staging canary (env-only)."""
+    monkeypatch.setenv("APP_ENV", "staging")
+    monkeypatch.setenv("INTENT_LAYER_ENABLED_STAGING", "true")
+    monkeypatch.setenv("INTENT_LAYER_CANARY_CAPABILITIES", "Notifications")
+    monkeypatch.delenv("INTENT_LAYER_ENABLED", raising=False)
+
+
+def test_staging_canary_dispatches_notifications(staging_canary):
+    resp = client.post(
+        "/v1/intent", json={"intent_text": "notifications", "correlation_id": "c-canary-1"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    assert body["disposition"] == "DISPATCHED"
+    assert body["decision_record"]["agent_id"] == "notification_agent"
+    # A lineage record was recorded for the canary intent.
+    assert client.get("/v1/intent/decision/c-canary-1").status_code == 200
+
+
+def test_staging_canary_withholds_high_risk_fx(staging_canary):
+    resp = client.post("/v1/intent", json={"intent_text": "fx", "correlation_id": "c-fx-1"})
+    body = resp.json()
+    assert body["disposition"] == "GOVERNANCE_EVENT"
+    assert "high-risk" in body["governance_event"]["reason"]
+    assert client.get("/v1/intent/decision/c-fx-1").status_code == 404
+
+
+def test_staging_canary_withholds_high_risk_kyc(staging_canary):
+    resp = client.post(
+        "/v1/intent", json={"intent_text": "complete KYC", "correlation_id": "c-kyc-1"}
+    )
+    assert resp.json()["disposition"] == "GOVERNANCE_EVENT"
+
+
+def test_staging_canary_withholds_other_low_risk_capability(staging_canary):
+    # Statements is low-risk but outside the canary scope → safe dark-mode no-op.
+    resp = client.post(
+        "/v1/intent", json={"intent_text": "statement", "correlation_id": "c-stmt-1"}
+    )
+    body = resp.json()
+    assert body["disposition"] == "NOT_ENABLED"
+    assert body["decision_record"] is None
+
+
+def test_enabled_without_allowlist_dispatches_nothing(monkeypatch):
+    # A leaked global flag with NO allowlist must dispatch nothing (default-deny).
+    monkeypatch.setenv("APP_ENV", "staging")
+    monkeypatch.setenv("INTENT_LAYER_ENABLED_STAGING", "true")
+    monkeypatch.delenv("INTENT_LAYER_CANARY_CAPABILITIES", raising=False)
+    resp = client.post(
+        "/v1/intent", json={"intent_text": "notifications", "correlation_id": "c-deny-1"}
+    )
+    body = resp.json()
+    assert body["disposition"] == "NOT_ENABLED"
+    assert body["decision_record"] is None
+
+
+def test_staging_override_does_not_leak_into_production(monkeypatch):
+    # APP_ENV=production with only the staging override set → layer stays dark.
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("INTENT_LAYER_ENABLED_STAGING", "true")
+    monkeypatch.setenv("INTENT_LAYER_CANARY_CAPABILITIES", "Notifications")
+    monkeypatch.delenv("INTENT_LAYER_ENABLED", raising=False)
+    resp = client.post(
+        "/v1/intent", json={"intent_text": "notifications", "correlation_id": "c-prod-1"}
+    )
+    body = resp.json()
+    assert body["enabled"] is False
+    assert body["disposition"] == "NOT_ENABLED"
+
+
+def test_canary_metrics_endpoint_counts_decisions(staging_canary):
+    before = client.get("/v1/intent/canary/metrics").json()
+    client.post("/v1/intent", json={"intent_text": "notifications", "correlation_id": "c-m-1"})
+    client.post("/v1/intent", json={"intent_text": "fx", "correlation_id": "c-m-2"})
+    after = client.get("/v1/intent/canary/metrics").json()
+    assert after["canary_intents_total"] >= before["canary_intents_total"] + 2
+    assert after["canary_dispatched"] >= before["canary_dispatched"] + 1
+    assert after["canary_withheld_high_risk"] >= before["canary_withheld_high_risk"] + 1

--- a/tests/test_intent_layer/test_canary.py
+++ b/tests/test_intent_layer/test_canary.py
@@ -1,0 +1,117 @@
+"""
+tests/test_intent_layer/test_canary.py — FU-2 Phase 5 canary policy + denylist
+banxe-emi-stack
+
+Proves the mechanistic guardrails of the staging canary:
+  • default-deny allowlist (empty → nothing dispatches),
+  • the hard-coded high-risk denylist (payments/FX/wallet/card/KYC/SAR/sanctions),
+  • denylist wins over the allowlist (a mislabelled high-risk capability is still
+    withheld even if explicitly allowlisted),
+  • normalisation matches the dispatcher's capability keying.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.intent_layer.canary import (
+    CANARY_CAPABILITIES_ENV,
+    CanaryDecision,
+    CanaryPolicy,
+    canary_policy_from_env,
+    is_high_risk,
+    normalise_capability,
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("Notifications", "notifications"),
+        ("FX / Exchange", "fx"),
+        ("Analytics / Reporting (ADR-054)", "analytics"),
+        ("  Statements (ADR-055) ", "statements"),
+    ],
+)
+def test_normalise_capability(label, expected):
+    assert normalise_capability(label) == expected
+
+
+# ── High-risk denylist ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "capability",
+    [
+        "Payments",
+        "FX / Exchange",
+        "Wallet",
+        "Card (Wallet/Payments-adjacent)",
+        "KYC onboarding",
+        # New / mislabelled high-risk capabilities caught by the token scan:
+        "Cross-border payment",
+        "Wire transfer",
+        "Sanctions screening",
+        "SAR filing",
+    ],
+)
+def test_high_risk_capabilities_are_denied(capability):
+    assert is_high_risk(capability) is True
+
+
+@pytest.mark.parametrize(
+    "capability",
+    ["Notifications", "Statements (ADR-055)", "Analytics / Reporting (ADR-054)", "Referral / CRM"],
+)
+def test_low_risk_capabilities_are_not_denied(capability):
+    assert is_high_risk(capability) is False
+
+
+def test_high_risk_detected_via_matched_intent_token():
+    # A blandly-labelled capability whose intent token is high-risk is still caught.
+    assert is_high_risk("Support", matched_intent="onboard-kyc") is True
+
+
+# ── Allowlist (default-deny) ──────────────────────────────────────────────────────
+
+
+def test_empty_allowlist_withholds_low_risk_capability():
+    policy = CanaryPolicy(allowed_capabilities=frozenset())
+    outcome = policy.decide("Notifications", "get-notified")
+    assert outcome.decision is CanaryDecision.WITHHELD_NOT_CANARY
+
+
+def test_allowlisted_low_risk_capability_dispatches():
+    policy = CanaryPolicy(allowed_capabilities=frozenset({"notifications"}))
+    outcome = policy.decide("Notifications", "get-notified")
+    assert outcome.decision is CanaryDecision.DISPATCH
+
+
+def test_non_allowlisted_low_risk_capability_withheld():
+    policy = CanaryPolicy(allowed_capabilities=frozenset({"notifications"}))
+    outcome = policy.decide("Statements (ADR-055)", "get-statement")
+    assert outcome.decision is CanaryDecision.WITHHELD_NOT_CANARY
+
+
+# ── Denylist beats the allowlist (mechanistic guardrail) ──────────────────────────
+
+
+def test_high_risk_withheld_even_if_explicitly_allowlisted():
+    # Misconfiguration: someone allowlists Payments. The hard denylist still wins.
+    policy = CanaryPolicy(allowed_capabilities=frozenset({"payments", "notifications"}))
+    outcome = policy.decide("Payments", "pay")
+    assert outcome.decision is CanaryDecision.WITHHELD_HIGH_RISK
+    assert "high-risk" in outcome.reason
+
+
+# ── Env builder ───────────────────────────────────────────────────────────────────
+
+
+def test_policy_from_env_default_is_deny_all():
+    policy = canary_policy_from_env(env={})
+    assert policy.allowed_capabilities == frozenset()
+
+
+def test_policy_from_env_parses_comma_list():
+    policy = canary_policy_from_env(env={CANARY_CAPABILITIES_ENV: "Notifications, Statements"})
+    assert policy.allowed_capabilities == frozenset({"notifications", "statements"})

--- a/tests/test_intent_layer/test_canary_metrics.py
+++ b/tests/test_intent_layer/test_canary_metrics.py
@@ -1,0 +1,51 @@
+"""
+tests/test_intent_layer/test_canary_metrics.py — canary observability hooks.
+"""
+
+from __future__ import annotations
+
+from services.intent_layer.canary import CanaryDecision
+from services.intent_layer.canary_metrics import (
+    CounterCanaryObserver,
+    FanOutCanaryObserver,
+    NullCanaryObserver,
+)
+
+
+def test_null_observer_is_noop():
+    obs = NullCanaryObserver()
+    obs.observe(decision=CanaryDecision.DISPATCH, capability="Notifications", correlation_id="c1")
+    obs.observe_error(capability="Notifications", correlation_id="c1")  # no exception
+
+
+def test_counter_tallies_decisions_and_snapshot():
+    obs = CounterCanaryObserver()
+    obs.observe(decision=CanaryDecision.DISPATCH, capability="Notifications", correlation_id="a")
+    obs.observe(
+        decision=CanaryDecision.WITHHELD_HIGH_RISK, capability="Payments", correlation_id="b"
+    )
+    obs.observe(
+        decision=CanaryDecision.WITHHELD_NOT_CANARY, capability="Statements", correlation_id="c"
+    )
+    obs.observe_error(capability="Notifications", correlation_id="a")
+
+    assert obs.total == 3
+    assert obs.dispatched == 1
+    assert obs.withheld == 2
+    snap = obs.snapshot()
+    assert snap == {
+        "canary_intents_total": 3,
+        "canary_dispatched": 1,
+        "canary_withheld_not_canary": 1,
+        "canary_withheld_high_risk": 1,
+        "canary_errors": 1,
+    }
+
+
+def test_fanout_forwards_to_all_observers():
+    a, b = CounterCanaryObserver(), CounterCanaryObserver()
+    fan = FanOutCanaryObserver((a, b))
+    fan.observe(decision=CanaryDecision.DISPATCH, capability="Notifications", correlation_id="x")
+    fan.observe_error(capability="Notifications", correlation_id="x")
+    assert a.dispatched == b.dispatched == 1
+    assert a.errors == b.errors == 1

--- a/tests/test_intent_layer/test_config.py
+++ b/tests/test_intent_layer/test_config.py
@@ -9,7 +9,9 @@ import pytest
 
 from services.intent_layer.config import (
     INTENT_LAYER_ENABLED_ENV,
+    current_environment,
     intent_layer_enabled,
+    per_env_flag_name,
 )
 
 
@@ -39,3 +41,45 @@ def test_reads_process_environ_by_default(monkeypatch):
     assert intent_layer_enabled() is True
     monkeypatch.delenv(INTENT_LAYER_ENABLED_ENV, raising=False)
     assert intent_layer_enabled() is False
+
+
+# ── FU-2 Phase 5: per-environment scoping ────────────────────────────────────────
+
+
+def test_environment_defaults_to_production_when_unset():
+    assert current_environment(env={}) == "production"
+
+
+@pytest.mark.parametrize("key", ["APP_ENV", "ENVIRONMENT"])
+def test_environment_read_from_either_key(key):
+    assert current_environment(env={key: "Staging"}) == "staging"
+
+
+def test_per_env_flag_name():
+    assert per_env_flag_name("staging") == "INTENT_LAYER_ENABLED_STAGING"
+
+
+def test_staging_override_enables_only_in_staging():
+    env = {"APP_ENV": "staging", "INTENT_LAYER_ENABLED_STAGING": "true"}
+    assert intent_layer_enabled(env=env) is True
+
+
+def test_staging_override_does_not_leak_into_production():
+    # A staging override MUST NOT enable the layer in production (no global flag set).
+    env = {"APP_ENV": "production", "INTENT_LAYER_ENABLED_STAGING": "true"}
+    assert intent_layer_enabled(env=env) is False
+
+
+def test_per_env_override_takes_precedence_over_global():
+    # Even with the global flag true, a per-env "false" override keeps that env dark.
+    env = {
+        "APP_ENV": "staging",
+        INTENT_LAYER_ENABLED_ENV: "true",
+        "INTENT_LAYER_ENABLED_STAGING": "false",
+    }
+    assert intent_layer_enabled(env=env) is False
+
+
+def test_global_flag_still_applies_when_no_override():
+    env = {"APP_ENV": "staging", INTENT_LAYER_ENABLED_ENV: "true"}
+    assert intent_layer_enabled(env=env) is True

--- a/tests/test_intent_layer/test_router.py
+++ b/tests/test_intent_layer/test_router.py
@@ -5,6 +5,8 @@ IL-126-INTENT-LAYER-CLIENT-MASKS-2026-06-07 | banxe-emi-stack
 
 from __future__ import annotations
 
+from services.intent_layer.canary import CanaryDecision, CanaryPolicy
+from services.intent_layer.canary_metrics import CounterCanaryObserver
 from services.intent_layer.classifier import IntentClassifier
 from services.intent_layer.models import (
     DispositionKind,
@@ -83,3 +85,44 @@ def test_dispatch_receipt_can_signal_rejection(catalog):
     disposition = router.route(_resolve(catalog, "pay"))
     assert disposition.kind is DispositionKind.DISPATCHED
     assert disposition.receipt.accepted is False
+
+
+# ── FU-2 Phase 5: canary gate (guard 3) ──────────────────────────────────────────
+
+
+def test_no_policy_keeps_legacy_dispatch_all(catalog, spy_dispatcher):
+    # Backward compatibility: with no CanaryPolicy injected the gate is inert.
+    router = IntentRouter(spy_dispatcher, enabled=True)
+    assert router.route(_resolve(catalog, "pay")).kind is DispositionKind.DISPATCHED
+
+
+def test_canary_allowlisted_capability_dispatches(catalog, spy_dispatcher):
+    policy = CanaryPolicy(allowed_capabilities=frozenset({"notifications"}))
+    observer = CounterCanaryObserver()
+    router = IntentRouter(spy_dispatcher, enabled=True, canary=policy, observer=observer)
+    disposition = router.route(_resolve(catalog, "notifications"))
+    assert disposition.kind is DispositionKind.DISPATCHED
+    assert len(spy_dispatcher.calls) == 1
+    assert observer.dispatched == 1
+
+
+def test_canary_non_allowlisted_capability_withheld_as_dark(catalog, spy_dispatcher):
+    policy = CanaryPolicy(allowed_capabilities=frozenset({"notifications"}))
+    observer = CounterCanaryObserver()
+    router = IntentRouter(spy_dispatcher, enabled=True, canary=policy, observer=observer)
+    disposition = router.route(_resolve(catalog, "get-statement"))
+    # Statements is low-risk but not in the canary → degrades to dark-mode no-op.
+    assert disposition.kind is DispositionKind.NOT_ENABLED
+    assert spy_dispatcher.calls == []
+    assert observer.decisions[CanaryDecision.WITHHELD_NOT_CANARY] == 1
+
+
+def test_canary_high_risk_withheld_to_governance_even_if_allowlisted(catalog, spy_dispatcher):
+    # Misconfiguration: payments allowlisted. The hard denylist still withholds it.
+    policy = CanaryPolicy(allowed_capabilities=frozenset({"notifications", "payments"}))
+    observer = CounterCanaryObserver()
+    router = IntentRouter(spy_dispatcher, enabled=True, canary=policy, observer=observer)
+    disposition = router.route(_resolve(catalog, "pay"))
+    assert disposition.kind is DispositionKind.GOVERNANCE_EVENT
+    assert spy_dispatcher.calls == []  # never auto-dispatched
+    assert observer.decisions[CanaryDecision.WITHHELD_HIGH_RISK] == 1


### PR DESCRIPTION
## FU-2 Phase 5 — Intent Layer canary (staging, low-risk only)

Moves the ADR-049 L1 Intent Layer from **dark mode** (Phase 3) to a **tightly-scoped, observable canary**: enabled **in staging only**, for **one low-risk capability (Notifications)**. Production stays dark; a single flag change reverts to dark mode. Ref: **IL-217** (banxe-architecture).

### What changed
- **Env-scoped enablement** (`services/intent_layer/config.py`): `APP_ENV`/`ENVIRONMENT` + `INTENT_LAYER_ENABLED_<ENV>` per-env override. A staging override **never leaks into production**.
- **Mechanistic auto-dispatch gate** (`services/intent_layer/canary.py`):
  - **Default-deny allowlist** `INTENT_LAYER_CANARY_CAPABILITIES` (empty ⇒ nothing dispatches, so a leaked global flag in prod stays mechanically dark).
  - **Hard-coded high-risk denylist** (payments/FX/wallet/card/KYC/SAR/sanctions) that wins **even if a capability is mislabelled or mistakenly allowlisted** — routed to the human/manual (governance) flow.
- **Monitoring hooks** (`services/intent_layer/canary_metrics.py`): observer port + counters + structured logs; read-only `GET /v1/intent/canary/metrics`.
- **Router guard** (`services/intent_layer/router.py`): inert when no policy is injected ⇒ fully backward-compatible.
- Tests (unit + API + env-scoping + metrics) and `docs/intent-layer-canary.md`.

### Guardrails honoured
- ❌ No `INTENT_LAYER_ENABLED=true` in production envs.
- ❌ No canary for payments/FX/KYC/SAR/sanctions (mechanistic denylist).
- ❌ No changes to `banxe-payment-core`.
- ✅ HTTP response schema unchanged — withheld degrades to current behaviour (no SLA change).

### Enable / disable in staging (env only)
```bash
# enable
APP_ENV=staging INTENT_LAYER_ENABLED_STAGING=true INTENT_LAYER_CANARY_CAPABILITIES=Notifications
# rollback to dark mode (instant, no deploy)
INTENT_LAYER_ENABLED_STAGING=false
```

### Proof
`ruff check` + `mypy` clean; full suite **11128 passed, 39 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)