### PR TITLE
FU-2: Intent Layer canary observability & gateway metrics (Phase 6)

### DIFF
--- a/api/routers/intent.py
+++ b/api/routers/intent.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
+import os
+import time
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
@@ -48,8 +50,22 @@ from services.intent_layer.composition import (
     InMemoryDecisionRecorder,
 )
 from services.intent_layer.config import intent_layer_enabled
-from services.intent_layer.models import DispositionKind
-from services.intent_layer.ports import DispatchRequest
+from services.intent_layer.models import (
+    ConfidenceBand,
+    Disposition,
+    DispositionKind,
+    ResolvedIntent,
+)
+from services.intent_layer.observability import (
+    CanaryEvent,
+    CanaryMetricsPort,
+    CanaryObserver,
+    InMemoryCanaryMetrics,
+    InstrumentedLLMClassifier,
+    NullCanaryMetrics,
+    canary_env,
+)
+from services.intent_layer.ports import DispatchRequest, NullLLMClassifier
 from services.intent_layer.router import IntentRouter
 from services.notifications.notification_provider_port import (
     DeliveryResult,
@@ -182,6 +198,7 @@ class _Composition:
     classifier: IntentClassifier
     router: IntentRouter
     recorder: InMemoryDecisionRecorder
+    observer: CanaryObserver
     enabled: bool
 
 
@@ -195,19 +212,42 @@ def _catalog() -> IntentCatalog:
     return load_catalog()
 
 
+def get_canary_metrics() -> CanaryMetricsPort:
+    """Select the canary metrics sink from ``CANARY_METRICS`` (composition seam).
+
+    Default (unset/``null``) → :class:`NullCanaryMetrics` (no-op): no metrics
+    backend is touched and prod stays silent. ``inmemory`` → a recordable sink for
+    local/staging diagnostics. A real Prometheus/StatsD/ClickHouse port is injected
+    here at the operator runtime step. Any other value fails closed."""
+    choice = os.environ.get("CANARY_METRICS", "null").strip().lower()
+    if choice in ("", "null", "none"):
+        return NullCanaryMetrics()
+    if choice == "inmemory":
+        return InMemoryCanaryMetrics()
+    raise ValueError(f"CANARY_METRICS={choice!r} is invalid; expected 'null' or 'inmemory'")
+
+
 def get_composition() -> _Composition:
     """Build the request-time composition. The flag is read fresh each call (safe
-    pre-activation toggling); the catalogue and the lineage sink are singletons."""
+    pre-activation toggling); the catalogue and the lineage sink are singletons.
+
+    The S1 LLM-gateway seam is wrapped in :class:`InstrumentedLLMClassifier` so any
+    live gateway call is timed/counted; wrapping the Null classifier is inert (the
+    fuzzy fallback is never consulted while dark)."""
     enabled = intent_layer_enabled()
+    env = canary_env()
+    metrics = get_canary_metrics()
     dispatcher = CapabilityDispatcher(
         handlers=_LIVE_HANDLERS,
         producers=ProducerBundle.null(),
         recorder=_RECORDER,
     )
+    llm = InstrumentedLLMClassifier(NullLLMClassifier(), metrics, env=env)
     return _Composition(
-        classifier=IntentClassifier(_catalog(), enabled=enabled),
+        classifier=IntentClassifier(_catalog(), enabled=enabled, llm=llm),
         router=IntentRouter(dispatcher, enabled=enabled),
         recorder=_RECORDER,
+        observer=CanaryObserver(metrics, env=env),
         enabled=enabled,
     )
 
@@ -239,6 +279,40 @@ def _to_record_model(record: AgentDecisionRecord) -> DecisionRecordModel:
     )
 
 
+# ── Canary observability ───────────────────────────────────────────────────────
+
+
+def _observe_canary(
+    comp: _Composition,
+    resolved: ResolvedIntent,
+    disposition: Disposition,
+    latency_ms: float,
+) -> None:
+    """Emit the FU-2 Phase 6 canary signals for a live (enabled) disposition.
+
+    Reached ONLY when the layer is enabled (NOT_ENABLED short-circuits earlier), so a
+    dark/prod deployment never lands here. ``success`` is false only for a dispatch the
+    L2 mask rejected — a GOVERNANCE_EVENT (UNRESOLVED → process-gap) is a correct,
+    expected outcome, not an error. Labels carry no PII (R-SEC)."""
+    record = comp.recorder.get_by_correlation(disposition.correlation_id)
+    receipt = disposition.receipt
+    dispatched = disposition.kind is DispositionKind.DISPATCHED
+    success = not dispatched or bool(getattr(receipt, "accepted", False))
+    error_reason = None if success else "dispatch_rejected"
+    comp.observer.observe(
+        CanaryEvent(
+            capability=disposition.capability or resolved.capability or "unknown",
+            disposition=disposition.kind.value,
+            latency_ms=latency_ms,
+            success=success,
+            compliance_result=record.compliance_result.value if record else "N/A",
+            high_risk_flag=resolved.band is not ConfidenceBand.AUTO,
+            error_reason=error_reason,
+            correlation_id=disposition.correlation_id,
+        )
+    )
+
+
 # ── Routes ───────────────────────────────────────────────────────────────────
 
 
@@ -251,11 +325,17 @@ def submit_intent(body: IntentRequest) -> IntentResponse:
     event loop. Off → NOT_ENABLED (no dispatch). UNRESOLVED → governance event.
     """
     comp = get_composition()
