### PR TITLE
feat(open-banking): MIG-M2.4-INT integration wiring (advisory, no live initiation, no merge) [MIG-M2.4-INT]

### DIFF
--- a/services/open_banking/m24_int_bridge.py
+++ b/services/open_banking/m24_int_bridge.py
@@ -1,0 +1,107 @@
+"""services/open_banking/m24_int_bridge.py — MIG-M2.4-INT open-banking integration bridge.
+
+Advisory, additive integration seam wiring the existing open-banking PISP/AISP surface to:
+  - the **payments engine contract** (MIG-M2.1 ``PaymentEnginePort``, which lives in banxe-payment-core
+    — a DIFFERENT repo). We therefore mirror its intent contract here as a local Protocol
+    (``PaymentEngineContract``) and map a PISP ``PaymentInitiation`` to an M2.1-shaped intent ref.
+    This is **contract-level** consumption — NO cross-repo import, NO live engine call.
+  - the **accounts SoT** (MIG-M2.2 ``api/models/account_sot.py``, same repo) — a **balance-free**
+    account-ref projection. Balances are NOT sourced here (no live funds-confirmation against live
+    balances; the existing ``InMemoryAccountData`` / live balance path is untouched).
+
+Does NOT modify the live FCA PISP/AISP services, does NOT call Midaz LedgerPort, does NOT touch the
+KYC/KYB/AML carve-out (pending I-27 sign-off). Advisory / read-only. I-05: amount_minor int (never
+float); I-01: amounts as Decimal upstream.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Protocol, runtime_checkable
+
+from api.models.account_sot import SandboxAccountSoT
+
+SANDBOX_SOURCE = "sandbox-mock"
+
+# ISO 4217 minor-unit exponents (config-as-data; default 2dp).
+_MINOR_UNITS: dict[str, int] = {"EUR": 2, "GBP": 2, "USD": 2, "CHF": 2}
+
+
+def to_minor_units(amount: Decimal, currency: str) -> int:
+    """Convert a Decimal amount to integer minor units (I-05; never float)."""
+    if not isinstance(amount, Decimal):  # I-01: Decimal upstream only
+        raise TypeError("amount must be Decimal")
+    dp = _MINOR_UNITS.get(currency.upper(), 2)
+    scaled = (amount * (Decimal(10) ** dp)).to_integral_value(rounding=ROUND_HALF_UP)
+    return int(scaled)
+
+
+@dataclass(frozen=True)
+class PaymentIntentRef:
+    """M2.1-aligned advisory payment-intent ref (mirrors banxe-payment-core PaymentIntent shape).
+
+    amount_minor: int minor units (I-05). account refs are projections — no balance.
+    """
+
+    idempotency_key: str
+    debtor_account_ref: str
+    creditor_account_ref: str
+    amount_minor: int
+    currency: str
+    source: str = SANDBOX_SOURCE
+
+
+@runtime_checkable
+class PaymentEngineContract(Protocol):
+    """Local mirror of the MIG-M2.1 PaymentEnginePort.create_intent contract (no cross-repo import).
+
+    A prod wiring would supply a real client implementing this Protocol against banxe-payment-core;
+    here it is contract-level only (advisory; no live execution).
+    """
+
+    def create_intent(
+        self,
+        *,
+        idempotency_key: str,
+        debtor_account_ref: str,
+        creditor_account_ref: str,
+        amount_minor: int,
+        currency: str,
+    ) -> object: ...
+
+
+class AccountSoTProjection:
+    """Balance-free account-ref projection over the accounts SoT (MIG-M2.2). No balances, no Midaz."""
+
+    def __init__(self) -> None:
+        self._sot = SandboxAccountSoT()
+
+    def account_refs(self) -> list[str]:
+        """Return account-type refs from the accounts SoT (descriptive; no balance)."""
+        return [a.account_type for a in self._sot.list_account_metadata()]
+
+    def is_known_ref(self, account_ref: str) -> bool:
+        return account_ref in set(self.account_refs())
+
+
+def pisp_to_engine_intent(
+    *,
+    idempotency_key: str,
+    debtor_account_ref: str,
+    creditor_account_ref: str,
+    amount: Decimal,
+    currency: str,
+) -> PaymentIntentRef:
+    """Map a PISP initiation to an M2.1-shaped advisory intent ref (contract-level; no live call).
+
+    Amount (Decimal, I-01) -> minor units (int, I-05). Projection over accounts SoT by ref (no balance).
+    """
+    return PaymentIntentRef(
+        idempotency_key=idempotency_key,
+        debtor_account_ref=debtor_account_ref,
+        creditor_account_ref=creditor_account_ref,
+        amount_minor=to_minor_units(amount, currency),
+        currency=currency,
+        source=SANDBOX_SOURCE,
+    )

--- a/tests/test_open_banking_int.py
+++ b/tests/test_open_banking_int.py
@@ -1,0 +1,67 @@
+"""MIG-M2.4-INT — open-banking integration bridge (advisory, no live initiation, KYC carve-out intact).
+
+contract: PISP -> M2.1-shaped PaymentIntentRef (amount_minor int I-05; account refs; idempotency).
+characterization: AccountSoTProjection returns balance-free account refs (M2.2). fence: bridge imports
+no Midaz/ledger/kyc; amount_minor int (no float); no live funds-confirmation.
+"""
+
+from dataclasses import fields
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from services.open_banking.m24_int_bridge import (
+    AccountSoTProjection,
+    PaymentEngineContract,
+    PaymentIntentRef,
+    pisp_to_engine_intent,
+    to_minor_units,
+)
+
+_BALANCE_FIELDS = {"balance", "available", "ledger_balance", "balance_minor", "amount"}
+
+
+def test_pisp_to_engine_intent_contract_shape() -> None:
+    ref = pisp_to_engine_intent(
+        idempotency_key="k1",
+        debtor_account_ref="INTERNAL",
+        creditor_account_ref="EXTERNAL",
+        amount=Decimal("15.00"),
+        currency="EUR",
+    )
+    assert isinstance(ref, PaymentIntentRef)
+    assert ref.amount_minor == 1500 and isinstance(ref.amount_minor, int)  # I-05 minor units
+    assert ref.debtor_account_ref == "INTERNAL" and ref.currency == "EUR"
+    # M2.1-aligned shape (no balance fields)
+    assert _BALANCE_FIELDS.isdisjoint({f.name for f in fields(PaymentIntentRef)} - {"amount_minor"})
+
+
+def test_to_minor_units_decimal_only_i05() -> None:
+    assert to_minor_units(Decimal("1.005"), "EUR") == 101  # ROUND_HALF_UP, int
+    with pytest.raises(TypeError):
+        to_minor_units(1.5, "EUR")  # float rejected (I-01/I-05)
+
+
+def test_account_sot_projection_balance_free() -> None:
+    proj = AccountSoTProjection()
+    refs = proj.account_refs()
+    assert "INTERNAL" in refs and proj.is_known_ref("INTERNAL")
+    assert proj.is_known_ref("NOPE") is False
+
+
+def test_payment_engine_contract_is_protocol() -> None:
+    # contract-level mirror of M2.1 PaymentEnginePort (no cross-repo import)
+    assert hasattr(PaymentEngineContract, "create_intent")
+
+
+def test_fence_no_midaz_ledger_kyc_imports() -> None:
+    import services.open_banking.m24_int_bridge as mod
+
+    import_lines = "\n".join(
+        ln
+        for ln in Path(mod.__file__).read_text().splitlines()
+        if ln.strip().startswith(("import ", "from "))
+    ).lower()
+    for bad in ("midaz", "ledger_port", "ledger", "kyc", "kyb", "sumsub", "httpx", "requests"):
+        assert bad not in import_lines, f"forbidden import token: {bad}"


### PR DESCRIPTION
## MIG-M2.4-INT — open-banking integration wiring (advisory, no live initiation, no merge) [MIG-M2.4-INT]

> **M2 follow-up — open-banking integration.** Server-side origin (evo1, isolated worktree). **Advisory, ADDITIVE bridge** wiring open-banking to M2.1/M2.2 **without modifying the live FCA PISP/AISP services.** **KYC/KYB/AML carve-out NOT touched (pending I-27).** **Do NOT auto-merge** (CI-gated + operator-gated).

### Scope (additive bridge — `services/open_banking/m24_int_bridge.py`)
- **`PaymentEngineContract`** (Protocol) — local mirror of MIG-M2.1 `PaymentEnginePort.create_intent`. **banxe-payment-core is a different repo → contract-level consumption, NO cross-repo import, NO live engine call.**
- **`pisp_to_engine_intent()` + `PaymentIntentRef`** — map a PISP initiation → M2.1-shaped intent ref; amount `Decimal` (I-01) → **minor units `int` (I-05)**, never float.
- **`AccountSoTProjection`** — **balance-free** account-ref projection over accounts SoT (MIG-M2.2, same repo); **no balances** (no live funds-confirmation; `InMemoryAccountData`/live path untouched).

### Wiring status
- **PISP → PaymentEngine:** contract-level (Protocol mirror) — cross-repo, so a prod client implementing the Protocol against banxe-payment-core is the future live wiring; here advisory only.
- **AISP/accounts → accounts SoT (M2.2):** balance-free `account_ref` projection (same repo) — wired.
- **Mount `psd2_gateway` / `consent_management`:** **DEFERRED.** These are regulated surfaces and there is **no governance sign-off** to expose them → left unmounted, documented (not self-exposed). `api/main.py` UNCHANGED.

### Duplication Audit (ADR-102)
Integration, **not a new surface.** open-banking remains a **single bounded context** (the existing `services/open_banking/*` + routers). The bridge **consumes** M2.1 (contract) + M2.2 (projection); it does not duplicate accounts/payments/ledger. Live PISP/AISP services UNCHANGED. KYC carve-out intact.

### Hard boundaries (verified)
No live initiation/execution; funds-confirmation descriptive/sandbox; **Midaz LedgerPort not called**; **KYC/KYB/AML carve-out not touched** (pending I-27 HITL-L4); I-01 Decimal upstream / I-05 int minor units. Diff = 2 files (bridge + test); **0 regulated/live files** (`pisp_service`/`aisp_service`/`main.py`/`ledger.py`/`kyc.py`/`consent_management`/`psd2_gateway`) in diff.

### Validation (server-side evo1, isolated worktree)
`ruff check` + `ruff format --check` **clean**; `pytest tests/test_open_banking_int.py` **5 passed** (--noconftest, isolated); import sanity OK. **Full Quality Gate / 9-check runs in CI** (module test isolated locally; full suite first in CI).

> **Paired** with banxe-architecture arch IL-shard. **No merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
