### PR TITLE
chore(ci): modernize GitHub Actions to Node 24 (clear deprecation annotations)

### DIFF
--- a/.github/workflows/alembic-check.yml
+++ b/.github/workflows/alembic-check.yml
@@ -29,9 +29,9 @@ jobs:
       DATABASE_URL: sqlite+aiosqlite:///./banxe_ci.db
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/canon-mirror-check.yml
+++ b/.github/workflows/canon-mirror-check.yml
@@ -15,7 +15,7 @@ jobs:
     name: Canon mirror presence + version pin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Verify canon mirror integrity
         run: |
           set -euo pipefail

--- a/.github/workflows/claude-daily-report.yml
+++ b/.github/workflows/claude-daily-report.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 50
 

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Claude Code Issue Triage
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-release-readiness.yml
+++ b/.github/workflows/claude-release-readiness.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 100
           ref: ${{ inputs.target_branch }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,7 +9,7 @@ jobs:
     if: contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/factory-guard.yml
+++ b/.github/workflows/factory-guard.yml
@@ -4,7 +4,7 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: test -f .claude/settings.json || (echo "Missing .claude/settings.json"; exit 1)
       - run: test -f .github/workflows/claude.yml || (echo "Missing claude.yml"; exit 1)
       - run: python3 -c "import json; json.load(open('.claude/settings.json'))"

--- a/.github/workflows/guardian.yml
+++ b/.github/workflows/guardian.yml
@@ -18,7 +18,7 @@ jobs:
         family: [factory, project]
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -27,9 +27,9 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
       - name: Install dependencies
@@ -51,9 +51,9 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
         run: npm run test:cov
         continue-on-error: true
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: frontend-coverage

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Detect whether the PR touches code or docs only
@@ -60,7 +60,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Ruff lint (check mode, GitHub annotations)
         if: needs.changes.outputs.docs_only != 'true'
         uses: astral-sh/ruff-action@v3
@@ -80,7 +80,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install semgrep
         if: needs.changes.outputs.docs_only != 'true'
         run: pip install semgrep

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Detect whether the PR touches code or docs only
@@ -49,7 +49,7 @@ jobs:
     name: Gitleaks - Secrets Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install gitleaks
@@ -60,7 +60,7 @@ jobs:
           test -s gitleaks.sarif || echo '{"version":"2.1.0","runs":[]}' > gitleaks.sarif
       - name: Upload SARIF
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: gitleaks-sarif
           path: gitleaks.sarif
@@ -71,7 +71,7 @@ jobs:
     name: Ruff lint + format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Ruff lint (GitHub annotations)
         uses: astral-sh/ruff-action@v3
         with:
@@ -89,8 +89,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
       - name: Install frontend deps
@@ -111,8 +111,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ruff]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -131,7 +131,7 @@ jobs:
           echo "## Test Results" >> $GITHUB_STEP_SUMMARY
           echo "All tests passed (coverage >= 80%)" >> $GITHUB_STEP_SUMMARY
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: coverage-report
@@ -142,7 +142,7 @@ jobs:
     name: Semgrep (banxe-rules)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install semgrep
         run: pip install semgrep
       - name: Run Semgrep
@@ -160,7 +160,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install semgrep
@@ -194,8 +194,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
       - name: Install frontend deps

--- a/.github/workflows/smoke-gate-full.yml
+++ b/.github/workflows/smoke-gate-full.yml
@@ -40,14 +40,14 @@ jobs:
       LLM_GATEWAY_URL: ${{ vars.LLM_GATEWAY_URL }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Start infra services (postgres, redis, clickhouse, frankfurter)
         run: |
           docker compose -f docker/docker-compose.master.yml up -d \
             postgres redis clickhouse frankfurter
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/smoke-gate-mock.yml
+++ b/.github/workflows/smoke-gate-mock.yml
@@ -16,9 +16,9 @@ jobs:
     name: Smoke Gate (mock tier)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"


### PR DESCRIPTION
Version-only pin bumps of first-party actions to their Node 24 majors:
- actions/checkout@v4 -> @v5 (23)
- actions/setup-node@v4 -> @v5 (4)
- actions/setup-python@v5 -> @v6 (4)
- actions/upload-artifact@v4 -> @v5 (3)

Version-clean only: no logic, inputs, with:, or runs-on edits. Untouched by design: codeql-action@v3, ruff-action@v3, claude-code-action@v1, setup-biome@v2, tailscale@v3. Requires runner >= v2.327.1 (satisfied on ubuntu-latest).