+    start = time.monotonic()
     resolved = comp.classifier.classify(body.intent_text, correlation_id=body.correlation_id)
     disposition = comp.router.route(resolved)
+    latency_ms = (time.monotonic() - start) * 1000
 
     if disposition.kind is DispositionKind.NOT_ENABLED:
+        # Dark/prod path: emit NOTHING (gating on enabled is gating on staging).
         return IntentResponse(enabled=False, disposition="NOT_ENABLED", detail=disposition.reason)
+
+    # Canary is live for this request → record the observability signals.
+    _observe_canary(comp, resolved, disposition, latency_ms)
 
     if disposition.kind is DispositionKind.GOVERNANCE_EVENT:
         return IntentResponse(

--- a/docs/intent-layer-observability.md
+++ b/docs/intent-layer-observability.md
@@ -1,0 +1,150 @@
+# Intent Layer — canary observability & rollback (FU-2 Phase 6)
+
+> **Status (FU-2 Phase 6):** observability + safety instrumentation for the ADR-049
+> L1 Intent Layer **canary** (the Notifications-in-staging path) and the S1
+> LLM-gateway calls it makes. This phase adds metrics/logs/queries/dashboards and a
+> written rollback policy. It does **not** widen the canary, add capabilities, or
+> flip `INTENT_LAYER_ENABLED` anywhere. Prod stays dark.
+
+This is the gate you read **before** expanding the canary beyond Notifications: it
+defines what "the canary is behaving" means in concrete, queryable terms, and the
+exact thresholds that trigger a rollback.
+
+---
+
+## 1. What is the canary?
+
+| | |
+| --- | --- |
+| **Surface** | `POST /v1/intent` (`api/routers/intent.py`) |
+| **In-process capability** | **Notifications only** (`_LIVE_HANDLERS = {"Notifications": …}`) — a low-consequence channel-availability *read*. Payments/FX/Wallet are cross-repo and return an honest *unrouted* receipt. |
+| **Activation** | `INTENT_LAYER_ENABLED=true` — **staging only**. Prod stays `false` (dark). |
+| **Gateway** | The S1 LLM fuzzy-fallback seam (`LLMClassifierPort`). Default `NullLLMClassifier` (abstains); a live gateway adapter is injected at the operator runtime step. |
+
+The canary is enabled *only* in staging, so **gating emission on "enabled" is gating
+on staging** — no second flag, and prod emits nothing.
+
+---
+
+## 2. Metric set
+
+Defined in `services/intent_layer/observability.py` (names are module constants).
+Metrics flow through `CanaryMetricsPort` (DI); the default sink is a no-op
+(`NullCanaryMetrics`), so a backend is touched only when one is wired
+(`CANARY_METRICS=inmemory` for local/staging diagnostics; a real Prometheus/StatsD/
+ClickHouse port at the operator runtime step).
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `intent_layer_canary_requests_total` | counter | `capability`, `env`, `disposition` | Canary traffic volume per disposition (`DISPATCHED` / `GOVERNANCE_EVENT`). |
+| `intent_layer_canary_errors_total` | counter | `capability`, `env`, `reason` | Failed dispositions (e.g. `dispatch_rejected`). |
+| `intent_layer_canary_latency_ms` | observation | `capability`, `env` | classify+route+dispatch latency → p50/p95. |
+| `intent_layer_canary_guardrail_triggers_total` | counter | `capability`, `env`, `reason` | Safety-violation signal: `compliance_fail` / `compliance_escalate` / `high_risk`. |
+| `llm_gateway_request_latency_ms` | observation | `env` | S1-gateway call latency (only when a live gateway is wired). |
+| `llm_gateway_errors_total` | counter | `env`, `reason` | S1-gateway call failures, keyed by exception type. |
+
+**Not yet available — `mismatch_count`.** A canary-vs-baseline comparator would need a
+shadow/baseline decision to diff against. No such comparator exists today (Notifications
+is a read with no prior automated baseline), so this metric is intentionally **omitted
+rather than fabricated**. Add it when a baseline comparator is introduced.
+
+### Structured logs (always-on, no backend required)
+
+* Logger `banxe.intent_layer.canary` — one line per live disposition with fields:
+  `env, capability, disposition, outcome (success|error), compliance, high_risk,
+  latency_ms, tenant, correlation_id` (+ `guardrail=<reason>` when triggered).
+* Logger `banxe.llm_gateway` — one line per gateway call: `env, latency_ms, matched`
+  (or `error=<type>` on failure).
+
+R-SEC: labels/logs carry **only** opaque governance fields — never intent text, PII,
+secrets, or a raw subject identity.
+
+---
+
+## 3. Queries
+
+The durable backend available **today** is `banxe.decision_records` (ClickHouse
+migration 006), written when the canary runs with `DECISION_RECORDER=clickhouse`. The
+canary's emitting mask is `agent_id = 'notification_agent'`. These queries work now;
+the latency/gateway panels additionally need the metrics port wired (operator step).
+
+```sql
+-- Canary traffic volume over time (hourly), last 24h
+SELECT toStartOfHour(timestamp) AS hour, count() AS requests
+FROM banxe.decision_records
+WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 24 HOUR
+GROUP BY hour ORDER BY hour;
+
+-- Error / guardrail rate: share of non-PASS compliance results (last 24h)
+SELECT
+  countIf(compliance_result != 'PASS') AS guardrail_triggers,
+  count() AS total,
+  round(100 * guardrail_triggers / nullIf(total, 0), 2) AS guardrail_pct
+FROM banxe.decision_records
+WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 24 HOUR;
+
+-- Compliance-result breakdown (PASS / FAIL / ESCALATE / N/A)
+SELECT compliance_result, count() AS cnt
+FROM banxe.decision_records
+WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 24 HOUR
+GROUP BY compliance_result ORDER BY cnt DESC;
+
+-- Before/after comparison: enable-window vs the prior equal window
+SELECT
+  if(timestamp >= now() - INTERVAL 24 HOUR, 'after', 'before') AS window,
+  count() AS requests,
+  countIf(compliance_result != 'PASS') AS guardrail_triggers,
+  round(avg(confidence_score), 3) AS avg_confidence
+FROM banxe.decision_records
+WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 48 HOUR
+GROUP BY window ORDER BY window;
+```
+
+Latency p50/p95 and gateway error-rate come from the metrics backend once wired, e.g.
+(PromQL, illustrative):
+
+```promql
+histogram_quantile(0.95, sum(rate(intent_layer_canary_latency_ms_bucket[5m])) by (le))
+sum(rate(llm_gateway_errors_total[5m])) / sum(rate(llm_gateway_request_latency_ms_count[5m]))
+```
+
+### Dashboard-as-code
+
+`infra/grafana/dashboards/intent-layer-canary.json` — a Grafana dashboard (ClickHouse
+datasource) with the traffic, guardrail-rate, compliance-breakdown and confidence
+panels above. It follows the same provisioning convention as
+`agent-routing-metrics.json` (`infra/grafana/dashboards/dashboard.yml`).
+
+---
+
+## 4. Rollback policy (FU-2 canary — staging Notifications)
+
+**Success criteria** (all must hold over a rolling 24h enable window vs the prior 24h
+baseline window):
+
+* **Error rate:** `intent_layer_canary_errors_total / requests_total` ≤ **1%**, and not
+  more than **+0.5pp** above the baseline window.
+* **Guardrail triggers:** no spike — `guardrail_triggers_total` rate ≤ **2×** the
+  baseline window, and zero `compliance_fail` for the Notifications read (a read should
+  never FAIL compliance).
+* **Latency:** canary p95 ≤ **750 ms** and gateway p95 ≤ **2 s** (when a live gateway is
+  wired).
+* **Gateway:** `llm_gateway_errors_total` rate ≤ **2%**.
+
+**Rollback triggers** — ANY one, sustained over ≥10 min (or a single hard breach):
+
+* error rate > **2%**, or any `compliance_fail` on the Notifications canary;
+* guardrail-trigger rate > **3×** baseline;
+* canary p95 > **1.5 s** or gateway error rate > **5%**.
+
+**Rollback mechanism — flags/env only, no code change, no deploy:**
+
+1. Set `INTENT_LAYER_ENABLED=false` in the staging environment. The very next request
+   short-circuits to `NOT_ENABLED` **before** any dispatch — no L2 mask, no gateway
+   call, no lineage write, no canary metric/log. (This is the safe pre-activation
+   contract proven by the dark-mode tests.)
+2. Optionally set `CANARY_METRICS` back to `null` to silence the metrics sink.
+
+No `INTENT_LAYER_CANARY_CAPABILITIES` change and no prod flip is involved in either
+activation or rollback. Widening the canary beyond Notifications is a **separate**
+future step, gated on this dashboard staying green across a full enable window.

--- a/infra/grafana/dashboards/intent-layer-canary.json
+++ b/infra/grafana/dashboards/intent-layer-canary.json
@@ -1,0 +1,185 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "vertamedia-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "2.5.0"
+    }
+  ],
+  "annotations": { "list": [] },
+  "description": "FU-2 Intent Layer canary (Notifications-in-staging) — traffic, guardrail rate, compliance breakdown and confidence, from banxe.decision_records (agent_id='notification_agent'). Latency/gateway panels require the CanaryMetricsPort wired to a metrics backend (operator runtime step).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Canary traffic & safety",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+          "rawSql": "SELECT toStartOfHour(timestamp) AS t, count() AS requests FROM banxe.decision_records WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 24 HOUR GROUP BY t ORDER BY t",
+          "refId": "A"
+        }
+      ],
+      "title": "Canary requests / hour (24h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+          "rawSql": "SELECT round(100 * countIf(compliance_result != 'PASS') / nullIf(count(), 0), 2) AS guardrail_pct FROM banxe.decision_records WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 24 HOUR",
+          "refId": "A"
+        }
+      ],
+      "title": "Guardrail-trigger rate (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+          "rawSql": "SELECT countIf(compliance_result = 'FAIL') AS compliance_fail FROM banxe.decision_records WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 24 HOUR",
+          "refId": "A"
+        }
+      ],
+      "title": "Compliance FAILs (24h) — must be 0",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "id": 5,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "pieType": "pie",
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+          "rawSql": "SELECT compliance_result, count() AS cnt FROM banxe.decision_records WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 24 HOUR GROUP BY compliance_result ORDER BY cnt DESC",
+          "refId": "A"
+        }
+      ],
+      "title": "Compliance-result breakdown (24h)",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "none" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "id": 6,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+          "rawSql": "SELECT toStartOfHour(timestamp) AS t, round(avg(confidence_score), 3) AS avg_confidence FROM banxe.decision_records WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 24 HOUR GROUP BY t ORDER BY t",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg classification confidence / hour (24h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 17 },
+      "id": 7,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "clickhouse" },
+          "rawSql": "SELECT if(timestamp >= now() - INTERVAL 24 HOUR, 'after', 'before') AS window, count() AS requests, countIf(compliance_result != 'PASS') AS guardrail_triggers FROM banxe.decision_records WHERE agent_id = 'notification_agent' AND timestamp >= now() - INTERVAL 48 HOUR GROUP BY window ORDER BY window",
+          "refId": "A"
+        }
+      ],
+      "title": "Before/after enable: requests & guardrail triggers",
+      "type": "table"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": ["intent-layer", "canary", "fu-2", "observability"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timezone": "utc",
+  "title": "Intent Layer Canary (FU-2)",
+  "uid": "intent-layer-canary",
+  "version": 1,
+  "weekStart": ""
+}

