### PR TITLE
feat(intent-layer): salvage Phase 5 canary library on Phase 7 base (from #190)

### DIFF
--- a/docs/intent-layer-canary.md
+++ b/docs/intent-layer-canary.md
@@ -1,0 +1,95 @@
+# Intent Layer — staging canary (FU-2 Phase 5)
+
+> **Status (FU-2 Phase 5):** the ADR-049 L1 Intent Layer moves from **dark mode**
+> (Phase 3) to a **tightly-scoped, observable canary** — enabled **in staging only**,
+> for **one low-risk capability** (Notifications). Production stays dark. There is **no**
+> activation for payments / FX / wallet / KYC / SAR / sanctions in this phase, and a
+> single flag change reverts to dark mode. See [`intent-layer-dev.md`](./intent-layer-dev.md)
+> for the dark-mode baseline.
+
+## What the canary does
+
+When the layer is enabled for an environment, an **auto-dispatch gate** decides which
+resolved capabilities may actually flow to an L2 mask. Two mechanistic checks — in code,
+never via prompt — run in safety order:
+
+1. **High-risk denylist (hard, non-configurable).** Any capability touching money
+   movement, FX, wallet/balance, cards, KYC/onboarding, SAR or sanctions/AML screening
+   is **never** auto-dispatched. It is routed to the human/manual (governance) flow.
+   The denylist wins **even if such a capability is mistakenly added to the allowlist.**
+   It matches on an explicit capability-key set **and** a token scan over the capability
+   label + matched intent, so a newly-added or mislabelled high-risk capability is still
+   caught. (`services/intent_layer/canary.py`)
+2. **Canary allowlist (default-deny).** `INTENT_LAYER_CANARY_CAPABILITIES` lists the
+   capability keys allowed to auto-dispatch. **Empty by default**, so an enabled-but-
+   unconfigured layer dispatches nothing — a leaked global flag in prod stays
+   mechanically dark.
+
+Anything withheld degrades to the **current behaviour**: high-risk → governance event;
+not-in-canary → the same `NOT_ENABLED` no-op shape as dark mode. The HTTP response schema
+is unchanged, so there is no customer-facing SLA change.
+
+## Flags
+
+| Flag | Where defined | Default | Purpose |
+| --- | --- | --- | --- |
+| `INTENT_LAYER_ENABLED` | `services/intent_layer/config.py` | `false` | Global master flag (legacy/back-compat) |
+| `APP_ENV` (or `ENVIRONMENT`) | `services/intent_layer/config.py` | `production` | Names the deployment environment |
+| `INTENT_LAYER_ENABLED_<ENV>` | `services/intent_layer/config.py` | unset | Per-env override (e.g. `INTENT_LAYER_ENABLED_STAGING`); wins over the global flag for that env only |
+| `INTENT_LAYER_CANARY_CAPABILITIES` | `services/intent_layer/canary.py` | empty | Comma-separated allowlist of capability keys permitted to auto-dispatch |
+
+The high-risk denylist is **not** a flag — it is hard-coded in `canary.py`
+(`HIGH_RISK_CAPABILITY_KEYS` + `HIGH_RISK_TOKENS`) and cannot be relaxed by config.
+
+## Enable / disable in staging (env changes only)
+
+**Enable the canary in staging:**
+
+```bash
+APP_ENV=staging
+INTENT_LAYER_ENABLED_STAGING=true
+INTENT_LAYER_CANARY_CAPABILITIES=Notifications
+# (optional) durable lineage:
+DECISION_RECORDER=clickhouse
+```
+
+**Roll back to dark mode (instant):** flip the per-env flag back —
+
+```bash
+INTENT_LAYER_ENABLED_STAGING=false   # or unset it
+```
+
+No code change, no deploy: the flag is read fresh on each request, so the next request
+returns to the dark-mode `NOT_ENABLED` behaviour. Production is unaffected throughout —
+it never sets `INTENT_LAYER_ENABLED_PRODUCTION` and the staging override does not leak
+across environments.
+
+## Monitoring
+
+* **Structured logs** (`LoggingCanaryObserver`, logger `banxe.intent_layer.canary`): one
+  record per gate decision — `decision`, `capability_key`, `correlation_id`. High-risk
+  withholds log at **WARNING** for alerting. No intent text or PII is logged.
+* **Counters** (`CounterCanaryObserver`), exposed read-only at
+  `GET /v1/intent/canary/metrics`:
+
+  ```json
+  {
+    "canary_intents_total": 0,
+    "canary_dispatched": 0,
+    "canary_withheld_not_canary": 0,
+    "canary_withheld_high_risk": 0,
+    "canary_errors": 0
+  }
+  ```
+
+  These give canary volume, dispatch vs withhold split, and the error count.
+
+## Tests
+
+```bash
+pytest tests/test_intent_layer/test_canary.py \
+       tests/test_intent_layer/test_canary_metrics.py \
+       tests/test_intent_layer/test_config.py \
+       tests/test_intent_layer/test_router.py \
+       tests/test_canary_api.py -v
+```

--- a/services/intent_layer/canary.py
+++ b/services/intent_layer/canary.py
@@ -26,6 +26,8 @@ unit-testable in isolation; the env read is injectable for deterministic tests.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 import os
 
 CANARY_CAPABILITIES_ENV = "INTENT_LAYER_CANARY_CAPABILITIES"
@@ -145,6 +147,98 @@ def canary_capabilities(env: dict[str, str] | None = None) -> frozenset[str]:
     return frozenset(key for key in keys if key and not is_high_risk_capability(key))
 
 
+# ──────────────────────────────────────────────────────────────────────────────────
+# Phase 5 canary auto-dispatch POLICY (salvaged additive library, supersedes #190).
+#
+# Phase 7's ``canary_capabilities`` answers "which capability KEYS may the canary widen
+# to in this env". The policy objects below answer the per-decision question "given a
+# resolved capability (+ optional matched intent), DISPATCH / withhold-not-canary /
+# withhold-high-risk?" — a pure value object built from env and injected into the router.
+# They reuse the single ``normalize_capability`` spelling and the same hard denylists
+# above, so the two surfaces can never drift apart.
+# ──────────────────────────────────────────────────────────────────────────────────
+
+
+class CanaryDecision(str, Enum):
+    """What the canary policy ruled for one resolved capability."""
+
+    DISPATCH = "DISPATCH"  # allowlisted + not high-risk → auto-dispatch
+    WITHHELD_NOT_CANARY = "WITHHELD_NOT_CANARY"  # enabled but not allowlisted → dark no-op
+    WITHHELD_HIGH_RISK = "WITHHELD_HIGH_RISK"  # high-risk denylist → manual/governance flow
+
+
+@dataclass(frozen=True)
+class CanaryOutcome:
+    """A canary decision plus an audit-legible reason (carried into logs/lineage)."""
+
+    decision: CanaryDecision
+    reason: str
+
+
+def is_high_risk(capability: str, matched_intent: str | None = None) -> bool:
+    """True if a capability must never be auto-dispatched in the canary phase.
+
+    Belt-and-suspenders: an explicit normalised-key hit OR any high-risk token found in
+    the capability label / matched intent. False-positives are safe (they withhold).
+    Mirrors :func:`is_high_risk_capability` but also scans an optional ``matched_intent``
+    so a blandly-labelled capability with a high-risk intent is still caught.
+    """
+    if normalize_capability(capability) in HIGH_RISK_CAPABILITY_KEYS:
+        return True
+    haystack = f"{capability} {matched_intent or ''}".lower()
+    return any(token in haystack for token in HIGH_RISK_TOKENS)
+
+
+def _parse_allowlist(raw: str) -> frozenset[str]:
+    """Parse the comma-separated allowlist into normalised capability keys."""
+    return frozenset(normalize_capability(item) for item in raw.split(",") if item.strip())
+
+
+@dataclass(frozen=True)
+class CanaryPolicy:
+    """Pure policy object: decides auto-dispatch for one resolved capability.
+
+    ``allowed_capabilities`` is the (already normalised) allowlist. The high-risk
+    denylist is NOT a field — it is hard-coded module state, so it cannot be relaxed
+    by configuration.
+    """
+
+    allowed_capabilities: frozenset[str]
+
+    def decide(self, capability: str, matched_intent: str | None = None) -> CanaryOutcome:
+        """Rule on one resolved capability. Assumes the layer is already enabled —
+        the router checks enablement first; this gate only narrows *which* capabilities
+        an enabled layer may dispatch."""
+        if is_high_risk(capability, matched_intent):
+            return CanaryOutcome(
+                CanaryDecision.WITHHELD_HIGH_RISK,
+                reason=(
+                    f"capability {capability!r} is high-risk (money/FX/wallet/card/KYC/"
+                    "SAR/sanctions) — never canary-dispatched; routed to human/manual flow"
+                ),
+            )
+        if normalize_capability(capability) not in self.allowed_capabilities:
+            return CanaryOutcome(
+                CanaryDecision.WITHHELD_NOT_CANARY,
+                reason=(
+                    f"capability {capability!r} not in {CANARY_CAPABILITIES_ENV} allowlist "
+                    "— no dispatch (dark-mode behaviour)"
+                ),
+            )
+        return CanaryOutcome(
+            CanaryDecision.DISPATCH,
+            reason=f"capability {capability!r} is an allowlisted low-risk canary capability",
+        )
+
+
+def canary_policy_from_env(env: dict[str, str] | None = None) -> CanaryPolicy:
+    """Build the canary policy from ``INTENT_LAYER_CANARY_CAPABILITIES`` (default empty)."""
+    source = env if env is not None else os.environ
+    return CanaryPolicy(
+        allowed_capabilities=_parse_allowlist(source.get(CANARY_CAPABILITIES_ENV, ""))
+    )
+
+
 __all__ = [
     "BANXE_ENV_ENV",
     "CANARY_CAPABILITIES_ENV",
@@ -152,8 +246,13 @@ __all__ = [
     "HIGH_RISK_CAPABILITY_KEYS",
     "HIGH_RISK_TOKENS",
     "STAGING_ENV_VALUE",
+    "CanaryDecision",
+    "CanaryOutcome",
+    "CanaryPolicy",
     "canary_capabilities",
     "canary_env",
+    "canary_policy_from_env",
+    "is_high_risk",
     "is_high_risk_capability",
     "normalize_capability",
     "parse_canary_capabilities",

--- a/services/intent_layer/canary_metrics.py
+++ b/services/intent_layer/canary_metrics.py
@@ -1,0 +1,163 @@
+"""
+services/intent_layer/canary_metrics.py — canary observability hooks
+FU-2 Phase 5 — staging canary (notifications only) | banxe-emi-stack
+
+A canary is only safe if it is observable. This module supplies the monitoring seam the
+router calls on every gated decision, so an operator can watch the Phase-5 canary:
+
+  • total canary intents seen (enabled-path resolutions reaching the gate),
+  • how many were dispatched vs withheld (not-canary) vs withheld (high-risk),
+  • and the dispatch error rate.
+
+The router depends only on the :class:`CanaryObserver` Protocol (consistent with the
+layer's injected-port design). Three implementations are provided:
+
+  • :class:`NullCanaryObserver`  — default no-op (zero overhead, no behaviour change).
+  • :class:`CounterCanaryObserver` — in-process counters for tests / a /metrics probe.
+  • :class:`LoggingCanaryObserver` — structured ``logging`` records for log-based
+    monitoring + alerting; carries only the correlation id + capability key + decision
+    (R-SEC: never raw intent text or PII).
+
+A :class:`FanOutCanaryObserver` composes several observers (e.g. log + counter) so a
+deployment can both emit logs and expose counters.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+import logging
+from typing import Protocol, runtime_checkable
+
+from services.intent_layer.canary import CanaryDecision, normalize_capability
+
+logger = logging.getLogger("banxe.intent_layer.canary")
+
+
+@runtime_checkable
+class CanaryObserver(Protocol):
+    """Sink for canary gate outcomes. Implementations MUST be side-effect-only —
+    a misbehaving observer must never change routing behaviour."""
+
+    def observe(
+        self, *, decision: CanaryDecision, capability: str, correlation_id: str
+    ) -> None: ...
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None: ...
+
+
+class NullCanaryObserver:
+    """Default observer: records nothing. Keeps the router's behaviour unchanged when
+    no monitoring is wired."""
+
+    def observe(self, *, decision: CanaryDecision, capability: str, correlation_id: str) -> None:
+        return None
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None:
+        return None
+
+
+@dataclass
+class CounterCanaryObserver:
+    """In-process counters — the read surface for a /metrics probe or a test assertion.
+
+    ``decisions`` counts gate outcomes by :class:`CanaryDecision`; ``errors`` counts
+    dispatch failures. ``total`` is every gate hit (the canary-intent volume).
+    """
+
+    decisions: Counter[CanaryDecision] = field(default_factory=Counter)
+    errors: int = 0
+
+    def observe(self, *, decision: CanaryDecision, capability: str, correlation_id: str) -> None:
+        self.decisions[decision] += 1
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None:
+        self.errors += 1
+
+    @property
+    def total(self) -> int:
+        """Total gated canary intents seen."""
+        return sum(self.decisions.values())
+
+    @property
+    def dispatched(self) -> int:
+        return self.decisions[CanaryDecision.DISPATCH]
+
+    @property
+    def withheld(self) -> int:
+        """Intents withheld for any reason (not-canary + high-risk)."""
+        return (
+            self.decisions[CanaryDecision.WITHHELD_NOT_CANARY]
+            + self.decisions[CanaryDecision.WITHHELD_HIGH_RISK]
+        )
+
+    def snapshot(self) -> dict[str, int]:
+        """A flat, JSON-friendly view for a metrics endpoint."""
+        return {
+            "canary_intents_total": self.total,
+            "canary_dispatched": self.dispatched,
+            "canary_withheld_not_canary": self.decisions[CanaryDecision.WITHHELD_NOT_CANARY],
+            "canary_withheld_high_risk": self.decisions[CanaryDecision.WITHHELD_HIGH_RISK],
+            "canary_errors": self.errors,
+        }
+
+
+class LoggingCanaryObserver:
+    """Emits one structured log record per gate decision (and per dispatch error).
+
+    R-SEC: only the correlation id, normalised capability key and decision are logged —
+    never the free-form intent text or any PII. High-risk withholds log at WARNING so
+    they surface in alerting; everything else is INFO/ERROR.
+    """
+
+    def observe(self, *, decision: CanaryDecision, capability: str, correlation_id: str) -> None:
+        level = logging.WARNING if decision is CanaryDecision.WITHHELD_HIGH_RISK else logging.INFO
+        logger.log(
+            level,
+            "intent_layer.canary decision=%s capability=%s correlation_id=%s",
+            decision.value,
+            normalize_capability(capability),
+            correlation_id,
+            extra={
+                "event": "intent_layer.canary.decision",
+                "decision": decision.value,
+                "capability_key": normalize_capability(capability),
+                "correlation_id": correlation_id,
+            },
+        )
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None:
+        logger.error(
+            "intent_layer.canary dispatch_error capability=%s correlation_id=%s",
+            normalize_capability(capability),
+            correlation_id,
+            extra={
+                "event": "intent_layer.canary.error",
+                "capability_key": normalize_capability(capability),
+                "correlation_id": correlation_id,
+            },
+        )
+
+
+@dataclass
+class FanOutCanaryObserver:
+    """Composes several observers — e.g. log + counter — behind one port."""
+
+    observers: tuple[CanaryObserver, ...]
+
+    def observe(self, *, decision: CanaryDecision, capability: str, correlation_id: str) -> None:
+        for obs in self.observers:
+            obs.observe(decision=decision, capability=capability, correlation_id=correlation_id)
+
+    def observe_error(self, *, capability: str, correlation_id: str) -> None:
+        for obs in self.observers:
+            obs.observe_error(capability=capability, correlation_id=correlation_id)
+
+
+__all__ = [
+    "CanaryObserver",
+    "CounterCanaryObserver",
+    "FanOutCanaryObserver",
+    "LoggingCanaryObserver",
+    "NullCanaryObserver",
+]

--- a/tests/test_intent_layer/test_canary.py
+++ b/tests/test_intent_layer/test_canary.py
@@ -14,8 +14,12 @@ from services.intent_layer.canary import (
     CANARY_CAPABILITIES_ENV,
     DEFAULT_CANARY_CAPABILITIES,
     HIGH_RISK_CAPABILITY_KEYS,
+    CanaryDecision,
+    CanaryPolicy,
     canary_capabilities,
     canary_env,
+    canary_policy_from_env,
+    is_high_risk,
     is_high_risk_capability,
     normalize_capability,
     parse_canary_capabilities,
@@ -140,3 +144,77 @@ def test_high_risk_is_subtracted_from_allowlist_even_if_misconfigured():
 def test_allowlist_of_only_high_risk_collapses_to_empty():
     env = {**_STAGING, CANARY_CAPABILITIES_ENV: "Payments,FX / Exchange"}
     assert canary_capabilities(env) == frozenset()
+
+
+# ── Phase 5 canary auto-dispatch POLICY (salvaged from #190) ───────────────────────
+# Exercises the additive policy library: is_high_risk (with matched_intent),
+# CanaryPolicy.decide and canary_policy_from_env — default-deny allowlist, the hard
+# high-risk denylist, and denylist-wins-over-allowlist.
+
+
+@pytest.mark.parametrize(
+    "capability",
+    [
+        "Payments",
+        "FX / Exchange",
+        "Wallet",
+        "Card (Wallet/Payments-adjacent)",
+        "KYC onboarding",
+        # New / mislabelled high-risk capabilities caught by the token scan:
+        "Cross-border payment",
+        "Wire transfer",
+        "Sanctions screening",
+        "SAR filing",
+    ],
+)
+def test_high_risk_capabilities_are_denied(capability):
+    assert is_high_risk(capability) is True
+
+
+@pytest.mark.parametrize(
+    "capability",
+    ["Notifications", "Statements (ADR-055)", "Analytics / Reporting (ADR-054)", "Referral / CRM"],
+)
+def test_low_risk_capabilities_are_not_denied(capability):
+    assert is_high_risk(capability) is False
+
+
+def test_high_risk_detected_via_matched_intent_token():
+    # A blandly-labelled capability whose intent token is high-risk is still caught.
+    assert is_high_risk("Support", matched_intent="onboard-kyc") is True
+
+
+def test_empty_allowlist_withholds_low_risk_capability():
+    policy = CanaryPolicy(allowed_capabilities=frozenset())
+    outcome = policy.decide("Notifications", "get-notified")
+    assert outcome.decision is CanaryDecision.WITHHELD_NOT_CANARY
+
+
+def test_allowlisted_low_risk_capability_dispatches():
+    policy = CanaryPolicy(allowed_capabilities=frozenset({"notifications"}))
+    outcome = policy.decide("Notifications", "get-notified")
+    assert outcome.decision is CanaryDecision.DISPATCH
+
+
+def test_non_allowlisted_low_risk_capability_withheld():
+    policy = CanaryPolicy(allowed_capabilities=frozenset({"notifications"}))
+    outcome = policy.decide("Statements (ADR-055)", "get-statement")
+    assert outcome.decision is CanaryDecision.WITHHELD_NOT_CANARY
+
+
+def test_high_risk_withheld_even_if_explicitly_allowlisted():
+    # Misconfiguration: someone allowlists Payments. The hard denylist still wins.
+    policy = CanaryPolicy(allowed_capabilities=frozenset({"payments", "notifications"}))
+    outcome = policy.decide("Payments", "pay")
+    assert outcome.decision is CanaryDecision.WITHHELD_HIGH_RISK
+    assert "high-risk" in outcome.reason
+
+
+def test_policy_from_env_default_is_deny_all():
+    policy = canary_policy_from_env(env={})
+    assert policy.allowed_capabilities == frozenset()
+
+
+def test_policy_from_env_parses_comma_list():
+    policy = canary_policy_from_env(env={CANARY_CAPABILITIES_ENV: "Notifications, Statements"})
+    assert policy.allowed_capabilities == frozenset({"notifications", "statements"})

--- a/tests/test_intent_layer/test_canary_metrics.py
+++ b/tests/test_intent_layer/test_canary_metrics.py
@@ -1,0 +1,51 @@
+"""
+tests/test_intent_layer/test_canary_metrics.py — canary observability hooks.
+"""
+
+from __future__ import annotations
+
+from services.intent_layer.canary import CanaryDecision
+from services.intent_layer.canary_metrics import (
+    CounterCanaryObserver,
+    FanOutCanaryObserver,
+    NullCanaryObserver,
+)
+
+
+def test_null_observer_is_noop():
+    obs = NullCanaryObserver()
+    obs.observe(decision=CanaryDecision.DISPATCH, capability="Notifications", correlation_id="c1")
+    obs.observe_error(capability="Notifications", correlation_id="c1")  # no exception
+
+
+def test_counter_tallies_decisions_and_snapshot():
+    obs = CounterCanaryObserver()
+    obs.observe(decision=CanaryDecision.DISPATCH, capability="Notifications", correlation_id="a")
+    obs.observe(
+        decision=CanaryDecision.WITHHELD_HIGH_RISK, capability="Payments", correlation_id="b"
+    )
+    obs.observe(
+        decision=CanaryDecision.WITHHELD_NOT_CANARY, capability="Statements", correlation_id="c"
+    )
+    obs.observe_error(capability="Notifications", correlation_id="a")
+
+    assert obs.total == 3
+    assert obs.dispatched == 1
+    assert obs.withheld == 2
+    snap = obs.snapshot()
+    assert snap == {
+        "canary_intents_total": 3,
+        "canary_dispatched": 1,
+        "canary_withheld_not_canary": 1,
+        "canary_withheld_high_risk": 1,
+        "canary_errors": 1,
+    }
+
+
+def test_fanout_forwards_to_all_observers():
+    a, b = CounterCanaryObserver(), CounterCanaryObserver()
+    fan = FanOutCanaryObserver((a, b))
+    fan.observe(decision=CanaryDecision.DISPATCH, capability="Notifications", correlation_id="x")
+    fan.observe_error(capability="Notifications", correlation_id="x")
+    assert a.dispatched == b.dispatched == 1
+    assert a.errors == b.errors == 1


### PR DESCRIPTION
Additive-only salvage of unique library code from #190 (CanaryPolicy, canary_metrics, docs) on top of Phase 7. No live-composition changes. #190 to be closed as superseded.