### PR TITLE
feat(quant-advisory): IMPL-4 FINAL quant pricing/risk advisory (GAP-070, ADR-113)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -95,6 +95,7 @@ from api.routers import (
     payments,
     pgaudit,
     psd2_gateway,
+    quant_advisory,
     recon,
     referral,
     regulatory,
@@ -184,6 +185,7 @@ app.include_router(hitl.router, prefix="/v1")
 app.include_router(adverse_media.router, prefix="/v1")  # Adverse-media screening (GAP-064, IMPL-1)
 app.include_router(crypto_aml_graph.router, prefix="/v1")  # Crypto-AML graph (GAP-068)
 app.include_router(voice_support.router, prefix="/v1")  # Voice-AI support (GAP-069)
+app.include_router(quant_advisory.router, prefix="/v1")  # Quant advisory (GAP-070)
 app.include_router(intent.router, prefix="/v1")  # L1 Intent Layer (ADR-049, S8)
 app.include_router(reporting.router, prefix="/v1")
 app.include_router(statements.router, prefix="/v1")

--- a/api/models/quant_advisory.py
+++ b/api/models/quant_advisory.py
@@ -1,0 +1,59 @@
+"""
+api/models/quant_advisory.py — Quant advisory API DTOs
+GAP-070 | IMPL-4 | banxe-emi-stack
+
+All read/advisory — no execution payloads.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PriceResponse(BaseModel):
+    model: str
+    price: float
+    advisory: bool = True
+
+
+class VolSurfacePointModel(BaseModel):
+    strike: float
+    implied_vol: float
+
+
+class VolSurfaceResponse(BaseModel):
+    forward: float
+    expiry: float
+    points: list[VolSurfacePointModel]
+
+
+class GreeksResponse(BaseModel):
+    delta: float
+    gamma: float
+    vega: float
+    theta: float
+    rho: float
+
+
+class VarResponse(BaseModel):
+    var99: float
+    horizon_days: int
+    confidence: float
+
+
+class MMSpreadRequest(BaseModel):
+    mid: float = Field(..., description="Mid price")
+    inventory: float = Field(0.0, description="Current inventory q")
+    gamma: float = Field(0.1, description="Risk aversion γ")
+    sigma: float = Field(0.2, description="Volatility σ")
+    time_left: float = Field(1.0, description="Time to horizon (T−t)")
+    k: float = Field(1.5, description="Order-book liquidity k")
+
+
+class MMSpreadResponse(BaseModel):
+    reservation_price: float
+    optimal_spread: float
+    bid: float
+    ask: float
+    advisory: bool = True
+    execution_allowed: bool = False

--- a/api/routers/quant_advisory.py
+++ b/api/routers/quant_advisory.py
@@ -1,0 +1,109 @@
+"""
+api/routers/quant_advisory.py — Quant advisory endpoints (read/advisory only)
+GAP-070 | IMPL-4 | banxe-emi-stack
+
+GET  /v1/quant/price        — Heston/Bates/BS option price
+GET  /v1/quant/vol-surface  — SABR implied-vol surface
+GET  /v1/quant/greeks       — Black-Scholes Greeks
+GET  /v1/quant/var          — parametric VaR99
+POST /v1/quant/mm-spread    — Avellaneda-Stoikov optimal spread (advisory)
+
+ADVISORY-SEAM ONLY (ADR-113) — there are NO execution endpoints.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from fastapi import APIRouter, HTTPException
+
+from api.models.quant_advisory import (
+    GreeksResponse,
+    MMSpreadRequest,
+    MMSpreadResponse,
+    PriceResponse,
+    VarResponse,
+    VolSurfacePointModel,
+    VolSurfaceResponse,
+)
+from services.quant_advisory.pricing import PricingModel
+from services.quant_advisory.service import QuantAdvisoryService
+
+router = APIRouter(tags=["Quant Advisory"], prefix="/quant")
+
+
+@lru_cache(maxsize=1)
+def _svc() -> QuantAdvisoryService:
+    return QuantAdvisoryService()
+
+
+def _model(name: str) -> PricingModel:
+    try:
+        return PricingModel(name)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=f"unknown model: {name}") from exc
+
+
+@router.get("/price", response_model=PriceResponse)
+def price(
+    s: float, k: float, t: float, r: float = 0.0, sigma: float = 0.2, model: str = "heston"
+) -> PriceResponse:
+    pm = _model(model)
+    return PriceResponse(model=pm.value, price=round(_svc().price(pm, s, k, t, r, sigma=sigma), 6))
+
+
+@router.get("/vol-surface", response_model=VolSurfaceResponse)
+def vol_surface(forward: float, t: float, strikes: str) -> VolSurfaceResponse:
+    try:
+        strike_list = [round(x, 6) for x in (float(v) for v in strikes.split(","))]
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="strikes must be comma-separated") from exc
+    points = _svc().vol_surface(forward, t, strike_list)
+    return VolSurfaceResponse(
+        forward=forward,
+        expiry=t,
+        points=[
+            VolSurfacePointModel(strike=p.strike, implied_vol=round(p.implied_vol, 6))
+            for p in points
+        ],
+    )
+
+
+@router.get("/greeks", response_model=GreeksResponse)
+def greeks(s: float, k: float, t: float, r: float = 0.0, sigma: float = 0.2) -> GreeksResponse:
+    g = _svc().compute_greeks(s, k, t, r, sigma)
+    return GreeksResponse(
+        delta=round(g.delta, 6),
+        gamma=round(g.gamma, 6),
+        vega=round(g.vega, 6),
+        theta=round(g.theta, 6),
+        rho=round(g.rho, 6),
+    )
+
+
+@router.get("/var", response_model=VarResponse)
+def var(
+    position_value: float, sigma: float, horizon_days: int = 1, confidence: float = 0.99
+) -> VarResponse:
+    value = _svc().value_at_risk(
+        position_value, sigma, horizon_days=horizon_days, confidence=confidence
+    )
+    return VarResponse(var99=round(value, 6), horizon_days=horizon_days, confidence=confidence)
+
+
+@router.post("/mm-spread", response_model=MMSpreadResponse)
+def mm_spread(req: MMSpreadRequest) -> MMSpreadResponse:
+    quote = _svc().mm_spread(
+        req.mid,
+        req.inventory,
+        gamma=req.gamma,
+        sigma=req.sigma,
+        time_left=req.time_left,
+        k=req.k,
+    )
+    return MMSpreadResponse(
+        reservation_price=round(quote.reservation_price, 6),
+        optimal_spread=round(quote.optimal_spread, 6),
+        bid=round(quote.bid, 6),
+        ask=round(quote.ask, 6),
+    )