--- a/services/intent_layer/observability.py
+++ b/services/intent_layer/observability.py
@@ -1,0 +1,266 @@
+"""
+services/intent_layer/observability.py — L1 Intent Layer canary + gateway observability
+IL-FU2-OBSERVABILITY-2026-06-14 | banxe-emi-stack (FU-2 Phase 6)
+
+Safety/observability instrumentation for the ADR-049 L1 Intent Layer *canary* (the
+Notifications-in-staging path) and the S1 LLM-gateway calls it makes. This is the
+seam that turns "is the canary behaving?" into concrete, queryable signals BEFORE the
+canary is widened beyond Notifications.
+
+DESIGN (banking-safe, additive, dependency-free):
+
+  * Metrics flow through a :class:`CanaryMetricsPort` (Protocol DI), exactly like the
+    ARL :class:`TelemetryPort`. The DEFAULT is :class:`NullCanaryMetrics` (no-op) so
+    importing/constructing the observer is free and never reaches a metrics backend.
+    Tests inject :class:`InMemoryCanaryMetrics`; a real Prometheus/StatsD/ClickHouse
+    port is the operator runtime step (no new hard dependency is added here).
+
+  * Structured logs go to the ``banxe.intent_layer.canary`` logger (and gateway calls
+    to ``banxe.llm_gateway``). Logs need NO backend, so they are the always-on
+    observable even when no metrics sink is wired.
+
+  * Emission is GATED on the canary actually running. The router only invokes the
+    observer when the disposition is NOT ``NOT_ENABLED`` — so a dark/prod deployment
+    (INTENT_LAYER_ENABLED=false → NOT_ENABLED) emits NOTHING. Gating on "enabled"
+    *is* gating on staging, because the canary is only enabled in staging. This keeps
+    prod free of canary noise without a second flag.
+
+R-SEC: only opaque governance labels are emitted — env, capability, disposition,
+compliance result, a coarse high-risk boolean, an opaque tenant handle and the
+correlation id. NEVER intent text, PII, secrets, or a raw subject identity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import os
+import time
+from typing import Protocol, runtime_checkable
+
+from services.intent_layer.models import IntentDefinition
+from services.intent_layer.ports import LLMClassification, LLMClassifierPort
+
+canary_logger = logging.getLogger("banxe.intent_layer.canary")
+gateway_logger = logging.getLogger("banxe.llm_gateway")
+
+# ── Metric names (stable label keys — keep in lockstep with the dashboards) ───────
+
+REQUESTS_TOTAL = "intent_layer_canary_requests_total"
+ERRORS_TOTAL = "intent_layer_canary_errors_total"
+LATENCY_MS = "intent_layer_canary_latency_ms"
+GUARDRAIL_TRIGGERS_TOTAL = "intent_layer_canary_guardrail_triggers_total"
+GATEWAY_LATENCY_MS = "llm_gateway_request_latency_ms"
+GATEWAY_ERRORS_TOTAL = "llm_gateway_errors_total"
+
+CANARY_ENV_ENV = "BANXE_ENV"
+
+
+def canary_env(env: dict[str, str] | None = None) -> str:
+    """Deployment label for canary metrics. Reads ``BANXE_ENV`` (e.g. ``staging``);
+    ``unknown`` when unset so an unlabelled emit is visible rather than silently
+    masquerading as prod. Injectable env for deterministic tests."""
+    source = env if env is not None else os.environ
+    return (source.get(CANARY_ENV_ENV) or "unknown").strip().lower() or "unknown"
+
+
+# ── Metrics port (Protocol DI) ────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class CanaryMetricsPort(Protocol):
+    """Sink for canary/gateway metrics. Implementations are wired at the composition
+    root; the layer depends only on this interface (no Prometheus import here)."""
+
+    def incr(self, name: str, *, labels: dict[str, str], value: int = 1) -> None: ...
+
+    def observe(self, name: str, value: float, *, labels: dict[str, str]) -> None: ...
+
+
+class NullCanaryMetrics:
+    """Default metrics port: discards everything. Lets the observer be constructed and
+    exercised with zero metrics-backend dependency (structured logs still fire)."""
+
+    def incr(self, name: str, *, labels: dict[str, str], value: int = 1) -> None:
+        return None
+
+    def observe(self, name: str, value: float, *, labels: dict[str, str]) -> None:
+        return None
+
+
+@dataclass(frozen=True)
+class MetricSample:
+    """One recorded metric point (diagnostics / tests)."""
+
+    name: str
+    kind: str  # "counter" | "observation"
+    value: float
+    labels: dict[str, str]
+
+
+class InMemoryCanaryMetrics:
+    """In-memory metrics port for tests and local development — records every sample
+    so assertions can check the exact name/labels/value emitted."""
+
+    def __init__(self) -> None:
+        self.samples: list[MetricSample] = []
+
+    def incr(self, name: str, *, labels: dict[str, str], value: int = 1) -> None:
+        self.samples.append(MetricSample(name, "counter", float(value), dict(labels)))
+
+    def observe(self, name: str, value: float, *, labels: dict[str, str]) -> None:
+        self.samples.append(MetricSample(name, "observation", float(value), dict(labels)))
+
+    def counter_total(self, name: str, **label_filter: str) -> float:
+        """Sum of counter ``name`` over samples matching every label in ``label_filter``."""
+        return sum(
+            s.value
+            for s in self.samples
+            if s.name == name
+            and s.kind == "counter"
+            and all(s.labels.get(k) == v for k, v in label_filter.items())
+        )
+
+    def observations(self, name: str) -> list[float]:
+        return [s.value for s in self.samples if s.name == name and s.kind == "observation"]
+
+
+# ── Canary disposition observer ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CanaryEvent:
+    """The auditable, PII-minimised summary of one canary disposition."""
+
+    capability: str
+    disposition: str
+    latency_ms: float
+    success: bool
+    compliance_result: str = "N/A"
+    high_risk_flag: bool = False
+    error_reason: str | None = None
+    tenant: str = "unknown"  # opaque handle; reserved for multi-tenant routing (never PII)
+    correlation_id: str | None = None
+
+
+class CanaryObserver:
+    """Emits structured logs + metrics for one canary disposition. Constructed per
+    request at the composition root; the metrics port defaults to the no-op sink."""
+
+    def __init__(self, metrics: CanaryMetricsPort | None = None, *, env: str | None = None) -> None:
+        self._metrics: CanaryMetricsPort = metrics if metrics is not None else NullCanaryMetrics()
+        self._env = env if env is not None else canary_env()
+
+    def observe(self, event: CanaryEvent) -> None:
+        """Record one canary disposition. Call ONLY when the canary actually ran
+        (disposition != NOT_ENABLED); dark/prod paths must not reach here."""
+        base = {"capability": event.capability, "env": self._env}
+
+        self._metrics.incr(REQUESTS_TOTAL, labels={**base, "disposition": event.disposition})
+        self._metrics.observe(LATENCY_MS, event.latency_ms, labels=base)
+
+        if not event.success:
+            reason = event.error_reason or "unknown"
+            self._metrics.incr(ERRORS_TOTAL, labels={**base, "reason": reason})
+
+        guardrail = _guardrail_reason(event.compliance_result, event.high_risk_flag)
+        if guardrail is not None:
+            self._metrics.incr(GUARDRAIL_TRIGGERS_TOTAL, labels={**base, "reason": guardrail})
+
+        canary_logger.info(
+            "intent_layer.canary disposition=%s capability=%s env=%s outcome=%s "
+            "compliance=%s high_risk=%s latency_ms=%.1f tenant=%s correlation_id=%s%s",
+            event.disposition,
+            event.capability,
+            self._env,
+            "success" if event.success else "error",
+            event.compliance_result,
+            str(event.high_risk_flag).lower(),
+            event.latency_ms,
+            event.tenant,
+            event.correlation_id,
+            f" guardrail={guardrail}" if guardrail else "",
+        )
+
+
+def _guardrail_reason(compliance_result: str, high_risk_flag: bool) -> str | None:
+    """Map a disposition's safety signals to a guardrail-trigger reason, or None.
+
+    A guardrail trigger is a compliance gate that did NOT cleanly PASS, or a
+    high-risk flag — the spikes the canary watches before widening scope."""
+    result = (compliance_result or "").upper()
+    if result == "FAIL":
+        return "compliance_fail"
+    if result == "ESCALATE":
+        return "compliance_escalate"
+    if high_risk_flag:
+        return "high_risk"
+    return None
+
+
+# ── LLM-gateway call instrumentation ────────────────────────────────────────────────
+
+
+class InstrumentedLLMClassifier(LLMClassifierPort):
+    """Decorates an :class:`LLMClassifierPort` (the S1 gateway seam) with latency +
+    error metrics and structured gateway logs. Transparent: it returns the delegate's
+    result and re-raises its errors after recording them, so behaviour is unchanged.
+
+    Wrapping the Null classifier is inert — ``classify`` is only consulted when
+    deterministic matching fails AND the layer is enabled, so dark mode never times a
+    call. A real gateway adapter is injected in the delegate's place when live."""
+
+    def __init__(
+        self,
+        delegate: LLMClassifierPort,
+        metrics: CanaryMetricsPort | None = None,
+        *,
+        env: str | None = None,
+    ) -> None:
+        self._delegate = delegate
+        self._metrics: CanaryMetricsPort = metrics if metrics is not None else NullCanaryMetrics()
+        self._env = env if env is not None else canary_env()
+
+    def classify(
+        self, intent_text: str, candidates: list[IntentDefinition]
+    ) -> LLMClassification | None:
+        labels = {"env": self._env}
+        start = time.monotonic()
+        try:
+            result = self._delegate.classify(intent_text, candidates)
+        except Exception as exc:
+            self._metrics.incr(
+                GATEWAY_ERRORS_TOTAL, labels={**labels, "reason": type(exc).__name__}
+            )
+            gateway_logger.warning(
+                "llm_gateway call failed env=%s error=%s", self._env, type(exc).__name__
+            )
+            raise
+        latency_ms = (time.monotonic() - start) * 1000
+        self._metrics.observe(GATEWAY_LATENCY_MS, latency_ms, labels=labels)
+        gateway_logger.info(
+            "llm_gateway call env=%s latency_ms=%.1f matched=%s",
+            self._env,
+            latency_ms,
+            "yes" if result is not None else "no",
+        )
+        return result
+
+
+__all__ = [
+    "CANARY_ENV_ENV",
+    "ERRORS_TOTAL",
+    "GATEWAY_ERRORS_TOTAL",
+    "GATEWAY_LATENCY_MS",
+    "GUARDRAIL_TRIGGERS_TOTAL",
+    "LATENCY_MS",
+    "REQUESTS_TOTAL",
+    "CanaryEvent",
+    "CanaryMetricsPort",
+    "CanaryObserver",
+    "InMemoryCanaryMetrics",
+    "InstrumentedLLMClassifier",
+    "MetricSample",
+    "NullCanaryMetrics",
+    "canary_env",
+]

