### PR TITLE
FU-2: Intent Layer production shadow-mode (no live actions)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,4 +192,22 @@ BANXE_ENV=production
 INTENT_LAYER_CANARY_CAPABILITIES=Notifications
 # Canary metrics sink: "null" (default, no-op — prod silent) | "inmemory" (staging
 # diagnostics). A real Prometheus/StatsD/ClickHouse port is wired at the operator step.
+# Also selects the FU-2 Phase 8 shadow metrics sink (same seam).
 CANARY_METRICS=null
+
+# === Intent Layer (ADR-049) PRODUCTION shadow-mode — FU-2 Phase 8 ===
+# Master gate for production shadow-mode. DEFAULT false. When true AND BANXE_ENV is
+# exactly "production", a sampled slice of prod intent-like traffic (notification
+# scheduling, support tickets, CRM referrals) is mirrored through the Intent Layer
+# CLASSIFY-ONLY — no live action, no payment/KYC/CRM write — purely to log + compare
+# the Intent Layer's decision against the mechanistic baseline. Set false to roll back
+# INSTANTLY (config-only, next request). NEVER implies INTENT_LAYER_ENABLED=true.
+INTENT_LAYER_SHADOW_ENABLED_PROD=false
+# Shadow scope — comma-separated capability labels the shadow path treats as in-scope.
+# Honoured ONLY when BANXE_ENV == "production"; high-risk surfaces are dropped by the
+# code denylist regardless. Default (unset) = the SAME low-risk scope as the staging
+# canary (Notifications, Referral / CRM) — never wider.
+#   INTENT_LAYER_SHADOW_CAPABILITIES=Notifications,Referral / CRM
+# Fraction (0-100) of the eligible slice to mirror. Default 1 (1%). Deterministic per
+# correlation id. Set 0 to mirror nothing while leaving the flag on.
+INTENT_LAYER_SHADOW_SAMPLE_PCT=1

--- a/api/routers/notifications_hub.py
+++ b/api/routers/notifications_hub.py
@@ -21,6 +21,7 @@ from typing import Annotated
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from services.intent_layer.shadow import maybe_mirror_intent
 from services.notification_hub.channel_dispatcher import ChannelDispatcher
 from services.notification_hub.delivery_tracker import DeliveryTracker
 from services.notification_hub.models import (
@@ -108,6 +109,12 @@ async def send_notification(body: SendNotificationRequest) -> dict:  # type: ign
         )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    # FU-2 Phase 8: production shadow-mode. Fire-and-forget — mirrors a sampled slice of
+    # this intent-like request into the Intent Layer (classify-only, no live action) and
+    # logs how its decision compares to this mechanistic baseline. A no-op unless
+    # INTENT_LAYER_SHADOW_ENABLED_PROD=true in production; never alters this response. The
+    # descriptor is a non-PII endpoint label, never the notification body (R-SEC).
+    maybe_mirror_intent("manage notifications", baseline_capability="Notifications")
     return result
 
 

--- a/api/routers/referral.py
+++ b/api/routers/referral.py
@@ -24,6 +24,7 @@ from functools import lru_cache
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from services.intent_layer.shadow import maybe_mirror_intent
 from services.referral.referral_agent import ReferralAgent
 
 router = APIRouter(tags=["referral"])