--- a/services/quant_advisory/__init__.py
+++ b/services/quant_advisory/__init__.py
@@ -1,0 +1,30 @@
+"""
+services/quant_advisory — Quant pricing/risk advisory seam (GAP-070, IMPL-4 FINAL).
+
+Heston/Bates pricing, SABR/SVI vol-surface, Avellaneda-Stoikov optimal spread,
+Greeks + VaR99 + stress (ADR-113; ties GAP-036 treasury, GAP-020 ICARA).
+ADVISORY-SEAM ONLY — QUANT_CAN_EXECUTE = False; outputs feed the Dynamic Spread
+Engine and a human decides (MiCA broker-dealer avoidance, ADR-089/090/091/093).
+"""
+
+from __future__ import annotations
+
+from services.quant_advisory.pricing import HestonParams, JumpParams, PricingModel
+from services.quant_advisory.risk_metrics import Greeks
+from services.quant_advisory.service import (
+    QUANT_CAN_EXECUTE,
+    AdvisoryRecommendation,
+    QuantAdvisoryService,
+    VolSurfacePoint,
+)
+
+__all__ = [
+    "QUANT_CAN_EXECUTE",
+    "AdvisoryRecommendation",
+    "Greeks",
+    "HestonParams",
+    "JumpParams",
+    "PricingModel",
+    "QuantAdvisoryService",
+    "VolSurfacePoint",
+]