--- a/tests/test_intent_layer/test_observability.py
+++ b/tests/test_intent_layer/test_observability.py
@@ -1,0 +1,261 @@
+"""
+tests/test_intent_layer/test_observability.py — FU-2 Phase 6 canary observability.
+
+Validates the metrics/logging hooks added for the ADR-049 L1 Intent Layer *canary*
+(Notifications in staging) and the S1 LLM-gateway seam, with NO live gateway and NO
+metrics backend — every dependency is an in-memory double:
+
+  * CanaryObserver emits the request/latency counters with the expected labels, an
+    error counter on a rejected dispatch, and a guardrail-trigger counter on a
+    compliance FAIL/ESCALATE or a high-risk flag.
+  * InstrumentedLLMClassifier times a gateway call and counts gateway errors, while
+    staying transparent (returns the delegate's result, re-raises its errors).
+  * The CANARY_METRICS selection seam defaults to the no-op sink and fails closed.
+  * At the HTTP surface: when the canary is ENABLED a ``banxe.intent_layer.canary``
+    log fires for a Notifications intent; when DISABLED (dark/prod) NOTHING is
+    emitted — the dark-mode no-side-effect contract is preserved.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from services.intent_layer.observability import (
+    ERRORS_TOTAL,
+    GATEWAY_ERRORS_TOTAL,
+    GATEWAY_LATENCY_MS,
+    GUARDRAIL_TRIGGERS_TOTAL,
+    LATENCY_MS,
+    REQUESTS_TOTAL,
+    CanaryEvent,
+    CanaryObserver,
+    InMemoryCanaryMetrics,
+    InstrumentedLLMClassifier,
+    NullCanaryMetrics,
+    canary_env,
+)
+from services.intent_layer.ports import LLMClassification, NullLLMClassifier
+
+CANARY_LOGGER = "banxe.intent_layer.canary"
+
+
+# ── CanaryObserver: counters + labels ────────────────────────────────────────────
+
+
+def _observe(event: CanaryEvent, env: str = "staging") -> InMemoryCanaryMetrics:
+    metrics = InMemoryCanaryMetrics()
+    CanaryObserver(metrics, env=env).observe(event)
+    return metrics
+
+
+def test_observer_emits_request_and_latency_with_labels():
+    """A successful dispatch increments requests_total{capability,env,disposition}
+    and observes the latency — the canary's traffic/latency signals."""
+    metrics = _observe(
+        CanaryEvent(
+            capability="Notifications",
+            disposition="DISPATCHED",
+            latency_ms=12.5,
+            success=True,
+        )
+    )
+    assert (
+        metrics.counter_total(
+            REQUESTS_TOTAL, capability="Notifications", env="staging", disposition="DISPATCHED"
+        )
+        == 1
+    )
+    assert metrics.observations(LATENCY_MS) == [12.5]
+    # A clean PASS dispatch is neither an error nor a guardrail trigger.
+    assert metrics.counter_total(ERRORS_TOTAL) == 0
+    assert metrics.counter_total(GUARDRAIL_TRIGGERS_TOTAL) == 0
+
+
+def test_observer_counts_error_on_rejected_dispatch():
+    """A failed dispatch increments errors_total with the reason label."""
+    metrics = _observe(
+        CanaryEvent(
+            capability="Notifications",
+            disposition="DISPATCHED",
+            latency_ms=4.0,
+            success=False,
+            error_reason="dispatch_rejected",
+        )
+    )
+    assert metrics.counter_total(ERRORS_TOTAL, reason="dispatch_rejected") == 1
+
+
+@pytest.mark.parametrize(
+    ("compliance_result", "high_risk", "expected_reason"),
+    [
+        ("FAIL", False, "compliance_fail"),
+        ("ESCALATE", False, "compliance_escalate"),
+        ("PASS", True, "high_risk"),
+    ],
+)
+def test_observer_counts_guardrail_triggers(compliance_result, high_risk, expected_reason):
+    """A compliance FAIL/ESCALATE or a high-risk flag is a guardrail trigger — the
+    safety-violation signal the canary watches for spikes."""
+    metrics = _observe(
+        CanaryEvent(
+            capability="Notifications",
+            disposition="DISPATCHED",
+            latency_ms=1.0,
+            success=True,
+            compliance_result=compliance_result,
+            high_risk_flag=high_risk,
+        )
+    )
+    assert metrics.counter_total(GUARDRAIL_TRIGGERS_TOTAL, reason=expected_reason) == 1
+
+
+def test_observer_clean_pass_triggers_no_guardrail():
+    """A PASS with no high-risk flag emits zero guardrail triggers."""
+    metrics = _observe(
+        CanaryEvent(
+            capability="Notifications",
+            disposition="DISPATCHED",
+            latency_ms=1.0,
+            success=True,
+            compliance_result="PASS",
+            high_risk_flag=False,
+        )
+    )
+    assert metrics.counter_total(GUARDRAIL_TRIGGERS_TOTAL) == 0
+
+
+def test_observer_logs_structured_fields(caplog):
+    """The structured canary log carries env/capability/disposition/compliance/
+    high_risk — the always-on observable that needs no metrics backend."""
+    with caplog.at_level(logging.INFO, logger=CANARY_LOGGER):
+        CanaryObserver(NullCanaryMetrics(), env="staging").observe(
+            CanaryEvent(
+                capability="Notifications",
+                disposition="DISPATCHED",
+                latency_ms=2.0,
+                success=True,
+                compliance_result="PASS",
+            )
+        )
+    records = [r for r in caplog.records if r.name == CANARY_LOGGER]
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "capability=Notifications" in msg
+    assert "env=staging" in msg
+    assert "disposition=DISPATCHED" in msg
+
+
+# ── LLM-gateway instrumentation ───────────────────────────────────────────────────
+
+
+class _StubGateway:
+    """LLMClassifierPort double that returns a fixed match (a 'live' gateway)."""
+
+    def classify(self, intent_text, candidates):
+        return LLMClassification(matched_intent="get-notified", confidence=0.95)
+
+
+class _BoomGateway:
+    """LLMClassifierPort double that always fails — a gateway error."""
+
+    def classify(self, intent_text, candidates):
+        raise TimeoutError("gateway unreachable")
+
+
+def test_gateway_instrumentation_times_successful_call():
+    """A successful gateway call records a latency observation and is transparent."""
+    metrics = InMemoryCanaryMetrics()
+    classifier = InstrumentedLLMClassifier(_StubGateway(), metrics, env="staging")
+
+    result = classifier.classify("ping me", [])
+
+    assert result is not None and result.matched_intent == "get-notified"
+    assert len(metrics.observations(GATEWAY_LATENCY_MS)) == 1
+    assert metrics.counter_total(GATEWAY_ERRORS_TOTAL) == 0
+
+
+def test_gateway_instrumentation_counts_and_reraises_errors():
+    """A gateway failure increments gateway_errors_total{reason} and re-raises."""
+    metrics = InMemoryCanaryMetrics()
+    classifier = InstrumentedLLMClassifier(_BoomGateway(), metrics, env="staging")
+
+    with pytest.raises(TimeoutError):
+        classifier.classify("ping me", [])
+
+    assert metrics.counter_total(GATEWAY_ERRORS_TOTAL, reason="TimeoutError") == 1
+    assert metrics.observations(GATEWAY_LATENCY_MS) == []
+
+
+def test_gateway_instrumentation_over_null_is_inert():
+    """Wrapping the Null classifier records a (fast) latency sample and abstains —
+    proving the wrap is transparent over the default no-LLM seam."""
+    metrics = InMemoryCanaryMetrics()
+    classifier = InstrumentedLLMClassifier(NullLLMClassifier(), metrics)
+    assert classifier.classify("anything", []) is None
+    assert len(metrics.observations(GATEWAY_LATENCY_MS)) == 1
+
+
+# ── Env label + metrics selection seam ────────────────────────────────────────────
+
+
+def test_canary_env_reads_banxe_env():
+    assert canary_env(env={"BANXE_ENV": "Staging"}) == "staging"
+    assert canary_env(env={}) == "unknown"
+
+
+def test_get_canary_metrics_seam(monkeypatch):
+    """Default → no-op sink; ``inmemory`` → recordable; anything else fails closed."""
+    from api.routers.intent import get_canary_metrics
+
+    monkeypatch.delenv("CANARY_METRICS", raising=False)
+    assert isinstance(get_canary_metrics(), NullCanaryMetrics)
+
+    monkeypatch.setenv("CANARY_METRICS", "inmemory")
+    assert isinstance(get_canary_metrics(), InMemoryCanaryMetrics)
+
+    monkeypatch.setenv("CANARY_METRICS", "prometheus")
+    with pytest.raises(ValueError, match="CANARY_METRICS"):
+        get_canary_metrics()
+
+
+# ── HTTP surface: emitted when enabled, silent when dark ──────────────────────────
+
+
+def _post_intent(monkeypatch, *, enabled: bool, caplog):
+    from fastapi.testclient import TestClient
+
+    from api.main import app
+
+    monkeypatch.setenv("INTENT_LAYER_ENABLED", "true" if enabled else "false")
+    monkeypatch.setenv("BANXE_ENV", "staging")
+    monkeypatch.setenv("CANARY_METRICS", "inmemory")
+    client = TestClient(app)
+    with caplog.at_level(logging.INFO, logger=CANARY_LOGGER):
+        resp = client.post(
+            "/v1/intent",
+            json={"intent_text": "notifications", "correlation_id": f"obs-{enabled}"},
+        )
+    assert resp.status_code == 200
+    return resp.json(), [r for r in caplog.records if r.name == CANARY_LOGGER]
+
+
+def test_http_canary_enabled_emits_log(monkeypatch, caplog):
+    """ENABLED: a Notifications intent produces a canary log (a metrics/logging hook
+    fired) tagged with the Notifications capability + staging env."""
+    body, records = _post_intent(monkeypatch, enabled=True, caplog=caplog)
+    assert body["enabled"] is True
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "capability=Notifications" in msg
+    assert "env=staging" in msg
+
+
+def test_http_canary_disabled_emits_nothing(monkeypatch, caplog):
+    """DISABLED (dark/prod): NOT_ENABLED envelope and NO canary log — the
+    no-side-effect dark-mode contract holds for observability too."""
+    body, records = _post_intent(monkeypatch, enabled=False, caplog=caplog)
+    assert body["enabled"] is False
+    assert body["disposition"] == "NOT_ENABLED"
+    assert records == []