@@ -92,7 +93,7 @@ async def track_referral(req: TrackReferralRequest) -> dict:
     HTTP 422 on invalid code, self-referral, or already-referred customer.
     """
     try:
-        return _get_agent().track_referral(
+        result = _get_agent().track_referral(
             referee_id=req.referee_id,
             code_str=req.code,
             ip_address=req.ip_address,
@@ -100,6 +101,17 @@ async def track_referral(req: TrackReferralRequest) -> dict:
         )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    # FU-2 Phase 8: production shadow-mode. Fire-and-forget — mirrors a sampled slice of
+    # this intent-like request into the Intent Layer (classify-only, no live action) and
+    # logs how its decision compares to this mechanistic baseline. A no-op unless
+    # INTENT_LAYER_SHADOW_ENABLED_PROD=true in production; never alters this response. The
+    # descriptor is a non-PII endpoint label, never referee/IP/device data (R-SEC).
+    maybe_mirror_intent(
+        "referral",
+        baseline_capability="Referral / CRM",
+        correlation_id=result.get("referral_id"),
+    )
+    return result
 
 
 @router.post("/v1/referral/{referral_id}/advance")

--- a/api/routers/support.py
+++ b/api/routers/support.py
@@ -23,6 +23,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from services.intent_layer.shadow import maybe_mirror_intent
 from services.support.complaint_triage_agent import ComplaintTriageAgent
 from services.support.customer_support_agent import CustomerSupportAgent
 from services.support.escalation_agent import EscalationAgent
@@ -225,6 +226,12 @@ async def create_ticket(
     resp = _ticket_to_response(ticket)
     resp.auto_resolved = faq.auto_resolved
     resp.is_formal_complaint = triage.is_formal_complaint
+    # FU-2 Phase 8: production shadow-mode. Fire-and-forget — mirrors a sampled slice of
+    # this intent-like request into the Intent Layer (classify-only, no live action) and
+    # logs how its decision compares to this mechanistic baseline. A no-op unless
+    # INTENT_LAYER_SHADOW_ENABLED_PROD=true in production; never alters this response. The
+    # descriptor is a non-PII endpoint label, never the ticket subject/body (R-SEC).
+    maybe_mirror_intent("support ticket", baseline_capability="Support", correlation_id=ticket.id)
     return resp
 
 

--- a/docs/intent-layer-observability.md
+++ b/docs/intent-layer-observability.md
@@ -49,10 +49,11 @@ ClickHouse port at the operator runtime step).
 | `llm_gateway_request_latency_ms` | observation | `env` | S1-gateway call latency (only when a live gateway is wired). |
 | `llm_gateway_errors_total` | counter | `env`, `reason` | S1-gateway call failures, keyed by exception type. |
 
-**Not yet available — `mismatch_count`.** A canary-vs-baseline comparator would need a
-shadow/baseline decision to diff against. No such comparator exists today (Notifications
-is a read with no prior automated baseline), so this metric is intentionally **omitted
-rather than fabricated**. Add it when a baseline comparator is introduced.
+**`mismatch_count` — introduced in FU-2 Phase 8.** The Phase 6 canary had no baseline to
+diff against, so this metric was deliberately omitted. **Production shadow-mode (Phase 8)**
+introduces the baseline-vs-shadow comparator and emits
+`intent_layer_shadow_baseline_vs_shadow_mismatch_total` (`env`, `mode=shadow`,
+`capability`). See **§6**.
 
 ### Structured logs (always-on, no backend required)
 
@@ -243,3 +244,80 @@ capability:
 
 Narrowing the scope is a config-only change and takes effect on the **very next** request;
 no prod flip is ever involved.
+
+---
+
+## 6. Production shadow-mode (FU-2 Phase 8)
+
+> **Status (FU-2 Phase 8):** the first *production* exposure of the Intent Layer — a
+> **shadow** one. A small, low-risk slice of prod intent-like traffic is mirrored through
+> the classifier + router **classify-only**, purely to log and compare what the Intent
+> Layer *would* decide against the mechanistic baseline that actually served the request.
+> It performs **no live action**: no payment, no KYC/CRM write, no notification send, no
+> lineage. `INTENT_LAYER_ENABLED` stays `false` in prod (the live `/v1/intent` path is
+> still dark); shadow-mode is a separate, independently-gated pipeline.
+
+Prerequisites (all already shipped): FU-2 runtime prep (ClickHouse baseline, dry-run
+harness), the staging canary (Phase 5/7) and its observability (Phase 6, §1–§5).
+
+### 6.1 What is mirrored, and how it stays safe
+
+| | |
+| --- | --- |
+| **Surfaces (the slice)** | A sampled subset of three existing prod entrypoints: notification scheduling (`POST /v1/notifications-hub/send`), support tickets (`POST /v1/support/tickets`), CRM referrals (`POST /v1/referral/track`). Each calls the fire-and-forget hook `services.intent_layer.shadow.maybe_mirror_intent(...)` *after* the live work, passing a **non-PII descriptor** (an endpoint label, never user content — R-SEC). |
+| **Pipeline** | `services/intent_layer/shadow.py` — `ShadowPipeline` runs classify + route with a `NullShadowDispatcher` that **never acts** (no producer, no L2 mask, no L3 port, no lineage). Even a resolved, in-scope intent yields only a *proposed* capability. |
+| **No live action** | Guaranteed three ways: (1) the Null dispatcher cannot call anything; (2) high-risk capabilities are subtracted from the shadow allow-list (router holds them `CANARY_HELD`); (3) every error/timeout is swallowed (`shadow_error`) and the live response is returned untouched. |
+| **Gating** | Active **only** when `INTENT_LAYER_SHADOW_ENABLED_PROD=true` **and** `BANXE_ENV=production`, then only for the deterministically-sampled slice (`INTENT_LAYER_SHADOW_SAMPLE_PCT`, default 1%). Outside production the effective scope is empty — a leaked flag is inert. |
+| **Scope** | Same low-risk capabilities as the staging canary (Notifications, Referral / CRM) — **never wider** (the high-risk denylist from §5.3 is reused verbatim). |
+
+### 6.2 Shadow metric set (tagged `env=prod, mode=shadow`)
+
+Defined in `services/intent_layer/shadow.py`; sink selected by `CANARY_METRICS` (same
+seam as the canary — default `null`/no-op, `inmemory` for diagnostics).
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `intent_layer_shadow_requests_total` | counter | `capability`, `env`, `mode`, `disposition` | `shadow_request_count` — mirrored volume per shadow disposition (`DISPATCHED` = would-engage / `CANARY_HELD` / `GOVERNANCE_EVENT`). |
+| `intent_layer_shadow_errors_total` | counter | `env`, `mode`, `reason` | `shadow_error_count` — swallowed shadow-pipeline failures (never reach the client). |
+| `intent_layer_shadow_baseline_vs_shadow_mismatch_total` | counter | `capability`, `env`, `mode` | `baseline_vs_shadow_mismatch_count` — how often the Intent Layer would have classified to a **different** capability than the mechanistic baseline (including resolving it to nothing). |
+
+**Structured log (always-on):** logger `banxe.intent_layer.shadow`, one line per mirror:
+`env, mode=shadow, disposition, baseline_capability, shadow_capability, mismatch,
+correlation_id`. No intent text, no PII.
+
+### 6.3 Dashboards / how to read the mismatch metric
+
+* **`shadow_request_count` by `disposition`** — confirms the slice is flowing and how the
+  Intent Layer would have classified it. `DISPATCHED` means *would-engage* (no action taken).
+* **`shadow_error_count`** — must stay ~0. A non-zero rate means the shadow pipeline is
+  unhealthy; it never affects users, but investigate before trusting the comparison.
+* **`baseline_vs_shadow_mismatch_total / shadow_requests_total`** — the headline signal for
+  any future live rollout. A **high, stable** mismatch rate on a surface (e.g. Support →
+  the Intent Layer has no canonical process, so it is always a mismatch) says "do not route
+  this surface live yet". A **low** mismatch rate (e.g. Notifications, Referral / CRM, where
+  the descriptor resolves to the matching capability) is evidence the Intent Layer agrees
+  with the baseline. Filter everything by `env=prod, mode=shadow`.
+
+### 6.4 Enable / disable (config/env only — no code change, no deploy)
+
+**Enable a tiny prod slice:**
+
+```
+BANXE_ENV=production
+INTENT_LAYER_SHADOW_ENABLED_PROD=true
+INTENT_LAYER_SHADOW_SAMPLE_PCT=1            # 1% of the eligible slice (deterministic)
+# optional — defaults to the staging canary scope; never add high-risk surfaces:
+# INTENT_LAYER_SHADOW_CAPABILITIES=Notifications,Referral / CRM
+CANARY_METRICS=inmemory                     # or a real Prometheus/ClickHouse port
+```
+
+**Instant rollback** — any one, effective on the **very next** request:
+
+| To… | Set | Effect |
+| --- | --- | --- |
+| **Stop shadow entirely** | `INTENT_LAYER_SHADOW_ENABLED_PROD=false` | every request short-circuits before any shadow work — no log, no metric. |
+| **Mirror nothing (keep flag on)** | `INTENT_LAYER_SHADOW_SAMPLE_PCT=0` | sampling admits no request. |
+| **Narrow the scope** | `INTENT_LAYER_SHADOW_CAPABILITIES="Notifications"` | other capabilities resolve but are held in the comparison only. |
+
+`INTENT_LAYER_ENABLED` is **not** involved and stays `false` in prod — shadow-mode never
+flips the live dispatch gate.

--- a/services/intent_layer/shadow.py
+++ b/services/intent_layer/shadow.py
@@ -1,0 +1,382 @@
+"""
+services/intent_layer/shadow.py — L1 Intent Layer PRODUCTION shadow-mode (FU-2 Phase 8).
+
+Phase 5/6/7 stood up and instrumented a **staging** canary (Notifications +
+Referral / CRM) behind ``INTENT_LAYER_ENABLED`` — prod stayed fully dark. Phase 8 is
+the first *production* exposure, but a **shadow** one: a small, low-risk slice of prod
+intent-like traffic is mirrored THROUGH the classifier + router (the same seam the
+canary uses) purely to LOG and COMPARE what the Intent Layer *would* decide against the
+mechanistic baseline that actually served the request. It performs **no live action**.
+
+The hard guarantees (banking-safe, ADR-049 §D3):
+
+  * **No live dispatch.** The shadow router is wired to :class:`NullShadowDispatcher`,
+    which acknowledges nothing and calls no L2 mask, no producer, no L3 port, and writes
+    no lineage. Even a resolved, in-scope intent only yields a *proposed* capability —
+    never a payment, KYC write, CRM mutation or notification.
+  * **Production-gated AND flag-gated.** Shadow runs only when
+    ``INTENT_LAYER_SHADOW_ENABLED_PROD == true`` **and** ``BANXE_ENV == production``.
+    Outside production the effective shadow scope is empty (a leaked flag is inert), so
+    it can never interfere with the staging canary or with tests.
+  * **High-risk stays blocked.** The Phase 7 ``is_high_risk_capability`` denylist is
+    reused: high-risk capabilities are subtracted from the shadow allow-list (router
+    holds them ``CANARY_HELD``) AND the Null dispatcher cannot act regardless.
+  * **Never impacts the live response.** :meth:`ShadowPipeline.mirror` swallows every
+    error/timeout (counted as ``shadow_error``) and returns ``None``; the caller's live
+    path is untouched. The mirror is fire-and-forget.
+
+R-SEC: only opaque governance labels are emitted — env, mode, capability, disposition,
+a baseline-vs-shadow mismatch boolean and the correlation id. NEVER intent text, PII or
+secrets. Callers pass a non-PII intent *descriptor* (e.g. an endpoint label), never raw
+user content.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import logging
+import os
+import uuid
+
+from services.intent_layer.canary import is_high_risk_capability, normalize_capability
+from services.intent_layer.catalog_snapshot import load_catalog
+from services.intent_layer.classifier import IntentClassifier
+from services.intent_layer.models import Disposition, DispositionKind
+from services.intent_layer.observability import (
+    CanaryMetricsPort,
+    InMemoryCanaryMetrics,
+    NullCanaryMetrics,
+    canary_env,
+)
+from services.intent_layer.ports import (
+    AgentDispatchPort,
+    DispatchReceipt,
+    DispatchRequest,
+    NullLLMClassifier,
+)
+from services.intent_layer.router import IntentRouter
+
+shadow_logger = logging.getLogger("banxe.intent_layer.shadow")
+
+# ── Env flags ─────────────────────────────────────────────────────────────────────
+
+SHADOW_ENABLED_ENV = "INTENT_LAYER_SHADOW_ENABLED_PROD"
+SHADOW_CAPABILITIES_ENV = "INTENT_LAYER_SHADOW_CAPABILITIES"
+SHADOW_SAMPLE_PCT_ENV = "INTENT_LAYER_SHADOW_SAMPLE_PCT"
+BANXE_ENV_ENV = "BANXE_ENV"
+PRODUCTION_ENV_VALUE = "production"
+
+# The shadow slice mirrors the SAME low-risk surfaces the staging canary covers — it is
+# never wider (FU-2 guardrail: no scope expansion beyond staging). Both are low-risk
+# reads; high-risk capabilities are subtracted regardless of what is configured here.
+DEFAULT_SHADOW_CAPABILITIES: tuple[str, ...] = ("Notifications", "Referral / CRM")
+
+# Default fraction of the eligible slice to mirror when the flag is on but no explicit
+# percentage is set: a deliberately tiny 1% (FU-2 step 1 decision).
+DEFAULT_SHADOW_SAMPLE_PCT = 1
+
+# ── Metric names (env=prod, mode=shadow — keep in lockstep with dashboards) ─────────
+
+SHADOW_REQUESTS_TOTAL = "intent_layer_shadow_requests_total"
+SHADOW_ERRORS_TOTAL = "intent_layer_shadow_errors_total"
+SHADOW_MISMATCH_TOTAL = "intent_layer_shadow_baseline_vs_shadow_mismatch_total"
+
+
+def shadow_env(env: dict[str, str] | None = None) -> str:
+    """Deployment label gating shadow-mode. Reads ``BANXE_ENV``; blank → ``"unknown"``
+    (a non-production value, so shadow stays off). Injectable env for deterministic tests."""
+    source = env if env is not None else os.environ
+    return (source.get(BANXE_ENV_ENV) or "unknown").strip().lower() or "unknown"
+
+
+def shadow_enabled(env: dict[str, str] | None = None) -> bool:
+    """Read ``INTENT_LAYER_SHADOW_ENABLED_PROD`` (default false). The master prod-shadow
+    flag; the instant rollback lever is setting it back to false."""
+    source = env if env is not None else os.environ
+    return source.get(SHADOW_ENABLED_ENV, "false").strip().lower() == "true"
+
+
+def shadow_active(env: dict[str, str] | None = None) -> bool:
+    """True only when the flag is on AND the env is exactly ``production``.
+
+    This is the single master gate the mirror hook checks first: it is the cheap,
+    fail-closed short-circuit that keeps every non-prod path (staging canary, CI, dev)
+    and every flag-off prod path entirely free of shadow work."""
+    source = env if env is not None else os.environ
+    return shadow_enabled(source) and shadow_env(source) == PRODUCTION_ENV_VALUE
+
+
+def shadow_sample_pct(env: dict[str, str] | None = None) -> int:
+    """The percentage [0, 100] of eligible requests to mirror. Defaults to a tiny 1%;
+    a malformed value fails closed to 0 (mirror nothing) rather than mirroring all."""
+    source = env if env is not None else os.environ
+    raw = source.get(SHADOW_SAMPLE_PCT_ENV)
+    if raw is None or not raw.strip():
+        return DEFAULT_SHADOW_SAMPLE_PCT
+    try:
+        return max(0, min(100, int(raw.strip())))
+    except ValueError:
+        return 0
+
+
+def in_shadow_sample(correlation_id: str, pct: int) -> bool:
+    """Deterministic per-correlation sampling: a stable hash of the id mod 100 < pct.
+
+    Deterministic (not random) so the same request is always sampled the same way —
+    reproducible, and a given trace either is or is not mirrored across retries."""
+    if pct <= 0:
+        return False
+    if pct >= 100:
+        return True
+    digest = hashlib.sha256(correlation_id.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % 100 < pct
+
+
+def shadow_capabilities(env: dict[str, str] | None = None) -> frozenset[str]:
+    """The EFFECTIVE shadow allow-list as normalised capability keys for this env.
+
+    Fail-closed, mirroring :func:`canary.canary_capabilities` but for production:
+      1. **Production gate** — outside ``BANXE_ENV == production`` the allow-list is
+         EMPTY (a leaked flag cannot widen the shadow anywhere else).
+      2. **High-risk subtraction** — any high-risk capability is dropped, so a
+         misconfigured allow-list can never admit a money/FX/KYC/etc surface."""
+    source = env if env is not None else os.environ
+    if shadow_env(source) != PRODUCTION_ENV_VALUE:
+        return frozenset()
+    raw = source.get(SHADOW_CAPABILITIES_ENV)
+    labels = (
+        DEFAULT_SHADOW_CAPABILITIES
+        if raw is None
+        else tuple(label.strip() for label in raw.split(",") if label.strip())
+    )
+    keys = {normalize_capability(label) for label in labels}
+    return frozenset(key for key in keys if key and not is_high_risk_capability(key))
+
+
+# ── Non-acting dispatcher ───────────────────────────────────────────────────────────
+
+
+class NullShadowDispatcher(AgentDispatchPort):
+    """An :class:`AgentDispatchPort` that NEVER acts. It is the mechanical guarantee
+    behind "shadow performs no live action": no producer runs, no L2 mask is consulted,
+    no L3 port is touched and no lineage is written — it just acknowledges the hand-off
+    with a non-accepted, ``(shadow)`` receipt. Even a resolved, in-scope intent that
+    reaches the dispatch boundary produces only a proposed capability, never an effect."""
+
+    def dispatch(self, request: DispatchRequest) -> DispatchReceipt:
+        return DispatchReceipt(
+            accepted=False,
+            agent="(shadow)",
+            detail="shadow-mode: classified only, no live action (FU-2 Phase 8)",
+            metadata={"mode": "shadow", "capability_key": normalize_capability(request.capability)},
+        )
+
+
+# ── Comparison + observer ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ShadowComparison:
+    """The PII-minimised summary of one shadow mirror: what the baseline did vs what the
+    Intent Layer would have proposed, and whether they differ."""
+
+    baseline_capability: str
+    shadow_disposition: str
+    shadow_capability: str | None
+    mismatch: bool
+    correlation_id: str
+
+
+class ShadowObserver:
+    """Emits structured logs + metrics (tagged ``env=prod, mode=shadow``) for one shadow
+    comparison. The metrics port defaults to the no-op sink, so a backend is touched only
+    when one is wired; the structured log is always-on (no backend needed)."""
+
+    def __init__(self, metrics: CanaryMetricsPort | None = None, *, env: str | None = None) -> None:
+        self._metrics: CanaryMetricsPort = metrics if metrics is not None else NullCanaryMetrics()
+        self._env = env if env is not None else canary_env()
+
+    def _base(self, capability: str) -> dict[str, str]:
+        return {"capability": capability, "env": self._env, "mode": "shadow"}
+
+    def observe(self, comparison: ShadowComparison) -> None:
+        base = self._base(comparison.shadow_capability or comparison.baseline_capability)
+        self._metrics.incr(
+            SHADOW_REQUESTS_TOTAL,
+            labels={**base, "disposition": comparison.shadow_disposition},
+        )
+        if comparison.mismatch:
+            self._metrics.incr(SHADOW_MISMATCH_TOTAL, labels=base)
+        shadow_logger.info(
+            "intent_layer.shadow env=%s mode=shadow disposition=%s baseline_capability=%s "
+            "shadow_capability=%s mismatch=%s correlation_id=%s",
+            self._env,
+            comparison.shadow_disposition,
+            comparison.baseline_capability,
+            comparison.shadow_capability or "unresolved",
+            str(comparison.mismatch).lower(),
+            comparison.correlation_id,
+        )
+
+    def observe_error(self, baseline_capability: str, correlation_id: str, reason: str) -> None:
+        self._metrics.incr(
+            SHADOW_ERRORS_TOTAL,
+            labels={"env": self._env, "mode": "shadow", "reason": reason},
+        )
+        shadow_logger.warning(
+            "intent_layer.shadow env=%s mode=shadow error=%s baseline_capability=%s "
+            "correlation_id=%s (swallowed — live response unaffected)",
+            self._env,
+            reason,
+            baseline_capability,
+            correlation_id,
+        )
+
+
+# ── Shadow pipeline ─────────────────────────────────────────────────────────────────
+
+
+class ShadowPipeline:
+    """Mirrors one prod intent through classify + route (with a non-acting dispatcher)
+    and records the baseline-vs-shadow comparison. Construct per call (cheap: the
+    catalogue load is the only cost) so flags are read fresh and rollback is instant."""
+
+    def __init__(
+        self,
+        *,
+        catalog=None,
+        dispatcher: AgentDispatchPort | None = None,
+        observer: ShadowObserver | None = None,
+        env: str | None = None,
+        capabilities: frozenset[str] | None = None,
+    ) -> None:
+        self._catalog = catalog if catalog is not None else load_catalog()
+        self._dispatcher = dispatcher if dispatcher is not None else NullShadowDispatcher()
+        self._env = env if env is not None else canary_env()
+        self._observer = observer if observer is not None else ShadowObserver(env=self._env)
+        self._capabilities = capabilities if capabilities is not None else shadow_capabilities()
+
+    def mirror(
+        self, intent_text: str, baseline_capability: str, correlation_id: str
+    ) -> ShadowComparison | None:
+        """Mirror one request. NEVER raises: any error is counted + logged and ``None``
+        returned so the live caller is unaffected. Returns the comparison on success."""
+        try:
+            classifier = IntentClassifier(self._catalog, enabled=True, llm=NullLLMClassifier())
+            resolved = classifier.classify(intent_text, correlation_id=correlation_id)
+            router = IntentRouter(
+                self._dispatcher, enabled=True, canary_capabilities=self._capabilities
+            )
+            disposition = router.route(resolved)
+            comparison = _build_comparison(baseline_capability, disposition)
+            self._observer.observe(comparison)
+            return comparison
+        except Exception as exc:  # noqa: BLE001 — shadow must never break the live path
+            self._observer.observe_error(baseline_capability, correlation_id, type(exc).__name__)
+            return None
+
+
+def _build_comparison(baseline_capability: str, disposition: Disposition) -> ShadowComparison:
+    """Diff the baseline routing against the shadow disposition. A mismatch = the Intent
+    Layer would have classified the intent to a different capability than the mechanistic
+    baseline (including resolving it to nothing — a governance event)."""
+    shadow_capability = (
+        disposition.capability
+        if disposition.kind
+        in (
+            DispositionKind.DISPATCHED,
+            DispositionKind.CANARY_HELD,
+        )
+        else None
+    )
+    mismatch = normalize_capability(baseline_capability) != normalize_capability(
+        shadow_capability or ""
+    )
+    return ShadowComparison(
+        baseline_capability=baseline_capability,
+        shadow_disposition=disposition.kind.value,
+        shadow_capability=shadow_capability,
+        mismatch=mismatch,
+        correlation_id=disposition.correlation_id,
+    )
+
+
+# ── Composition seam ────────────────────────────────────────────────────────────────
+
+
+def get_shadow_metrics() -> CanaryMetricsPort:
+    """Select the shadow metrics sink from ``CANARY_METRICS`` (same seam as the canary).
+
+    Default (unset/``null``) → :class:`NullCanaryMetrics` (no-op): no backend touched.
+    ``inmemory`` → a recordable sink for diagnostics. A real Prometheus/StatsD/ClickHouse
+    port is injected here at the operator runtime step. Any other value fails closed."""
+    choice = os.environ.get("CANARY_METRICS", "null").strip().lower()
+    if choice in ("", "null", "none"):
+        return NullCanaryMetrics()
+    if choice == "inmemory":
+        return InMemoryCanaryMetrics()
+    raise ValueError(f"CANARY_METRICS={choice!r} is invalid; expected 'null' or 'inmemory'")
+
+
+def maybe_mirror_intent(
+    intent_text: str,
+    baseline_capability: str,
+    *,
+    correlation_id: str | None = None,
+    env: dict[str, str] | None = None,
+) -> ShadowComparison | None:
+    """Fire-and-forget hook for prod entrypoints. Mirrors the request into the shadow
+    Intent Layer ONLY when shadow-mode is active in production AND the request falls in
+    the sampled slice; otherwise it is a cheap no-op. Never raises, never alters the live
+    response — call it after the live work, ignoring the return value.
+
+    ``correlation_id`` is the trace key for deterministic sampling; a fresh opaque id is
+    generated when the caller has none. ``intent_text`` MUST be a non-PII descriptor
+    (e.g. an endpoint label), never raw user content (R-SEC)."""
+    source = env if env is not None else os.environ
+    if not shadow_active(source):
+        return None
+    cid = correlation_id or uuid.uuid4().hex
+    if not in_shadow_sample(cid, shadow_sample_pct(source)):
+        return None
+    try:
+        pipeline = ShadowPipeline(
+            observer=ShadowObserver(get_shadow_metrics(), env=shadow_env(source)),
+            env=shadow_env(source),
+            capabilities=shadow_capabilities(source),
+        )
+    except Exception:  # noqa: BLE001 — construction must never break the live path
+        shadow_logger.warning(
+            "intent_layer.shadow construction failed correlation_id=%s "
+            "(swallowed — live response unaffected)",
+            cid,
+        )
+        return None
+    return pipeline.mirror(intent_text, baseline_capability, cid)
+
+
+__all__ = [
+    "BANXE_ENV_ENV",
+    "DEFAULT_SHADOW_CAPABILITIES",
+    "DEFAULT_SHADOW_SAMPLE_PCT",
+    "PRODUCTION_ENV_VALUE",
+    "SHADOW_CAPABILITIES_ENV",
+    "SHADOW_ENABLED_ENV",
+    "SHADOW_ERRORS_TOTAL",
+    "SHADOW_MISMATCH_TOTAL",
+    "SHADOW_REQUESTS_TOTAL",
+    "SHADOW_SAMPLE_PCT_ENV",
+    "NullShadowDispatcher",
+    "ShadowComparison",
+    "ShadowObserver",
+    "ShadowPipeline",
+    "get_shadow_metrics",
+    "in_shadow_sample",
+    "maybe_mirror_intent",
+    "shadow_active",
+    "shadow_capabilities",
+    "shadow_enabled",
+    "shadow_env",
+    "shadow_sample_pct",
+]

--- a/tests/test_api_shadow.py
+++ b/tests/test_api_shadow.py
@@ -1,0 +1,74 @@
+"""
+tests/test_api_shadow.py — FU-2 Phase 8 production shadow-mode at the HTTP boundary.
+
+Proves the two banking-safe properties of the prod entrypoint wiring through the real
+FastAPI app:
+
+  * **Flag off (default):** no shadow log/metric is emitted — the mirror is a pure no-op.
+  * **Flag on in a simulated prod env (sampled):** the SAME live response is returned
+    (status + business fields unchanged) AND a shadow comparison is logged. The live path
+    is never altered by, nor dependent on, the shadow mirror.
+
+The shadow descriptor is a non-PII endpoint label, so nothing here exercises user content.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+_TICKET = {
+    "customer_id": "cust-shadow-001",
+    "subject": "Question about my statement",
+    "body": "I would like to understand a line item on my latest statement please",
+}
+
+
+def _create_ticket() -> dict:
+    resp = client.post("/v1/support/tickets", json=_TICKET)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def test_shadow_off_by_default_emits_nothing(caplog):
+    with caplog.at_level(logging.INFO, logger="banxe.intent_layer.shadow"):
+        body = _create_ticket()
+    # Live response is well-formed and the shadow logger stayed silent.
+    assert body["id"]
+    assert "intent_layer.shadow" not in caplog.text
+
+
+def test_shadow_on_in_prod_leaves_live_response_unchanged_and_logs(monkeypatch, caplog):
+    monkeypatch.setenv("INTENT_LAYER_SHADOW_ENABLED_PROD", "true")
+    monkeypatch.setenv("BANXE_ENV", "production")
+    monkeypatch.setenv("INTENT_LAYER_SHADOW_SAMPLE_PCT", "100")  # force the slice
+
+    with caplog.at_level(logging.INFO, logger="banxe.intent_layer.shadow"):
+        body = _create_ticket()
+
+    # Live business outcome is unchanged: same 201, same response contract.
+    assert body["id"]
+    assert body["customer_id"] == "cust-shadow-001"
+    assert "auto_resolved" in body and "is_formal_complaint" in body
+    # The shadow mirror ran and recorded the baseline-vs-shadow comparison.
+    assert "intent_layer.shadow" in caplog.text
+    assert "mode=shadow" in caplog.text
+    # Support has no canonical IL intent → a governance event, i.e. a baseline mismatch.
+    assert "baseline_capability=Support" in caplog.text
+
+
+def test_shadow_failure_never_breaks_the_live_endpoint(monkeypatch):
+    # Even if the shadow pipeline itself raised, the endpoint must still serve. Force the
+    # slice and point the metrics sink at an invalid value (get_shadow_metrics raises);
+    # the mirror swallows it, so the ticket is still created.
+    monkeypatch.setenv("INTENT_LAYER_SHADOW_ENABLED_PROD", "true")
+    monkeypatch.setenv("BANXE_ENV", "production")
+    monkeypatch.setenv("INTENT_LAYER_SHADOW_SAMPLE_PCT", "100")
+    monkeypatch.setenv("CANARY_METRICS", "not-a-valid-sink")
+    resp = client.post("/v1/support/tickets", json=_TICKET)
+    assert resp.status_code == 201

--- a/tests/test_intent_layer/test_shadow.py
+++ b/tests/test_intent_layer/test_shadow.py
@@ -1,0 +1,191 @@
+"""
+tests/test_intent_layer/test_shadow.py — FU-2 Phase 8 production shadow-mode.
+
+Covers ``services/intent_layer/shadow.py``: the production-gated, flag-gated, sampled
+shadow pipeline that mirrors a prod intent through classify+route with a NON-ACTING
+dispatcher, and logs/compares the result against the mechanistic baseline. The env is
+injected (no os.environ), so every gate case is deterministic, and an exploding
+dispatcher proves a high-risk intent never reaches a live action.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.intent_layer.observability import InMemoryCanaryMetrics
+from services.intent_layer.ports import AgentDispatchPort, DispatchReceipt, DispatchRequest
+from services.intent_layer.shadow import (
+    SHADOW_ERRORS_TOTAL,
+    SHADOW_MISMATCH_TOTAL,
+    SHADOW_REQUESTS_TOTAL,
+    NullShadowDispatcher,
+    ShadowObserver,
+    ShadowPipeline,
+    in_shadow_sample,
+    maybe_mirror_intent,
+    shadow_active,
+    shadow_capabilities,
+    shadow_enabled,
+    shadow_sample_pct,
+)
+
+_PROD = {"BANXE_ENV": "production", "INTENT_LAYER_SHADOW_ENABLED_PROD": "true"}
+
+
+class _ExplodingDispatcher(AgentDispatchPort):
+    """Fails the test loudly if the shadow ever tries to dispatch (= a live action)."""
+
+    def dispatch(self, request: DispatchRequest) -> DispatchReceipt:  # pragma: no cover
+        raise AssertionError(f"shadow dispatched {request.capability!r} — must never act")
+
+
+# ── Gates: flag + production + sampling ─────────────────────────────────────────────
+
+
+def test_shadow_inactive_when_flag_off_even_in_production():
+    assert shadow_enabled({"BANXE_ENV": "production"}) is False
+    assert shadow_active({"BANXE_ENV": "production"}) is False
+
+
+def test_shadow_inactive_outside_production_even_when_flag_on():
+    # A flag leaked to staging/dev/CI must not activate shadow anywhere but prod.
+    for env_value in ("staging", "dev", "unknown", ""):
+        env = {"BANXE_ENV": env_value, "INTENT_LAYER_SHADOW_ENABLED_PROD": "true"}
+        assert shadow_active(env) is False
+
+
+def test_shadow_active_only_in_production_with_flag_on():
+    assert shadow_active(_PROD) is True
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(None, 1), ("", 1), ("0", 0), ("100", 100), ("250", 100), ("-5", 0), ("oops", 0)],
+)
+def test_shadow_sample_pct_clamps_and_fails_closed(raw, expected):
+    env = {} if raw is None else {"INTENT_LAYER_SHADOW_SAMPLE_PCT": raw}
+    assert shadow_sample_pct(env) == expected
+
+
+def test_in_shadow_sample_is_deterministic_and_bounded():
+    assert in_shadow_sample("any-id", 0) is False
+    assert in_shadow_sample("any-id", 100) is True
+    # Deterministic: same id → same decision every time.
+    assert in_shadow_sample("corr-xyz", 50) == in_shadow_sample("corr-xyz", 50)
+
+
+# ── shadow_capabilities: prod gate + high-risk subtraction ──────────────────────────
+
+
+def test_shadow_capabilities_empty_outside_production():
+    assert shadow_capabilities({"BANXE_ENV": "staging"}) == frozenset()
+    assert shadow_capabilities({}) == frozenset()
+
+
+def test_shadow_capabilities_defaults_to_staging_scope_in_production():
+    # Same low-risk scope as the staging canary — never wider (FU-2 guardrail).
+    assert shadow_capabilities(_PROD) == frozenset({"notifications", "referral"})
+
+
+def test_shadow_capabilities_subtracts_high_risk_even_if_configured():
+    env = {**_PROD, "INTENT_LAYER_SHADOW_CAPABILITIES": "Notifications,Payments,FX / Exchange"}
+    # Payments + FX are mechanically dropped; only the low-risk surface remains.
+    assert shadow_capabilities(env) == frozenset({"notifications"})
+
+
+# ── NullShadowDispatcher: never acts ────────────────────────────────────────────────
+
+
+def test_null_shadow_dispatcher_never_accepts():
+    req = DispatchRequest(
+        capability="Notifications", process_refs=(), resolved_intent=None, correlation_id="c1"
+    )
+    receipt = NullShadowDispatcher().dispatch(req)
+    assert receipt.accepted is False
+    assert receipt.agent == "(shadow)"
+
+
+# ── ShadowPipeline.mirror ───────────────────────────────────────────────────────────
+
+
+def _pipeline(metrics: InMemoryCanaryMetrics, dispatcher=None) -> ShadowPipeline:
+    return ShadowPipeline(
+        dispatcher=dispatcher if dispatcher is not None else NullShadowDispatcher(),
+        observer=ShadowObserver(metrics, env="production"),
+        env="production",
+        capabilities=frozenset({"notifications", "referral"}),
+    )
+
+
+def test_mirror_low_risk_match_records_request_no_mismatch():
+    metrics = InMemoryCanaryMetrics()
+    comparison = _pipeline(metrics).mirror("notifications", "Notifications", "c-notif")
+    assert comparison is not None
+    assert comparison.shadow_disposition == "DISPATCHED"
+    assert comparison.shadow_capability == "Notifications"
+    assert comparison.mismatch is False
+    assert metrics.counter_total(SHADOW_REQUESTS_TOTAL, mode="shadow", env="production") == 1
+    assert metrics.counter_total(SHADOW_MISMATCH_TOTAL) == 0
+
+
+def test_mirror_baseline_vs_shadow_mismatch_is_counted():
+    # The Support surface has no canonical intent → IL resolves it to nothing
+    # (governance event), which differs from the "Support" baseline = a mismatch.
+    metrics = InMemoryCanaryMetrics()
+    comparison = _pipeline(metrics).mirror("support ticket", "Support", "c-support")
+    assert comparison is not None
+    assert comparison.shadow_disposition == "GOVERNANCE_EVENT"
+    assert comparison.shadow_capability is None
+    assert comparison.mismatch is True
+    assert metrics.counter_total(SHADOW_MISMATCH_TOTAL, mode="shadow") == 1
+
+
+def test_mirror_high_risk_intent_is_held_and_never_dispatched():
+    # "pay" → Payments (high-risk). It is outside the shadow allow-list, so the router
+    # holds it BEFORE the dispatch boundary — the exploding dispatcher is never reached.
+    metrics = InMemoryCanaryMetrics()
+    pipeline = _pipeline(metrics, dispatcher=_ExplodingDispatcher())
+    comparison = pipeline.mirror("pay", "Payments", "c-pay")
+    assert comparison is not None
+    assert comparison.shadow_disposition == "CANARY_HELD"
+    assert comparison.shadow_capability == "Payments"
+    # No error was recorded (held is a correct, expected non-action, not a failure).
+    assert metrics.counter_total(SHADOW_ERRORS_TOTAL) == 0
+
+
+def test_mirror_swallows_errors_and_never_raises():
+    # A broken catalogue makes classification raise; mirror must swallow it, count an
+    # error, and return None so the live caller is unaffected.
+    metrics = InMemoryCanaryMetrics()
+    pipeline = ShadowPipeline(
+        catalog=object(),  # has no .lookup → AttributeError inside classify
+        observer=ShadowObserver(metrics, env="production"),
+        env="production",
+        capabilities=frozenset({"notifications"}),
+    )
+    assert pipeline.mirror("notifications", "Notifications", "c-err") is None
+    assert metrics.counter_total(SHADOW_ERRORS_TOTAL, mode="shadow") == 1
+
+
+# ── maybe_mirror_intent hook ────────────────────────────────────────────────────────
+
+
+def test_hook_is_noop_when_inactive(caplog):
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="banxe.intent_layer.shadow"):
+        assert maybe_mirror_intent("notifications", "Notifications", env={}) is None
+    assert "intent_layer.shadow" not in caplog.text
+
+
+def test_hook_mirrors_when_active_and_sampled():
+    env = {**_PROD, "INTENT_LAYER_SHADOW_SAMPLE_PCT": "100"}
+    comparison = maybe_mirror_intent("referral", "Referral / CRM", correlation_id="c-ref", env=env)
+    assert comparison is not None
+    assert comparison.shadow_capability == "Referral / CRM"
+    assert comparison.mismatch is False
+
+
+def test_hook_skips_unsampled_request():
+    env = {**_PROD, "INTENT_LAYER_SHADOW_SAMPLE_PCT": "0"}
+    assert maybe_mirror_intent("notifications", "Notifications", env=env) is None