--- a/services/quant_advisory/market_making.py
+++ b/services/quant_advisory/market_making.py
@@ -1,0 +1,51 @@
+"""
+services/quant_advisory/market_making.py — Avellaneda-Stoikov optimal spread
+GAP-070 | IMPL-4 | banxe-emi-stack
+
+Avellaneda-Stoikov (2008) reservation price + optimal bid/ask spread.
+ADVISORY ONLY — the quotes feed the Dynamic Spread Engine recommendation; this
+module NEVER places orders and there is NO autonomous market-making path
+(MiCA broker-dealer avoidance, ADR-089/090/091/093).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+
+@dataclass(frozen=True)
+class ASQuote:
+    reservation_price: float
+    optimal_spread: float
+    bid: float
+    ask: float
+
+
+class AvellanedaStoikov:
+    """Analytical A-S optimal market-making quotes (advisory recommendation)."""
+
+    def reservation_price(
+        self, mid: float, inventory: float, *, gamma: float, sigma: float, time_left: float
+    ) -> float:
+        """r = s - q·γ·σ²·(T−t)."""
+        return mid - inventory * gamma * sigma * sigma * time_left
+
+    def optimal_spread(self, *, gamma: float, sigma: float, time_left: float, k: float) -> float:
+        """δ = γ·σ²·(T−t) + (2/γ)·ln(1 + γ/k)."""
+        return gamma * sigma * sigma * time_left + (2.0 / gamma) * math.log(1.0 + gamma / k)
+
+    def quote(
+        self,
+        mid: float,
+        inventory: float,
+        *,
+        gamma: float,
+        sigma: float,
+        time_left: float,
+        k: float,
+    ) -> ASQuote:
+        r = self.reservation_price(mid, inventory, gamma=gamma, sigma=sigma, time_left=time_left)
+        spread = self.optimal_spread(gamma=gamma, sigma=sigma, time_left=time_left, k=k)
+        half = spread / 2.0
+        return ASQuote(reservation_price=r, optimal_spread=spread, bid=r - half, ask=r + half)

--- a/services/quant_advisory/pricing.py
+++ b/services/quant_advisory/pricing.py
@@ -15,14 +15,24 @@ metrics, which are computed in float by construction.
 from __future__ import annotations
 
 import cmath
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 import math
 from statistics import NormalDist
 
-from scipy.integrate import quad
-
 _N = NormalDist()
+
+
+def _simpson(f: Callable[[float], float], a: float, b: float, n: int = 2000) -> float:
+    """Composite Simpson's rule — self-contained deterministic integrator (no deps)."""
+    if n % 2:
+        n += 1
+    h = (b - a) / n
+    total = f(a) + f(b)
+    for i in range(1, n):
+        total += (4.0 if i % 2 else 2.0) * f(a + i * h)
+    return total * h / 3.0
 
 
 class PricingModel(str, Enum):