### PR DESCRIPTION
## FU-2 Phase 6 — observability & safety metrics for the Intent Layer canary + LLM-gateway

Strengthens observability/safety monitoring **before** the canary is widened beyond
Notifications-in-staging. Additive, banking-safe, dependency-free.

### What this adds
- **`services/intent_layer/observability.py`** — `CanaryMetricsPort` (Protocol DI;
  `NullCanaryMetrics` default, `InMemoryCanaryMetrics` for tests), `CanaryObserver`
  (request/error/latency/guardrail-trigger metrics + structured
  `banxe.intent_layer.canary` log), `InstrumentedLLMClassifier` (gateway latency/error
  metrics on the S1 seam + `banxe.llm_gateway` log), and a `BANXE_ENV` label helper.
- **`api/routers/intent.py`** — wires the observer and a `CANARY_METRICS` selection
  seam; wraps the LLM seam in the instrumented classifier. **Emission is gated on the
  canary being live** (`disposition != NOT_ENABLED`); a dark/prod deployment emits
  nothing (gating on enabled = gating on staging).
- **`docs/intent-layer-observability.md`** — metric set, ClickHouse/PromQL queries,
  before/after comparison, and the explicit **success criteria + rollback policy**.
- **`infra/grafana/dashboards/intent-layer-canary.json`** — dashboard-as-code over
  `banxe.decision_records` (`agent_id='notification_agent'`), same convention as
  `agent-routing-metrics.json`.