### PR DESCRIPTION
## FU-2 Phase 8 — production shadow-mode for the Intent Layer + LLM-gateway

First **production** exposure of the ADR-049 Intent Layer — a **shadow** one. A sampled, low-risk slice of prod intent-like traffic is mirrored through classify+route purely to **log and compare** what the Intent Layer *would* decide against the mechanistic baseline that actually served the request. **No live action.**

> **Base branch:** stacked on `fu-2-intent-layer-phase7-canary-expand` (PR #192) because Phase 8 reuses the Phase 7 high-risk denylist (`canary.py`), which is not yet on `main`. Retarget to `main` once #192 merges.

### What it does
- Mirrors a subset of three existing prod entrypoints — notification scheduling (`POST /v1/notifications-hub/send`), support tickets (`POST /v1/support/tickets`), CRM referrals (`POST /v1/referral/track`) — via the fire-and-forget hook `maybe_mirror_intent(...)`, *after* the live work, using **non-PII descriptors** (R-SEC).
- Runs the request through `ShadowPipeline` (classify + route) with a `NullShadowDispatcher` that performs **no action**, and records a baseline-vs-shadow comparison.

### Safety guarantees (banking-safe)
- **No live dispatch.** `NullShadowDispatcher` calls no producer, no L2 mask, no L3 port, writes no lineage. `INTENT_LAYER_ENABLED` stays `false` in prod — the live `/v1/intent` path remains dark. Shadow is a *separate* pipeline.
- **Production- and flag-gated.** Active only when `INTENT_LAYER_SHADOW_ENABLED_PROD=true` **and** `BANXE_ENV=production`, then only for the deterministically-sampled slice (`INTENT_LAYER_SHADOW_SAMPLE_PCT`, default 1%). A leaked flag is inert in staging/CI/dev.
- **High-risk stays blocked.** The Phase 7 denylist is reused verbatim: money/FX/wallet/card/KYC/SAR/sanctions surfaces are subtracted from the shadow allow-list (router holds them `CANARY_HELD`) and the Null dispatcher cannot act regardless.
- **Never impacts the live response.** `maybe_mirror_intent` swallows every error/timeout (counted as `shadow_error`) and returns `None`.
- **No scope expansion.** Shadow scope defaults to the same low-risk capabilities as the staging canary (Notifications, Referral / CRM) — never wider.

### Flags (defined in `services/intent_layer/shadow.py`, documented in `.env.example`)
| Flag | Default | Purpose |
| --- | --- | --- |
| `INTENT_LAYER_SHADOW_ENABLED_PROD` | `false` | master gate; instant rollback = set `false` |
| `INTENT_LAYER_SHADOW_CAPABILITIES` | staging scope | in-scope capabilities (prod-gated, high-risk-subtracted) |
| `INTENT_LAYER_SHADOW_SAMPLE_PCT` | `1` | % of eligible slice to mirror (deterministic) |

### Metrics (tagged `env=prod, mode=shadow`)
- `intent_layer_shadow_requests_total` (`shadow_request_count`)
- `intent_layer_shadow_errors_total` (`shadow_error_count`)
- `intent_layer_shadow_baseline_vs_shadow_mismatch_total` (`baseline_vs_shadow_mismatch_count`)

### Tests
- `tests/test_intent_layer/test_shadow.py` — gates, prod/high-risk scope, no-dispatch-on-high-risk (exploding dispatcher), error swallowing, sampling.
- `tests/test_api_shadow.py` — HTTP invariance: live response unchanged with flag off vs on; shadow logs only when active; endpoint survives a shadow-pipeline failure.

### Docs
- `docs/intent-layer-observability.md` §6 — enable/disable, mirrored traffic, mismatch interpretation; updates the §2 `mismatch_count` note (Phase 8 introduces the comparator).

### Out of scope (guardrails honoured)
- No live auto-dispatch in prod. No `INTENT_LAYER_ENABLED=true`. No changes in `banxe-payment-core`. No canary-scope expansion beyond staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)