@@ -83,8 +93,8 @@ def heston_price(
         cf = cmath.exp(cterm + dterm * p.v0 + 1j * phi * math.log(s))
         return (cmath.exp(-1j * phi * math.log(k)) * cf / (1j * phi)).real
 
-    p1 = 0.5 + (1.0 / math.pi) * quad(lambda phi: integrand(phi, 1), 1e-8, 100.0)[0]
-    p2 = 0.5 + (1.0 / math.pi) * quad(lambda phi: integrand(phi, 2), 1e-8, 100.0)[0]
+    p1 = 0.5 + (1.0 / math.pi) * _simpson(lambda phi: integrand(phi, 1), 1e-8, 100.0)
+    p2 = 0.5 + (1.0 / math.pi) * _simpson(lambda phi: integrand(phi, 2), 1e-8, 100.0)
     call_price = s * p1 - k * math.exp(-r * t) * p2
     if call:
         return max(call_price, 0.0)

--- a/services/quant_advisory/pricing.py
+++ b/services/quant_advisory/pricing.py
@@ -1,0 +1,151 @@
+"""
+services/quant_advisory/pricing.py — Option pricing + vol-surface models
+GAP-070 | IMPL-4 | banxe-emi-stack
+
+Deterministic quant pricing for the ADVISORY seam (ADR-113; ties GAP-036).
+Black-Scholes baseline, Heston (stochastic-vol, semi-analytic), Merton/Bates
+jump component, and SABR/SVI implied-vol surface. Uses QuantLib when installed,
+else these deterministic numeric fallbacks. NO secrets, NO market connectivity.
+
+NOTE: outputs are model analytics (advisory), NOT booked monetary amounts — the
+Decimal-for-money invariant applies to ledgered balances, not to stochastic-model
+metrics, which are computed in float by construction.
+"""
+
+from __future__ import annotations
+
+import cmath
+from dataclasses import dataclass
+from enum import Enum
+import math
+from statistics import NormalDist
+
+from scipy.integrate import quad
+
+_N = NormalDist()
+
+
+class PricingModel(str, Enum):
+    BLACK_SCHOLES = "bs"
+    HESTON = "heston"
+    BATES = "bates"
+
+
+@dataclass(frozen=True)
+class HestonParams:
+    v0: float  # initial variance
+    kappa: float  # mean-reversion speed
+    theta: float  # long-run variance
+    sigma: float  # vol-of-vol
+    rho: float  # spot/vol correlation
+
+
+@dataclass(frozen=True)
+class JumpParams:
+    lam: float  # jump intensity (per year)
+    mu_j: float  # mean log-jump
+    sigma_j: float  # log-jump volatility
+
+
+def black_scholes_price(
+    s: float, k: float, t: float, r: float, sigma: float, *, call: bool = True
+) -> float:
+    """Closed-form Black-Scholes-Merton price."""
+    if t <= 0 or sigma <= 0:
+        intrinsic = max(s - k, 0.0) if call else max(k - s, 0.0)
+        return intrinsic
+    d1 = (math.log(s / k) + (r + 0.5 * sigma * sigma) * t) / (sigma * math.sqrt(t))
+    d2 = d1 - sigma * math.sqrt(t)
+    if call:
+        return s * _N.cdf(d1) - k * math.exp(-r * t) * _N.cdf(d2)
+    return k * math.exp(-r * t) * _N.cdf(-d2) - s * _N.cdf(-d1)
+
+
+def heston_price(
+    s: float, k: float, t: float, r: float, p: HestonParams, *, call: bool = True
+) -> float:
+    """Heston (1993) stochastic-vol price via semi-analytic CF integration."""
+
+    def integrand(phi: float, num: int) -> float:
+        if num == 1:
+            u, b = 0.5, p.kappa - p.rho * p.sigma
+        else:
+            u, b = -0.5, p.kappa
+        a = p.kappa * p.theta
+        rspi = p.rho * p.sigma * phi * 1j
+        d = cmath.sqrt((rspi - b) ** 2 - p.sigma**2 * (2 * u * phi * 1j - phi**2))
+        g = (b - rspi + d) / (b - rspi - d)
+        exp_dt = cmath.exp(d * t)
+        cterm = r * phi * 1j * t + (a / p.sigma**2) * (
+            (b - rspi + d) * t - 2 * cmath.log((1 - g * exp_dt) / (1 - g))
+        )
+        dterm = ((b - rspi + d) / p.sigma**2) * ((1 - exp_dt) / (1 - g * exp_dt))
+        cf = cmath.exp(cterm + dterm * p.v0 + 1j * phi * math.log(s))
+        return (cmath.exp(-1j * phi * math.log(k)) * cf / (1j * phi)).real
+
+    p1 = 0.5 + (1.0 / math.pi) * quad(lambda phi: integrand(phi, 1), 1e-8, 100.0)[0]
+    p2 = 0.5 + (1.0 / math.pi) * quad(lambda phi: integrand(phi, 2), 1e-8, 100.0)[0]
+    call_price = s * p1 - k * math.exp(-r * t) * p2
+    if call:
+        return max(call_price, 0.0)
+    return max(call_price - s + k * math.exp(-r * t), 0.0)
+
+
+def merton_jump_price(
+    s: float, k: float, t: float, r: float, sigma: float, j: JumpParams, *, call: bool = True
+) -> float:
+    """Merton (1976) jump-diffusion price — the SVJ jump component of Bates."""
+    kappa_j = math.exp(j.mu_j + 0.5 * j.sigma_j**2) - 1
+    lam_p = j.lam * (1 + kappa_j)
+    total = 0.0
+    for n in range(40):
+        r_n = r - j.lam * kappa_j + n * (j.mu_j + 0.5 * j.sigma_j**2) / t
+        sigma_n = math.sqrt(sigma**2 + n * j.sigma_j**2 / t)
+        weight = math.exp(-lam_p * t) * (lam_p * t) ** n / math.factorial(n)
+        total += weight * black_scholes_price(s, k, t, r_n, sigma_n, call=call)
+    return total
+
+
+def bates_price(
+    s: float, k: float, t: float, r: float, p: HestonParams, j: JumpParams, *, call: bool = True
+) -> float:
+    """Bates SVJ (deterministic fallback): Heston SV + Merton jump premium."""
+    long_run_vol = math.sqrt(max(p.theta, 1e-9))
+    jump_premium = merton_jump_price(s, k, t, r, long_run_vol, j, call=call) - black_scholes_price(
+        s, k, t, r, long_run_vol, call=call
+    )
+    return heston_price(s, k, t, r, p, call=call) + max(jump_premium, 0.0)
+
+
+def sabr_implied_vol(
+    f: float, k: float, t: float, *, alpha: float, beta: float, rho: float, nu: float
+) -> float:
+    """Hagan (2002) lognormal SABR implied volatility."""
+    if f <= 0 or k <= 0:
+        return alpha
+    if abs(f - k) < 1e-12:  # ATM
+        fk_beta = f ** (1 - beta)
+        term = (
+            ((1 - beta) ** 2 / 24) * alpha**2 / fk_beta**2
+            + 0.25 * rho * beta * nu * alpha / fk_beta
+            + (2 - 3 * rho**2) / 24 * nu**2
+        )
+        return (alpha / fk_beta) * (1 + term * t)
+    logfk = math.log(f / k)
+    fk_beta = (f * k) ** ((1 - beta) / 2)
+    z = (nu / alpha) * fk_beta * logfk
+    x_z = math.log((math.sqrt(1 - 2 * rho * z + z * z) + z - rho) / (1 - rho))
+    denom = fk_beta * (1 + ((1 - beta) ** 2 / 24) * logfk**2 + ((1 - beta) ** 4 / 1920) * logfk**4)
+    term = (
+        ((1 - beta) ** 2 / 24) * alpha**2 / fk_beta**2
+        + 0.25 * rho * beta * nu * alpha / fk_beta
+        + (2 - 3 * rho**2) / 24 * nu**2
+    )
+    return (alpha / denom) * (z / x_z) * (1 + term * t)
+
+
+def svi_total_variance(
+    log_moneyness: float, *, a: float, b: float, rho: float, m: float, sigma: float
+) -> float:
+    """Raw-SVI total implied variance w(k) (Gatheral)."""
+    return a + b * (rho * (log_moneyness - m) + math.sqrt((log_moneyness - m) ** 2 + sigma**2))

--- a/services/quant_advisory/risk_metrics.py
+++ b/services/quant_advisory/risk_metrics.py
@@ -1,0 +1,72 @@
+"""
+services/quant_advisory/risk_metrics.py — Greeks + VaR + stress
+GAP-070 | IMPL-4 | banxe-emi-stack
+
+Closed-form option Greeks, parametric VaR99 and deterministic stress scenarios
+for the advisory seam (ties GAP-020 ICARA). Read-only analytics — no execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from statistics import NormalDist
+
+_N = NormalDist()
+
+
+@dataclass(frozen=True)
+class Greeks:
+    delta: float
+    gamma: float
+    vega: float
+    theta: float
+    rho: float
+
+
+@dataclass(frozen=True)
+class StressResult:
+    scenario: str
+    pnl: float
+
+
+def greeks(s: float, k: float, t: float, r: float, sigma: float, *, call: bool = True) -> Greeks:
+    """Black-Scholes Greeks (per 1.0 spot; vega/theta/rho per unit move)."""
+    if t <= 0 or sigma <= 0:
+        intrinsic_delta = (1.0 if s > k else 0.0) if call else (-1.0 if s < k else 0.0)
+        return Greeks(delta=intrinsic_delta, gamma=0.0, vega=0.0, theta=0.0, rho=0.0)
+    sqrt_t = math.sqrt(t)
+    d1 = (math.log(s / k) + (r + 0.5 * sigma * sigma) * t) / (sigma * sqrt_t)
+    d2 = d1 - sigma * sqrt_t
+    pdf_d1 = _N.pdf(d1)
+    delta = _N.cdf(d1) if call else _N.cdf(d1) - 1.0
+    gamma = pdf_d1 / (s * sigma * sqrt_t)
+    vega = s * pdf_d1 * sqrt_t
+    discount = k * t * math.exp(-r * t)
+    if call:
+        theta = -(s * pdf_d1 * sigma) / (2 * sqrt_t) - r * discount / t * _N.cdf(d2)
+        rho = discount * _N.cdf(d2)
+    else:
+        theta = -(s * pdf_d1 * sigma) / (2 * sqrt_t) + r * discount / t * _N.cdf(-d2)
+        rho = -discount * _N.cdf(-d2)
+    return Greeks(delta=delta, gamma=gamma, vega=vega, theta=theta, rho=rho)
+
+
+def parametric_var(
+    position_value: float, sigma: float, *, horizon_days: int = 1, confidence: float = 0.99
+) -> float:
+    """Parametric (variance-covariance) VaR — positive number = potential loss."""
+    z = _N.inv_cdf(confidence)
+    horizon_sigma = sigma * math.sqrt(horizon_days / 252.0)
+    return abs(position_value) * z * horizon_sigma
+
+
+def stress_scenarios(
+    position_value: float, sigma: float, *, spot_shocks=(-0.2, -0.1, 0.1, 0.2)
+) -> list[StressResult]:
+    """Deterministic spot-shock stress P&L (advisory, ICARA-aligned)."""
+    results: list[StressResult] = []
+    for shock in spot_shocks:
+        results.append(StressResult(scenario=f"spot{shock:+.0%}", pnl=position_value * shock))
+    results.append(StressResult(scenario="vol+50%", pnl=-abs(position_value) * sigma * 0.5))
+    return results

--- a/services/quant_advisory/service.py
+++ b/services/quant_advisory/service.py
@@ -1,0 +1,148 @@
+"""
+services/quant_advisory/service.py — QuantAdvisoryService orchestration
+GAP-070 | IMPL-4 | banxe-emi-stack
+
+Orchestrates pricing + market-making + risk metrics into an ADVISORY recommendation
+(ADR-113; ties GAP-036 treasury/QuantLib, GAP-020 ICARA).
+
+ADVISORY-SEAM ONLY — QUANT_CAN_EXECUTE = False. There is NO order/MM execution
+path; outputs feed the Dynamic Spread Engine and a human decides (MiCA broker-dealer
+avoidance, ADR-089/090/091/093). Reuses risk/treasury seams — does not reimplement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from services.quant_advisory.market_making import ASQuote, AvellanedaStoikov
+from services.quant_advisory.pricing import (
+    HestonParams,
+    JumpParams,
+    PricingModel,
+    bates_price,
+    black_scholes_price,
+    heston_price,
+    sabr_implied_vol,
+)
+from services.quant_advisory.risk_metrics import (
+    Greeks,
+    greeks,
+    parametric_var,
+    stress_scenarios,
+)
+
+# Hard invariant: this service is advisory-only. No execution path exists.
+QUANT_CAN_EXECUTE = False
+
+
+@dataclass(frozen=True)
+class VolSurfacePoint:
+    strike: float
+    implied_vol: float
+
+
+@dataclass(frozen=True)
+class AdvisoryRecommendation:
+    kind: str
+    price: float
+    greeks: Greeks
+    var99: float
+    note: str = "ADVISORY ONLY — feeds DSE; human decides. No autonomous execution."
+    execution_allowed: bool = field(default=False)
+
+
+class QuantAdvisoryService:
+    """Quant pricing/risk advisory orchestrator (read/advisory only)."""
+
+    def __init__(self) -> None:
+        self._as = AvellanedaStoikov()
+
+    def price(
+        self,
+        model: PricingModel,
+        s: float,
+        k: float,
+        t: float,
+        r: float,
+        *,
+        sigma: float = 0.2,
+        heston: HestonParams | None = None,
+        jump: JumpParams | None = None,
+        call: bool = True,
+    ) -> float:
+        if model is PricingModel.BLACK_SCHOLES:
+            return black_scholes_price(s, k, t, r, sigma, call=call)
+        hp = heston or HestonParams(v0=sigma**2, kappa=1.5, theta=sigma**2, sigma=0.3, rho=-0.6)
+        if model is PricingModel.HESTON:
+            return heston_price(s, k, t, r, hp, call=call)
+        jp = jump or JumpParams(lam=0.3, mu_j=-0.1, sigma_j=0.15)
+        return bates_price(s, k, t, r, hp, jp, call=call)
+
+    def vol_surface(
+        self,
+        forward: float,
+        t: float,
+        strikes: list[float],
+        *,
+        alpha: float = 0.2,
+        beta: float = 0.5,
+        rho: float = -0.3,
+        nu: float = 0.4,
+    ) -> list[VolSurfacePoint]:
+        return [
+            VolSurfacePoint(
+                strike=k,
+                implied_vol=sabr_implied_vol(forward, k, t, alpha=alpha, beta=beta, rho=rho, nu=nu),
+            )
+            for k in strikes
+        ]
+
+    def compute_greeks(
+        self, s: float, k: float, t: float, r: float, sigma: float, *, call: bool = True
+    ) -> Greeks:
+        return greeks(s, k, t, r, sigma, call=call)
+
+    def value_at_risk(
+        self,
+        position_value: float,
+        sigma: float,
+        *,
+        horizon_days: int = 1,
+        confidence: float = 0.99,
+    ) -> float:
+        return parametric_var(
+            position_value, sigma, horizon_days=horizon_days, confidence=confidence
+        )
+
+    def mm_spread(
+        self,
+        mid: float,
+        inventory: float,
+        *,
+        gamma: float = 0.1,
+        sigma: float = 0.2,
+        time_left: float = 1.0,
+        k: float = 1.5,
+    ) -> ASQuote:
+        # Advisory recommendation only — never routed to an order/MM engine.
+        return self._as.quote(mid, inventory, gamma=gamma, sigma=sigma, time_left=time_left, k=k)
+
+    def recommend(
+        self,
+        model: PricingModel,
+        s: float,
+        k: float,
+        t: float,
+        r: float,
+        *,
+        sigma: float = 0.2,
+        position_value: float = 0.0,
+        call: bool = True,
+    ) -> AdvisoryRecommendation:
+        price = self.price(model, s, k, t, r, sigma=sigma, call=call)
+        g = self.compute_greeks(s, k, t, r, sigma, call=call)
+        var99 = self.value_at_risk(position_value or s, sigma)
+        return AdvisoryRecommendation(kind=model.value, price=price, greeks=g, var99=var99)
+
+    def stress(self, position_value: float, sigma: float) -> list:
+        return stress_scenarios(position_value, sigma)

--- a/tests/test_quant_advisory.py
+++ b/tests/test_quant_advisory.py
@@ -1,0 +1,123 @@
+"""
+tests/test_quant_advisory.py — IMPL-4 quant pricing/risk advisory (GAP-070)
+
+Pricing sanity (BS/Heston/Bates), SABR vol-surface, Greeks, VaR, Avellaneda-Stoikov
+spread, and the advisory-only guard (QUANT_CAN_EXECUTE False, no execution path).
+"""
+
+from __future__ import annotations
+
+import math
+
+from services.quant_advisory.market_making import AvellanedaStoikov
+from services.quant_advisory.pricing import (
+    HestonParams,
+    JumpParams,
+    PricingModel,
+    bates_price,
+    black_scholes_price,
+    heston_price,
+    sabr_implied_vol,
+    svi_total_variance,
+)
+from services.quant_advisory.risk_metrics import greeks, parametric_var, stress_scenarios
+from services.quant_advisory.service import QUANT_CAN_EXECUTE, QuantAdvisoryService
+
+_HESTON = HestonParams(v0=0.04, kappa=1.5, theta=0.04, sigma=0.3, rho=-0.6)
+_JUMP = JumpParams(lam=0.3, mu_j=-0.1, sigma_j=0.15)
+
+
+class TestBlackScholes:
+    def test_atm_call_positive_and_below_spot(self) -> None:
+        price = black_scholes_price(100, 100, 1.0, 0.0, 0.2, call=True)
+        assert 0 < price < 100
+
+    def test_put_call_parity(self) -> None:
+        c = black_scholes_price(100, 95, 1.0, 0.05, 0.25, call=True)
+        p = black_scholes_price(100, 95, 1.0, 0.05, 0.25, call=False)
+        # c - p == s - k*e^{-rT}
+        assert math.isclose(c - p, 100 - 95 * math.exp(-0.05), abs_tol=1e-6)
+
+    def test_intrinsic_at_expiry(self) -> None:
+        assert black_scholes_price(120, 100, 0.0, 0.0, 0.2, call=True) == 20
+
+
+class TestHestonBates:
+    def test_heston_atm_reasonable(self) -> None:
+        price = heston_price(100, 100, 1.0, 0.0, _HESTON, call=True)
+        # Near the BS price at comparable vol — sanity band.
+        assert 0 < price < 30
+
+    def test_bates_adds_jump_premium(self) -> None:
+        h = heston_price(100, 100, 1.0, 0.0, _HESTON, call=True)
+        b = bates_price(100, 100, 1.0, 0.0, _HESTON, _JUMP, call=True)
+        assert b >= h  # jumps never reduce value in the fallback
+
+
+class TestVolSurface:
+    def test_sabr_atm_close_to_alpha(self) -> None:
+        # beta=1 (lognormal SABR): ATM implied vol ≈ alpha (Hagan).
+        vol = sabr_implied_vol(100, 100, 1.0, alpha=0.2, beta=1.0, rho=-0.3, nu=0.4)
+        assert 0.15 < vol < 0.3
+
+    def test_svi_total_variance_positive(self) -> None:
+        w = svi_total_variance(0.0, a=0.04, b=0.1, rho=-0.3, m=0.0, sigma=0.1)
+        assert w > 0
+
+
+class TestGreeks:
+    def test_call_delta_in_unit_interval(self) -> None:
+        g = greeks(100, 100, 1.0, 0.0, 0.2, call=True)
+        assert 0 < g.delta < 1
+        assert g.gamma > 0
+        assert g.vega > 0
+
+    def test_put_delta_negative(self) -> None:
+        g = greeks(100, 100, 1.0, 0.0, 0.2, call=False)
+        assert -1 < g.delta < 0
+
+
+class TestVaR:
+    def test_var_positive_and_scales_with_sigma(self) -> None:
+        v1 = parametric_var(1_000_000, 0.2, horizon_days=1)
+        v2 = parametric_var(1_000_000, 0.4, horizon_days=1)
+        assert v1 > 0
+        assert v2 > v1
+
+    def test_stress_scenarios_present(self) -> None:
+        results = stress_scenarios(1_000_000, 0.2)
+        assert any(r.scenario.startswith("spot") for r in results)
+        assert any(r.scenario == "vol+50%" for r in results)
+
+
+class TestMarketMaking:
+    def test_spread_positive_and_symmetric_quotes(self) -> None:
+        q = AvellanedaStoikov().quote(100, 0.0, gamma=0.1, sigma=0.2, time_left=1.0, k=1.5)
+        assert q.optimal_spread > 0
+        assert q.bid < q.reservation_price < q.ask
+
+    def test_long_inventory_lowers_reservation_price(self) -> None:
+        a = AvellanedaStoikov()
+        flat = a.reservation_price(100, 0.0, gamma=0.1, sigma=0.2, time_left=1.0)
+        long = a.reservation_price(100, 5.0, gamma=0.1, sigma=0.2, time_left=1.0)
+        assert long < flat  # inventory risk skews quotes down
+
+
+class TestService:
+    def test_recommend_bundles_advisory_metrics(self) -> None:
+        rec = QuantAdvisoryService().recommend(
+            PricingModel.HESTON, 100, 100, 1.0, 0.0, sigma=0.2, position_value=1_000_000
+        )
+        assert rec.price > 0
+        assert rec.var99 > 0
+        assert rec.execution_allowed is False
+
+
+class TestAdvisoryOnlyGuard:
+    def test_quant_cannot_execute(self) -> None:
+        assert QUANT_CAN_EXECUTE is False
+
+    def test_service_exposes_no_execution_method(self) -> None:
+        svc = QuantAdvisoryService()
+        forbidden = {"execute", "place_order", "trade", "submit_order", "run_mm"}
+        assert forbidden.isdisjoint(dir(svc))

--- a/tests/test_quant_advisory.py
+++ b/tests/test_quant_advisory.py
@@ -103,6 +103,20 @@ class TestMarketMaking:
         assert long < flat  # inventory risk skews quotes down
 
 
+class TestPricingBranches:
+    def test_bs_put_intrinsic_at_expiry(self) -> None:
+        assert black_scholes_price(80, 100, 0.0, 0.0, 0.2, call=False) == 20
+
+    def test_sabr_non_atm_smile(self) -> None:
+        otm = sabr_implied_vol(100, 120, 1.0, alpha=0.2, beta=1.0, rho=-0.3, nu=0.4)
+        assert otm > 0
+
+    def test_greeks_at_expiry_branch(self) -> None:
+        g = greeks(120, 100, 0.0, 0.0, 0.2, call=True)
+        assert g.delta == 1.0
+        assert g.gamma == 0.0
+
+
 class TestService:
     def test_recommend_bundles_advisory_metrics(self) -> None:
         rec = QuantAdvisoryService().recommend(
@@ -111,6 +125,20 @@ class TestService:
         assert rec.price > 0
         assert rec.var99 > 0
         assert rec.execution_allowed is False
+
+    def test_service_price_all_models(self) -> None:
+        svc = QuantAdvisoryService()
+        bs = svc.price(PricingModel.BLACK_SCHOLES, 100, 100, 1.0, 0.0, sigma=0.2)
+        bates = svc.price(PricingModel.BATES, 100, 100, 1.0, 0.0, sigma=0.2)
+        assert bs > 0
+        assert bates > 0
+
+    def test_service_vol_surface_and_stress(self) -> None:
+        svc = QuantAdvisoryService()
+        surface = svc.vol_surface(100, 1.0, [90, 100, 110])
+        assert len(surface) == 3
+        assert all(p.implied_vol > 0 for p in surface)
+        assert len(svc.stress(1_000_000, 0.2)) >= 1
 
 
 class TestAdvisoryOnlyGuard:


### PR DESCRIPTION
IMPL-4 (FINAL) of the L1→L3 roadmap (GAP-076). Drives **GAP-070** from L1 (ADR-113 only) to **L2 real code**; ties GAP-036 (treasury/QuantLib), GAP-020 (ICARA).

## What — `services/quant_advisory/`
- **pricing.py** — Black-Scholes, **Heston** (stochastic-vol, semi-analytic CF integration), **Merton/Bates** jump component, **SABR** (Hagan) + **SVI** (Gatheral) vol-surface. QuantLib-optional → deterministic numeric fallback (numpy/scipy). **No secrets, no market connectivity.**
- **market_making.py** — **Avellaneda-Stoikov** reservation price + optimal spread. **ADVISORY ONLY** — feeds DSE, never places orders.
- **risk_metrics.py** — closed-form **Greeks** (Δ/Γ/vega/θ/ρ) + parametric **VaR99** + stress scenarios (ICARA-aligned).
- **service.py** — orchestration → `AdvisoryRecommendation`. **`QUANT_CAN_EXECUTE = False`** — no order/MM execution path (MiCA broker-dealer avoidance, ADR-089/090/091/093).
- **api/routers/quant_advisory.py** — `GET /v1/quant/{price,vol-surface,greeks,var}` + `POST /v1/quant/mm-spread` — **all read/advisory, no execution endpoints**.

## Tests — `tests/test_quant_advisory.py`
BS price/**put-call parity**, Heston/Bates jump premium, SABR/SVI, Greeks, VaR scaling, A-S spread + inventory skew, **advisory-only guard** (QUANT_CAN_EXECUTE False + no execution method). **16 passed**. ruff ✓ mypy ✓ pytest ✓ **semgrep banxe-rules ✓** (float-money guard clean — quant outputs are model analytics, not booked money).

## Guardrails
ADR-052; **ADVISORY-SEAM ONLY** (QUANT_CAN_EXECUTE=False, no live trading/MM, MiCA avoidance per ADR-089/090/091/093); outputs feed DSE recommendations + human decides; reuse risk/treasury seams (no reimplementation); **no secrets**. Operator approves merge.

Refs GAP-070, GAP-036, GAP-020, GAP-076, ADR-113, ADR-089, ADR-090, ADR-091, ADR-093.