- **`tests/test_intent_layer/test_observability.py`** — 14 tests: hooks fire with the
  expected labels/fields when enabled; **nothing emitted when disabled** (dark-mode
  no-side-effect contract preserved); gateway timing/error + seam coverage. Mocks only
  (no live gateway/ClickHouse).

### Metrics
`intent_layer_canary_requests_total{capability,env,disposition}`,
`intent_layer_canary_errors_total{...,reason}`,
`intent_layer_canary_latency_ms` (p50/p95),
`intent_layer_canary_guardrail_triggers_total{...,reason}`,
`llm_gateway_request_latency_ms`, `llm_gateway_errors_total{...,reason}`.
`mismatch_count` intentionally **omitted** — no baseline comparator exists yet (not fabricated).

### Rollback rule (one-liner)
Roll back by setting `INTENT_LAYER_ENABLED=false` in staging (flags/env only — next
request short-circuits to `NOT_ENABLED` before any dispatch) when canary error rate
> 2%, any `compliance_fail` on the Notifications read, guardrail-trigger rate > 3×
baseline, canary p95 > 1.5 s, or gateway error rate > 5%.

### Guardrails honoured
- ❌ No new `INTENT_LAYER_CANARY_CAPABILITIES`. ❌ No `INTENT_LAYER_ENABLED` flip.
- ❌ No `banxe-payment-core` change. ❌ No new hard dependency. ❌ No weakened safety check.

### Tests
`pytest tests/test_intent_layer/ tests/test_api_intent.py tests/agents/test_recorders.py` → **116 passed, 2 skipped** (skips are opt-in ClickHouse). `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)