### PR TITLE
feat(account-sot): MIG-M2.2 accounts/balance SoT scaffold (advisory, balance-free, no merge) [MIG-M2.2]

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -35,6 +35,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from api.routers import (
+    account_sot,
     adverse_media,
     api_gateway,
     api_versioning,
@@ -173,6 +174,7 @@ app.include_router(customers.router, prefix="/v1")
 app.include_router(kyc.router, prefix="/v1")
 app.include_router(payments.router, prefix="/v1")
 app.include_router(ledger.router, prefix="/v1")
+app.include_router(account_sot.router, prefix="/v1")  # MIG-M2.2 advisory account-metadata SoT
 app.include_router(notifications.router, prefix="/v1")
 app.include_router(fraud.router, prefix="/v1")
 app.include_router(consumer_duty.router, prefix="/v1")

--- a/api/models/account_sot.py
+++ b/api/models/account_sot.py
@@ -1,0 +1,168 @@
+"""api/models/account_sot.py — Advisory account/balance SoT (MIG-M2.2) | banxe-emi-stack.
+
+The **advisory account-metadata Source-of-Truth**: descriptive account metadata, virtual-account
+descriptors, and intermediary-bank descriptors. **Balance-free by design** — it does NOT hold or
+return live balances and **does NOT call the Midaz LedgerPort** (``api/models/ledger.py`` +
+``services/ledger`` remain the live balance SoT, ADR-013). Payments (MIG-M2.1) will be a
+**projection-consumer** of this SoT, never a second balance store (MIG-M1.3).
+
+Consumes the **accounts-connector** contract baseline pinned in MIG-M2.0/M2.7 (``@banxe/*`` from
+``banxe-shared-libs``) at the **gRPC/proto contract level** (language-agnostic; not an npm import).
+Advisory / read-only / sandbox-mock-safe. Numerics: integer meta / DecimalString only (I-01) — no
+balances, no float.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel
+
+SANDBOX_SOURCE = "sandbox-mock"
+
+
+class AccountAdvisoryMetadata(BaseModel):
+    """Descriptive advisory account metadata (read-only; NOT a live account/balance)."""
+
+    account_type: str
+    ledger_nature: str
+    account_status: str
+    supported_assets: list[str]
+    capabilities: list[str]
+    source: str
+
+
+class VirtualAccountDescriptor(BaseModel):
+    """Descriptive virtual-account record (balance-free; no live amount)."""
+
+    virtual_account_id: str
+    parent_account_ref: str
+    asset: str
+    status: str
+    source: str
+
+
+class IntermediaryBankDescriptor(BaseModel):
+    """Descriptive intermediary-bank routing record (reference-only)."""
+
+    name: str
+    bic: str
+    country: str
+    role: str
+    source: str
+
+
+class AccountSoTMetadataResponse(BaseModel):
+    """Advisory account-metadata SoT response (balance-free)."""
+
+    accounts: list[AccountAdvisoryMetadata]
+    source: str
+    disclaimer: str
+
+
+class VirtualAccountListResponse(BaseModel):
+    by_virtual_account: list[VirtualAccountDescriptor]
+    total: int
+    source: str
+
+
+class IntermediaryListResponse(BaseModel):
+    intermediaries: list[IntermediaryBankDescriptor]
+    total: int
+    source: str
+
+
+_DISCLAIMER = (
+    "Advisory account-metadata SoT — descriptive only. NOT a balance/ledger surface; "
+    "balances are owned by the Midaz LedgerPort (live), never returned here."
+)
+
+# Config-as-data sandbox descriptors (balance-free; no Midaz call).
+_ACCOUNTS: tuple[dict[str, object], ...] = (
+    {
+        "account_type": "INTERNAL",
+        "ledger_nature": "ACTIVE",
+        "account_status": "ACTIVE",
+        "supported_assets": ["EUR", "GBP", "USD", "CHF", "BTC", "ETH", "USDC"],
+        "capabilities": ["fiat", "crypto", "self_custodial"],
+    },
+    {
+        "account_type": "EXTERNAL",
+        "ledger_nature": "PASSIVE",
+        "account_status": "ACTIVE",
+        "supported_assets": ["EUR", "GBP", "USD", "CHF"],
+        "capabilities": ["fiat"],
+    },
+    {
+        "account_type": "SYSTEM",
+        "ledger_nature": "ACTIVE",
+        "account_status": "ACTIVE",
+        "supported_assets": [],
+        "capabilities": ["internal"],
+    },
+)
+_VIRTUAL_ACCOUNTS: tuple[dict[str, str], ...] = (
+    {
+        "virtual_account_id": "VA-EUR-0001",
+        "parent_account_ref": "INTERNAL",
+        "asset": "EUR",
+        "status": "ACTIVE",
+    },
+    {
+        "virtual_account_id": "VA-GBP-0001",
+        "parent_account_ref": "INTERNAL",
+        "asset": "GBP",
+        "status": "ACTIVE",
+    },
+)
+_INTERMEDIARIES: tuple[dict[str, str], ...] = (
+    {"name": "Intermediary Bank A", "bic": "INTBGB2L", "country": "GB", "role": "correspondent"},
+    {"name": "Intermediary Bank B", "bic": "INTBDEFF", "country": "DE", "role": "correspondent"},
+)
+
+
+class AccountSoTPort(ABC):
+    """Read-only advisory account-metadata SoT contract (balance-free; Midaz LedgerPort NOT called)."""
+
+    @abstractmethod
+    def list_account_metadata(self) -> list[AccountAdvisoryMetadata]: ...
+
+    @abstractmethod
+    def list_virtual_accounts(self) -> list[VirtualAccountDescriptor]: ...
+
+    @abstractmethod
+    def list_intermediaries(self) -> list[IntermediaryBankDescriptor]: ...
+
+
+class SandboxAccountSoT(AccountSoTPort):
+    """Sandbox config-as-data provider (mock-safe; no Midaz, no balances)."""
+
+    def list_account_metadata(self) -> list[AccountAdvisoryMetadata]:
+        return [AccountAdvisoryMetadata(source=SANDBOX_SOURCE, **a) for a in _ACCOUNTS]  # type: ignore[arg-type]
+
+    def list_virtual_accounts(self) -> list[VirtualAccountDescriptor]:
+        return [VirtualAccountDescriptor(source=SANDBOX_SOURCE, **v) for v in _VIRTUAL_ACCOUNTS]
+
+    def list_intermediaries(self) -> list[IntermediaryBankDescriptor]:
+        return [IntermediaryBankDescriptor(source=SANDBOX_SOURCE, **i) for i in _INTERMEDIARIES]
+
+
+def account_sot_metadata_response() -> AccountSoTMetadataResponse:
+    sot = SandboxAccountSoT()
+    return AccountSoTMetadataResponse(
+        accounts=sot.list_account_metadata(),
+        source=SANDBOX_SOURCE,
+        disclaimer=_DISCLAIMER,
+    )
+
+
+def virtual_account_list_response() -> VirtualAccountListResponse:
+    items = SandboxAccountSoT().list_virtual_accounts()
+    return VirtualAccountListResponse(
+        by_virtual_account=items, total=len(items), source=SANDBOX_SOURCE
+    )
+
+
+def intermediary_list_response() -> IntermediaryListResponse:
+    items = SandboxAccountSoT().list_intermediaries()
+    return IntermediaryListResponse(intermediaries=items, total=len(items), source=SANDBOX_SOURCE)

--- a/api/routers/account_sot.py
+++ b/api/routers/account_sot.py
@@ -1,0 +1,41 @@
+"""api/routers/account_sot.py — Advisory account/balance SoT endpoints (MIG-M2.2) | banxe-emi-stack.
+
+GET /v1/account-sot/metadata          — advisory account metadata (balance-free)
+GET /v1/account-sot/virtual-accounts  — virtual-account descriptors (balance-free)
+GET /v1/account-sot/intermediaries    — intermediary-bank descriptors (reference-only)
+
+Advisory account-metadata SoT (MIG-M2.2). Balance-free; does NOT call the Midaz LedgerPort (live
+balances stay in /v1/ledger/*, ADR-013). Payments = future projection-consumer (MIG-M1.3). Sandbox:
+config-as-data mock. Consumes the accounts-connector contract baseline (MIG-M2.0/M2.7) at the proto
+level. No live mutation (operator-gated, ADR-103 PART 2).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from api.models.account_sot import (
+    AccountSoTMetadataResponse,
+    IntermediaryListResponse,
+    VirtualAccountListResponse,
+    account_sot_metadata_response,
+    intermediary_list_response,
+    virtual_account_list_response,
+)
+
+router = APIRouter(prefix="/account-sot", tags=["account-sot"])
+
+
+@router.get("/metadata", response_model=AccountSoTMetadataResponse)
+async def get_account_metadata() -> AccountSoTMetadataResponse:
+    return account_sot_metadata_response()
+
+
+@router.get("/virtual-accounts", response_model=VirtualAccountListResponse)
+async def get_virtual_accounts() -> VirtualAccountListResponse:
+    return virtual_account_list_response()
+
+
+@router.get("/intermediaries", response_model=IntermediaryListResponse)
+async def get_intermediaries() -> IntermediaryListResponse:
+    return intermediary_list_response()

--- a/tests/test_account_sot.py
+++ b/tests/test_account_sot.py
@@ -1,0 +1,67 @@
+"""MIG-M2.2 — advisory account/balance SoT scaffold (balance-free, read-only, sandbox-mock).
+
+characterization: SoT port returns expected metadata/virtual-accounts/intermediaries; deterministic;
+endpoints 200. contract/fence: DTOs are BALANCE-FREE (no balance/amount fields); SoT does NOT import
+or call the Midaz ledger surface. fail-closed: counts consistent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.models import account_sot as sot
+
+client = TestClient(app)
+
+_BALANCE_FIELDS = {"balance", "amount", "available", "ledger_balance", "amount_str"}
+
+
+def test_metadata_shape_and_balance_free() -> None:
+    resp = sot.account_sot_metadata_response()
+    assert resp.source == "sandbox-mock"
+    assert len(resp.accounts) == 3
+    # balance-free: no balance/amount fields on any advisory DTO
+    for model in (
+        sot.AccountAdvisoryMetadata,
+        sot.VirtualAccountDescriptor,
+        sot.IntermediaryBankDescriptor,
+    ):
+        assert _BALANCE_FIELDS.isdisjoint(set(model.model_fields))
+
+
+def test_virtual_accounts_and_intermediaries() -> None:
+    va = sot.virtual_account_list_response()
+    assert va.total == len(va.by_virtual_account) == 2
+    assert all(v.source == "sandbox-mock" for v in va.by_virtual_account)
+    inter = sot.intermediary_list_response()
+    assert inter.total == len(inter.intermediaries) == 2
+
+
+def test_deterministic() -> None:
+    assert sot.account_sot_metadata_response() == sot.account_sot_metadata_response()
+
+
+def test_sot_does_not_import_or_call_midaz_ledger() -> None:
+    # fence: the SoT module must not import the live Midaz ledger surface / client (docstring may mention it)
+    import api.models.account_sot as mod
+
+    text = Path(mod.__file__).read_text()
+    import_lines = [ln for ln in text.splitlines() if ln.strip().startswith(("import ", "from "))]
+    joined = "\n".join(import_lines).lower()
+    assert "ledger" not in joined and "midaz" not in joined  # no ledger/midaz imports
+    assert "midaz_client" not in text  # no client call
+
+
+def test_endpoints_200_balance_free() -> None:
+    for path in (
+        "/v1/account-sot/metadata",
+        "/v1/account-sot/virtual-accounts",
+        "/v1/account-sot/intermediaries",
+    ):
+        r = client.get(path)
+        assert r.status_code == 200
+        txt = r.text.lower()
+        assert '"balance"' not in txt and '"amount"' not in txt


### PR DESCRIPTION
## MIG-M2.2 — accounts/balance SoT scaffold (advisory, balance-free, no live mutation) [MIG-M2.2]

> **Cross-context migration M2 — first backend substep.** Server-side origin (evo1, isolated worktree). **Advisory account-metadata Source-of-Truth, balance-free.** **Do NOT auto-merge** (operator-gated, ADR-103 PART 2).

### Scope
`api/models/account_sot.py`: `AccountSoTPort` (ABC) + `SandboxAccountSoT` (config-as-data mock) + DTOs `AccountAdvisoryMetadata` / `VirtualAccountDescriptor` / `IntermediaryBankDescriptor` + response wrappers — **balance-free** (no balance/amount fields). New read-only `GET /v1/account-sot/{metadata,virtual-accounts,intermediaries}` (`api/routers/account_sot.py`, registered in `api/main.py`). Consumes the **accounts-connector contract baseline** (MIG-M2.0/M2.7, `banxe-shared-libs`) at the **gRPC/proto level** (language-agnostic — emi-stack is Python/FastAPI, not an npm consumer).

### Duplication Audit (ADR-102)
| Asset | Decision | Rationale |
|---|---|---|
| `api/models/ledger.py` + `services/ledger` (Midaz CBS live balances, ADR-013) | **KEEP — live balance SoT; NOT called/duplicated** | account_sot is balance-free; **0 ledger/midaz imports** (fence test); ledger.py UNCHANGED (0 in diff). |
| **account_sot** (advisory metadata SoT) | **new — single advisory SoT** | descriptive account metadata + virtual-accounts + intermediaries; not a second balance store. |
| payments-side accounts (MIG-M1.3) | **future projection-consumer** | payments will project over this SoT, never a second balance ledger. |
| accounts-connector (`@banxe/common`) | **consume contract (proto-level)** | aligned to pinned baseline; no re-implementation. |

**Verdict:** single advisory account-metadata SoT; live balance SoT (Midaz) untouched; no duplication; no second balance store.

### Numeric Invariants (I-01)
**Balance-free** — DTOs carry **no balance/amount fields**; no `float`; descriptive strings + lists only. No balances/postings surfaced.

### Activation Safety
**Advisory / read-only / sandbox-mock**; **NO live balances, NO Midaz LedgerPort call, NO postings/payments/fund movement, NO live mutation** (operator-gated ADR-103 PART 2); sandbox config-as-data; fail-closed.

### Keep / Merge / Delete decisions
**Keep/extend** only: `+account_sot` model/port/router + main.py registration + tests. **Nothing merged or deleted;** Midaz ledger surface unchanged.

### Source-of-truth & consumers
- **SoT-owner:** `account_sot` (advisory account metadata / virtual-accounts / intermediaries) — sandbox `SandboxAccountSoT`; prod adapter would wire a real source **behind the same port, never calling the live Midaz balance SoT**.
- **Consumers (future):** payments engine (MIG-M2.1) as projection-consumer; behind accounts-connector contract.

### Out-of-scope
Live balances/postings (Midaz live SoT untouched); payments engine (M2.1); KYC/AML; live mutation; `banxe-fiat-backend` lift-and-shift; second balance store.

### Validation (server-side evo1, isolated worktree)
`ruff check` + `ruff format --check` **clean** (repo pyproject config); `py_compile` OK. Diff = 4 files (3 new + main.py register), **`api/models/ledger.py` / `api/routers/ledger.py` UNCHANGED (0 in diff)**. **Full `mypy`/`pytest`/quality-gate run in CI** (lint-python + quality-gate + smoke-gate workflows) — the project venv was not provisioned in the server-side clone, so local mypy/pytest were not run; flagged for CI. Authored tests: characterization + balance-free fence + no-Midaz-import fence.

> **Paired** with banxe-architecture arch IL-shard. **No merge** (operator-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
