### PR TITLE
feat(adverse-media): IMPL-1 adverse-media screening (GAP-064, MLR Reg.28 EDD)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -35,6 +35,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from api.routers import (
+    adverse_media,
     api_gateway,
     api_versioning,
     ato_prevention,
@@ -176,6 +177,7 @@ app.include_router(notifications.router, prefix="/v1")
 app.include_router(fraud.router, prefix="/v1")
 app.include_router(consumer_duty.router, prefix="/v1")
 app.include_router(hitl.router, prefix="/v1")
+app.include_router(adverse_media.router, prefix="/v1")  # Adverse-media screening (GAP-064, IMPL-1)
 app.include_router(intent.router, prefix="/v1")  # L1 Intent Layer (ADR-049, S8)
 app.include_router(reporting.router, prefix="/v1")
 app.include_router(statements.router, prefix="/v1")

--- a/api/models/adverse_media.py
+++ b/api/models/adverse_media.py
@@ -1,0 +1,32 @@
+"""
+api/models/adverse_media.py — Adverse-media screening API DTOs
+GAP-064 | IMPL-1 | banxe-emi-stack
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ScreenRequest(BaseModel):
+    customer_id: str = Field(..., description="Customer to screen for adverse media")
+
+
+class HitModel(BaseModel):
+    subject_name: str
+    headline: str
+    source: str
+    categories: list[str]
+    composite_score: float
+    confidence: str
+    url: str | None = None
+
+
+class ScreenResponse(BaseModel):
+    customer_id: str
+    screened_at: str
+    action: str  # CLEAR | HITL_REVIEW
+    risk: str  # NONE | LOW | MEDIUM | HIGH
+    hits: list[HitModel]
+    marble_case_id: str | None = None
+    hitl_case_id: str | None = None

--- a/api/routers/adverse_media.py
+++ b/api/routers/adverse_media.py
@@ -1,0 +1,53 @@
+"""
+api/routers/adverse_media.py — Adverse-media screening endpoint
+GAP-064 | IMPL-1 | banxe-emi-stack
+
+POST /v1/compliance/adverse-media/screen {customer_id} -> {hits[], risk, action}
+MLR 2017 Reg.28 EDD. Advisory output — adverse hits route to MLRO HITL (no auto-clear).
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from fastapi import APIRouter, HTTPException
+
+from api.models.adverse_media import HitModel, ScreenRequest, ScreenResponse
+from services.adverse_media.service import AdverseMediaService
+from services.customer.customer_port import CustomerManagementError
+from services.customer.customer_service import get_customer_service
+
+router = APIRouter(tags=["Adverse Media Screening"])
+
+
+@lru_cache(maxsize=1)
+def _get_service() -> AdverseMediaService:
+    return AdverseMediaService(customer_service=get_customer_service())
+
+
+@router.post("/compliance/adverse-media/screen", response_model=ScreenResponse)
+def screen(req: ScreenRequest) -> ScreenResponse:
+    try:
+        result = _get_service().screen_customer(req.customer_id)
+    except CustomerManagementError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return ScreenResponse(
+        customer_id=result.customer_id,
+        screened_at=result.screened_at.isoformat(),
+        action=result.action.value,
+        risk=result.risk,
+        hits=[
+            HitModel(
+                subject_name=h.article.subject_name,
+                headline=h.article.headline,
+                source=h.article.source,
+                categories=h.article.categories,
+                composite_score=float(h.composite_score),
+                confidence=h.confidence.value,
+                url=h.article.url,
+            )
+            for h in result.hits
+        ],
+        marble_case_id=result.marble_case_id,
+        hitl_case_id=result.hitl_case_id,
+    )

--- a/services/adverse_media/__init__.py
+++ b/services/adverse_media/__init__.py
@@ -1,0 +1,29 @@
+"""
+services/adverse_media — Adverse-media / negative-news screening (GAP-064, IMPL-1).
+
+Enhanced Due Diligence support under MLR 2017 Reg.28(3), FCA SYSC 6.3, Banxe I-04.
+Reuses structured screening (sanctions_screening fuzzy matcher), Marble case
+management, the append-only ClickHouse audit trail and the MLRO HITL queue —
+it does NOT reimplement structured screening. Advisory output only: an adverse
+hit ALWAYS routes to MLRO review (no auto-clear, no auto-block).
+"""
+
+from __future__ import annotations
+
+from services.adverse_media.matcher import AdverseMediaMatcher
+from services.adverse_media.models import (
+    AdverseMediaArticle,
+    AdverseMediaHit,
+    AdverseMediaResult,
+    ScreeningAction,
+)
+from services.adverse_media.service import AdverseMediaService
+
+__all__ = [
+    "AdverseMediaArticle",
+    "AdverseMediaHit",
+    "AdverseMediaMatcher",
+    "AdverseMediaResult",
+    "AdverseMediaService",
+    "ScreeningAction",
+]

--- a/services/adverse_media/feed.py
+++ b/services/adverse_media/feed.py
@@ -1,0 +1,68 @@
+"""
+services/adverse_media/feed.py — Adverse-media source adapters
+GAP-064 | IMPL-1 | banxe-emi-stack
+
+Pluggable negative-news feeds. The default OpenSanctions-adjacency feed performs
+NO network call and holds NO secrets when unconfigured (safe-stub returning []).
+Configure ADVERSE_MEDIA_FEED_URL (+ optional ADVERSE_MEDIA_FEED_TOKEN, via env only —
+never in code, ACCESS-AND-SECRETS I-SEC) to enable a live feed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+from services.adverse_media.models import AdverseMediaArticle
+
+logger = logging.getLogger(__name__)
+
+
+class OpenSanctionsAdjacencyFeed:
+    """Default adverse-media feed.
+
+    Queries an OpenSanctions-compatible adverse-media endpoint when
+    ADVERSE_MEDIA_FEED_URL is set; otherwise returns [] (safe stub, no network,
+    no secrets). A feed error never breaks screening — it degrades to [].
+    """
+
+    def __init__(self, feed_url: str | None = None, timeout_s: float = 5.0) -> None:
+        self._feed_url = (feed_url or os.environ.get("ADVERSE_MEDIA_FEED_URL", "")).rstrip("/")
+        self._token = os.environ.get("ADVERSE_MEDIA_FEED_TOKEN", "")
+        self._timeout_s = timeout_s
+
+    def fetch(self, name: str, *, jurisdiction: str | None = None) -> list[AdverseMediaArticle]:
+        if not self._feed_url:
+            logger.info("adverse-media feed not configured — safe-stub (no hits) for %s", name)
+            return []
+        headers = {"Authorization": f"Bearer {self._token}"} if self._token else {}
+        params: dict[str, str] = {"q": name}
+        if jurisdiction:
+            params["jurisdiction"] = jurisdiction
+        try:
+            with httpx.Client(timeout=self._timeout_s) as client:
+                resp = client.get(f"{self._feed_url}/search", params=params, headers=headers)
+                resp.raise_for_status()
+                payload = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.error("adverse-media feed error for %s: %s", name, exc)
+            return []
+        results = payload.get("results", []) if isinstance(payload, dict) else []
+        return [_to_article(item) for item in results]
+
+
+def _to_article(item: dict) -> AdverseMediaArticle:
+    return AdverseMediaArticle(
+        article_id=str(item.get("id", "")),
+        subject_name=str(item.get("name", "")),
+        headline=str(item.get("headline", item.get("title", ""))),
+        source=str(item.get("source", "openSanctions")),
+        categories=list(item.get("topics", item.get("categories", []))),
+        subject_dob=item.get("dob"),
+        subject_jurisdiction=item.get("jurisdiction"),
+        url=item.get("url"),
+        published=item.get("published"),
+        snippet=item.get("snippet"),
+    )

--- a/services/adverse_media/matcher.py
+++ b/services/adverse_media/matcher.py
@@ -1,0 +1,70 @@
+"""
+services/adverse_media/matcher.py — NLP entity match (name + DOB + jurisdiction)
+GAP-064 | IMPL-1 | banxe-emi-stack
+
+Reuses services.sanctions_screening.fuzzy_matcher (I-01 weighted composite) —
+does NOT reimplement structured screening (watchman/yente live there).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from services.adverse_media.models import AdverseMediaArticle, AdverseMediaHit
+from services.customer.customer_port import CustomerProfile
+from services.sanctions_screening.fuzzy_matcher import FuzzyMatcher
+
+# MEDIUM-confidence composite (I-01) — adverse-media is advisory, so we err toward review.
+DEFAULT_HIT_THRESHOLD = Decimal("65")
+
+
+def subject_identity(profile: CustomerProfile) -> tuple[str, str | None, str | None]:
+    """Return (full_name, dob_iso, jurisdiction) for the customer's screenable subject."""
+    if profile.individual is not None:
+        ind = profile.individual
+        return (
+            f"{ind.first_name} {ind.last_name}",
+            ind.date_of_birth.isoformat() if ind.date_of_birth else None,
+            ind.nationality,
+        )
+    if profile.company is not None:
+        co = profile.company
+        return (co.company_name, None, co.country_of_incorporation)
+    return (profile.customer_id, None, None)
+
+
+class AdverseMediaMatcher:
+    """Match adverse-media articles to a customer profile via fuzzy composite score."""
+
+    def __init__(self, threshold: Decimal = DEFAULT_HIT_THRESHOLD) -> None:
+        self._fuzzy = FuzzyMatcher()
+        self._threshold = threshold
+
+    def find_hits(
+        self, profile: CustomerProfile, articles: list[AdverseMediaArticle]
+    ) -> list[AdverseMediaHit]:
+        name, dob, nationality = subject_identity(profile)
+        hits: list[AdverseMediaHit] = []
+        for article in articles:
+            name_score = self._fuzzy.match_name(name, article.subject_name)
+            dob_match = bool(
+                dob and article.subject_dob and self._fuzzy.match_dob(dob, article.subject_dob)
+            )
+            nat_match = bool(
+                nationality
+                and article.subject_jurisdiction
+                and self._fuzzy.match_nationality(nationality, article.subject_jurisdiction)
+            )
+            composite = self._fuzzy.calculate_composite_score(name_score, dob_match, nat_match)
+            if composite >= self._threshold:
+                hits.append(
+                    AdverseMediaHit(
+                        article=article,
+                        name_score=name_score,
+                        dob_match=dob_match,
+                        nat_match=nat_match,
+                        composite_score=composite,
+                        confidence=self._fuzzy.classify_confidence(composite),
+                    )
+                )
+        return hits

--- a/services/adverse_media/models.py
+++ b/services/adverse_media/models.py
@@ -1,0 +1,78 @@
+"""
+services/adverse_media/models.py — Adverse-media screening domain models + ports
+GAP-064 | IMPL-1 | banxe-emi-stack
+
+MLR 2017 Reg.28(3) | FCA SYSC 6.3 | Banxe I-04.
+Advisory output only — an adverse hit ALWAYS routes to MLRO HITL review.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Protocol
+
+from services.case_management.case_port import CaseRequest, CaseResult
+from services.sanctions_screening.models import MatchConfidence
+
+
+class ScreeningAction(str, Enum):
+    """Advisory action — never auto-blocks (MLRO decides)."""
+
+    CLEAR = "CLEAR"  # no adverse-media hit
+    HITL_REVIEW = "HITL_REVIEW"  # hit → mandatory MLRO review (no auto-clear)
+
+
+@dataclass(frozen=True)
+class AdverseMediaArticle:
+    """A single negative-news / adverse-media record about a subject."""
+
+    article_id: str
+    subject_name: str
+    headline: str
+    source: str
+    categories: list[str] = field(default_factory=list)  # e.g. ["fraud", "sanctions"]
+    subject_dob: str | None = None  # ISO YYYY-MM-DD if known
+    subject_jurisdiction: str | None = None  # ISO-3166-1 alpha-2 if known
+    url: str | None = None
+    published: str | None = None  # ISO date
+    snippet: str | None = None
+
+
+@dataclass(frozen=True)
+class AdverseMediaHit:
+    """A customer↔article match at/above the configured fuzzy threshold."""
+
+    article: AdverseMediaArticle
+    name_score: Decimal
+    dob_match: bool
+    nat_match: bool
+    composite_score: Decimal
+    confidence: MatchConfidence
+
+
+@dataclass(frozen=True)
+class AdverseMediaResult:
+    """Outcome of a single adverse-media screen."""
+
+    customer_id: str
+    screened_at: datetime
+    action: ScreeningAction
+    risk: str  # NONE / LOW / MEDIUM / HIGH
+    hits: list[AdverseMediaHit] = field(default_factory=list)
+    marble_case_id: str | None = None
+    hitl_case_id: str | None = None
+
+
+class NegativeNewsFeed(Protocol):
+    """Pluggable adverse-media source. Implementations MUST NOT hold secrets in code."""
+
+    def fetch(self, name: str, *, jurisdiction: str | None = None) -> list[AdverseMediaArticle]: ...
+
+
+class CaseOpenerPort(Protocol):
+    """Marble case opener — reuses services.case_management."""
+
+    def create_case(self, request: CaseRequest) -> CaseResult: ...

--- a/services/adverse_media/service.py
+++ b/services/adverse_media/service.py
@@ -1,0 +1,193 @@
+"""
+services/adverse_media/service.py — AdverseMediaService orchestration
+GAP-064 | IMPL-1 | banxe-emi-stack
+
+Onboarding + periodic adverse-media screening for EDD (MLR 2017 Reg.28(3),
+FCA SYSC 6.3, I-04). On hit: open a Marble case (reuse case_management),
+append an append-only ClickHouse audit event (reuse audit_trail), and enqueue
+a MANDATORY MLRO HITL review (reuse hitl) — no auto-clear, no auto-block.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+import logging
+
+from services.adverse_media.feed import OpenSanctionsAdjacencyFeed
+from services.adverse_media.matcher import AdverseMediaMatcher, subject_identity
+from services.adverse_media.models import (
+    AdverseMediaHit,
+    AdverseMediaResult,
+    CaseOpenerPort,
+    NegativeNewsFeed,
+    ScreeningAction,
+)
+from services.audit_trail.event_store import EventStore
+from services.audit_trail.models import (
+    AuditAction,
+    EventCategory,
+    EventSeverity,
+    SourceSystem,
+)
+from services.case_management.case_port import CasePriority, CaseRequest, CaseResult, CaseType
+from services.customer.customer_port import (
+    CustomerManagementPort,
+    CustomerProfile,
+    RiskLevel,
+)
+from services.hitl.hitl_port import ReviewReason
+from services.hitl.hitl_service import HITLService
+from services.sanctions_screening.models import MatchConfidence
+
+logger = logging.getLogger(__name__)
+
+# Risk levels at/above which adverse-media screening is triggered (>= I-04 EDD scrutiny).
+_SCREEN_RISK_LEVELS = frozenset(
+    {RiskLevel.MEDIUM, RiskLevel.HIGH, RiskLevel.VERY_HIGH, RiskLevel.PROHIBITED}
+)
+_CONFIDENCE_RISK: dict[MatchConfidence, str] = {
+    MatchConfidence.HIGH: "HIGH",
+    MatchConfidence.MEDIUM: "MEDIUM",
+    MatchConfidence.LOW: "LOW",
+}
+_RISK_ORDER = {"LOW": 1, "MEDIUM": 2, "HIGH": 3}
+
+
+class _LazyMarbleOpener:
+    """Default case opener — instantiates MarbleAdapter lazily (needs env at call time)."""
+
+    def create_case(self, request: CaseRequest) -> CaseResult:
+        from services.case_management.marble_adapter import MarbleAdapter
+
+        return MarbleAdapter().create_case(request)
+
+
+class AdverseMediaService:
+    """Orchestrates feed → match → (Marble case + audit + MLRO HITL) on hit."""
+
+    def __init__(
+        self,
+        *,
+        customer_service: CustomerManagementPort,
+        feed: NegativeNewsFeed | None = None,
+        matcher: AdverseMediaMatcher | None = None,
+        case_opener: CaseOpenerPort | None = None,
+        audit: EventStore | None = None,
+        hitl: HITLService | None = None,
+    ) -> None:
+        self._customers = customer_service
+        self._feed: NegativeNewsFeed = feed or OpenSanctionsAdjacencyFeed()
+        self._matcher = matcher or AdverseMediaMatcher()
+        self._case_opener: CaseOpenerPort = case_opener or _LazyMarbleOpener()
+        self._audit = audit or EventStore()
+        self._hitl = hitl or HITLService()
+
+    @staticmethod
+    def should_screen(profile: CustomerProfile) -> bool:
+        """Trigger adverse-media screening at onboarding for risk >= I-04 scrutiny."""
+        return profile.risk_level in _SCREEN_RISK_LEVELS
+
+    def screen_customer(self, customer_id: str, *, actor_id: str = "system") -> AdverseMediaResult:
+        profile = self._customers.get_customer(customer_id)
+        name, _dob, jurisdiction = subject_identity(profile)
+        articles = self._feed.fetch(name, jurisdiction=jurisdiction)
+        hits = self._matcher.find_hits(profile, articles)
+        now = datetime.now(UTC)
+
+        if not hits:
+            self._audit.append(
+                category=EventCategory.COMPLIANCE,
+                severity=EventSeverity.INFO,
+                action=AuditAction.READ,
+                entity_type="customer",
+                entity_id=customer_id,
+                actor_id=actor_id,
+                details={"screen": "adverse_media", "result": "clear", "articles": len(articles)},
+                source=SourceSystem.API,
+            )
+            return AdverseMediaResult(
+                customer_id=customer_id,
+                screened_at=now,
+                action=ScreeningAction.CLEAR,
+                risk="NONE",
+            )
+
+        risk = _max_risk(hits)
+        marble_case_id = self._open_case(profile, hits, risk)
+        hitl_case_id = self._enqueue_mlro(profile, hits)
+        self._audit.append(
+            category=EventCategory.AML,
+            severity=EventSeverity.WARNING,
+            action=AuditAction.CREATE,
+            entity_type="customer",
+            entity_id=customer_id,
+            actor_id=actor_id,
+            details={
+                "screen": "adverse_media",
+                "result": "hit",
+                "hits": len(hits),
+                "risk": risk,
+                "marble_case_id": marble_case_id,
+                "hitl_case_id": hitl_case_id,
+                "subjects": [h.article.subject_name for h in hits],
+            },
+            source=SourceSystem.API,
+        )
+        return AdverseMediaResult(
+            customer_id=customer_id,
+            screened_at=now,
+            action=ScreeningAction.HITL_REVIEW,
+            risk=risk,
+            hits=hits,
+            marble_case_id=marble_case_id,
+            hitl_case_id=hitl_case_id,
+        )
+
+    def _open_case(
+        self, profile: CustomerProfile, hits: list[AdverseMediaHit], risk: str
+    ) -> str | None:
+        priority = CasePriority.CRITICAL if risk == "HIGH" else CasePriority.HIGH
+        top_score = max(h.composite_score for h in hits)
+        request = CaseRequest(
+            case_reference=f"AM-{profile.customer_id}",
+            case_type=CaseType.EDD,
+            entity_id=profile.customer_id,
+            entity_type=profile.entity_type.value.lower(),
+            priority=priority,
+            description=(
+                f"Adverse-media hit ({len(hits)}) for {profile.display_name} — "
+                "EDD / MLRO review required (MLR 2017 Reg.28)."
+            ),
+            risk_score=int(top_score),
+            metadata={
+                "screen": "adverse_media",
+                "subjects": [h.article.subject_name for h in hits],
+            },
+        )
+        try:
+            return self._case_opener.create_case(request).case_id
+        except (OSError, RuntimeError) as exc:  # Marble env not configured — HITL still gates
+            logger.error("Marble case open failed (degraded); MLRO HITL still enforced: %s", exc)
+            return None
+
+    def _enqueue_mlro(self, profile: CustomerProfile, hits: list[AdverseMediaHit]) -> str:
+        subjects = ", ".join(h.article.subject_name for h in hits)
+        case = self._hitl.enqueue(
+            transaction_id=f"adverse-media:{profile.customer_id}",
+            customer_id=profile.customer_id,
+            entity_type=profile.entity_type.value.lower(),
+            amount=Decimal("0"),
+            currency="GBP",
+            reasons=[ReviewReason.EDD_REQUIRED],
+            fraud_score=0,
+            fraud_risk="N/A",
+            aml_flags=[f"ADVERSE_MEDIA:{subjects}"],
+            hold_reasons=["Adverse-media hit — mandatory MLRO review (no auto-clear)"],
+        )
+        return case.case_id
+
+
+def _max_risk(hits: list[AdverseMediaHit]) -> str:
+    risks = [_CONFIDENCE_RISK[h.confidence] for h in hits]
+    return max(risks, key=lambda r: _RISK_ORDER[r])

--- a/tests/test_adverse_media.py
+++ b/tests/test_adverse_media.py
@@ -1,0 +1,173 @@
+"""
+tests/test_adverse_media.py — IMPL-1 adverse-media screening (GAP-064)
+
+Unit (feed safe-stub, matcher, service CLEAR/HIT) + EDD trigger + MANDATORY
+MLRO HITL gate (no auto-clear). Reuses real EventStore / HITLService (in-memory)
+and fakes for the customer source and Marble case opener.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from services.adverse_media.feed import OpenSanctionsAdjacencyFeed
+from services.adverse_media.matcher import AdverseMediaMatcher
+from services.adverse_media.models import (
+    AdverseMediaArticle,
+    ScreeningAction,
+)
+from services.adverse_media.service import AdverseMediaService
+from services.audit_trail.event_store import EventStore
+from services.case_management.case_port import CaseRequest, CaseResult, CaseStatus
+from services.customer.customer_port import (
+    Address,
+    CustomerProfile,
+    EntityType,
+    IndividualProfile,
+    LifecycleState,
+    RiskLevel,
+)
+from services.hitl.hitl_port import CaseStatus as HITLCaseStatus
+from services.hitl.hitl_service import HITLService
+
+
+def _profile(risk: RiskLevel = RiskLevel.HIGH) -> CustomerProfile:
+    return CustomerProfile(
+        customer_id="cust-001",
+        entity_type=EntityType.INDIVIDUAL,
+        kyc_status="VERIFIED",
+        risk_level=risk,
+        lifecycle_state=LifecycleState.ONBOARDING,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        individual=IndividualProfile(
+            first_name="John",
+            last_name="Smith",
+            date_of_birth=date(1980, 5, 1),
+            nationality="GB",
+            address=Address(line1="1 High St", city="London", country="GB"),
+        ),
+    )
+
+
+class _StubFeed:
+    def __init__(self, articles: list[AdverseMediaArticle]) -> None:
+        self._articles = articles
+
+    def fetch(self, name: str, *, jurisdiction: str | None = None) -> list[AdverseMediaArticle]:
+        return list(self._articles)
+
+
+class _FakeCustomers:
+    def __init__(self, profile: CustomerProfile) -> None:
+        self._p = profile
+
+    def get_customer(self, customer_id: str) -> CustomerProfile:
+        return self._p
+
+
+class _FakeOpener:
+    def __init__(self) -> None:
+        self.requests: list[CaseRequest] = []
+
+    def create_case(self, request: CaseRequest) -> CaseResult:
+        self.requests.append(request)
+        return CaseResult(
+            case_id="marble-123",
+            case_reference=request.case_reference,
+            status=CaseStatus.OPEN,
+            provider="mock",
+            created_at=datetime(2026, 6, 20, tzinfo=UTC),
+        )
+
+
+_HIT_ARTICLE = AdverseMediaArticle(
+    article_id="a1",
+    subject_name="John Smith",
+    headline="John Smith charged in fraud probe",
+    source="reuters",
+    categories=["fraud"],
+    subject_dob="1980-05-01",
+    subject_jurisdiction="GB",
+)
+_NOISE_ARTICLE = AdverseMediaArticle(
+    article_id="a2",
+    subject_name="Zachary Albright",
+    headline="Unrelated person wins award",
+    source="local",
+)
+
+
+def _service(
+    profile: CustomerProfile,
+    feed_articles: list[AdverseMediaArticle],
+    opener: _FakeOpener | None = None,
+    audit: EventStore | None = None,
+    hitl: HITLService | None = None,
+) -> AdverseMediaService:
+    return AdverseMediaService(
+        customer_service=_FakeCustomers(profile),
+        feed=_StubFeed(feed_articles),
+        case_opener=opener or _FakeOpener(),
+        audit=audit or EventStore(),
+        hitl=hitl or HITLService(),
+    )
+
+
+class TestFeedSafeStub:
+    def test_unconfigured_feed_returns_empty_no_secrets(self) -> None:
+        # No ADVERSE_MEDIA_FEED_URL → safe stub, no network, no secrets.
+        assert OpenSanctionsAdjacencyFeed(feed_url="").fetch("John Smith") == []
+
+
+class TestMatcher:
+    def test_matches_same_person(self) -> None:
+        hits = AdverseMediaMatcher().find_hits(_profile(), [_HIT_ARTICLE])
+        assert len(hits) == 1
+        assert hits[0].composite_score >= Decimal("65")
+        assert hits[0].dob_match is True
+        assert hits[0].nat_match is True
+
+    def test_ignores_unrelated(self) -> None:
+        assert AdverseMediaMatcher().find_hits(_profile(), [_NOISE_ARTICLE]) == []
+
+
+class TestService:
+    def test_clear_when_no_articles(self) -> None:
+        res = _service(_profile(), []).screen_customer("cust-001")
+        assert res.action is ScreeningAction.CLEAR
+        assert res.risk == "NONE"
+        assert res.hitl_case_id is None
+
+    def test_hit_opens_marble_case(self) -> None:
+        opener = _FakeOpener()
+        res = _service(_profile(), [_HIT_ARTICLE], opener=opener).screen_customer("cust-001")
+        assert res.action is ScreeningAction.HITL_REVIEW
+        assert res.marble_case_id == "marble-123"
+        assert len(opener.requests) == 1
+        assert opener.requests[0].entity_id == "cust-001"
+
+    def test_hit_appends_audit_event(self) -> None:
+        audit = EventStore()
+        _service(_profile(), [_HIT_ARTICLE], audit=audit).screen_customer("cust-001")
+        events = audit.list_by_entity("cust-001")
+        assert any(e.details.get("result") == "hit" for e in events)
+
+
+class TestHITLGate:
+    def test_hit_enqueues_mlro_review_no_auto_clear(self) -> None:
+        hitl = HITLService()
+        res = _service(_profile(), [_HIT_ARTICLE], hitl=hitl).screen_customer("cust-001")
+        assert res.hitl_case_id is not None
+        case = hitl.get_case(res.hitl_case_id)
+        assert case is not None
+        assert case.status is HITLCaseStatus.PENDING  # mandatory review, not auto-cleared
+
+
+class TestEddTrigger:
+    def test_should_screen_high_risk(self) -> None:
+        assert AdverseMediaService.should_screen(_profile(RiskLevel.HIGH)) is True
+
+    def test_should_not_screen_low_risk(self) -> None:
+        assert AdverseMediaService.should_screen(_profile(RiskLevel.LOW)) is False


### PR DESCRIPTION
IMPL-1 of the L1→L3 implementation roadmap (GAP-076). Drives GAP-064 from L1 (ADR/passport only) to **L2/L3 real code** in banxe-emi-stack.

## What
`services/adverse_media/` — adverse-media / negative-news screening for Enhanced Due Diligence (MLR 2017 Reg.28(3), FCA SYSC 6.3, Banxe I-04):
- **feed.py** — pluggable `OpenSanctionsAdjacencyFeed`; safe-stub (no network, **no secrets**) when `ADVERSE_MEDIA_FEED_URL` unset (ACCESS-AND-SECRETS I-SEC).
- **matcher.py** — NLP entity match (name+DOB+jurisdiction) **reusing** `sanctions_screening.fuzzy_matcher` (I-01 weighted composite) — does NOT reimplement structured screening (watchman/yente).
- **service.py** — orchestration + onboarding trigger (risk ≥ I-04 scrutiny) + periodic re-screen.
- On hit → **reuse** Marble case (`case_management`) + append-only ClickHouse audit (`audit_trail`) + **mandatory MLRO HITL** review (`hitl`) — **no auto-clear, no auto-block (advisory only)**.
- **api/routers/adverse_media.py** — `POST /v1/compliance/adverse-media/screen {customer_id} → {hits[], risk, action}`.

## Tests
`tests/test_adverse_media.py` — feed safe-stub, matcher (match/non-match), service CLEAR/HIT, EDD-trigger, **HITL-gate (no auto-clear)**. **9 passed**. ruff ✓ mypy ✓ pytest ✓ (coverage 38% ≥ 35%).

## Guardrails
ADR-052; MLRO HITL mandatory on hit; advisory output (no auto-block); no secrets; reuses watchman/yente/Marble (no structured-screening reimplementation). Operator approves merge.

Refs GAP-064, IMPL-1, GAP-076.