### PR TITLE
feat(abs): MIG abs-info-field advisory descriptive metadata surface (genuine-gap #1, no live, no merge) [MIG-abs-info-field]

### DIFF
--- a/services/abs/__init__.py
+++ b/services/abs/__init__.py
@@ -1,0 +1,1 @@
+"""services/abs — advisory ABS descriptive surfaces (MIG genuine-gap track)."""

--- a/services/abs/info_field.py
+++ b/services/abs/info_field.py
@@ -1,0 +1,95 @@
+"""services/abs/info_field.py — Advisory ABS info-field metadata surface (MIG genuine-gap #1).
+
+Descriptive, config-as-data ABS **info-field metadata** (semantic port for the legacy
+`abs-info-field.service.ts`). Advisory / sandbox / read-only: it describes field metadata (key, label,
+type, group) — it holds NO live data, performs NO live integrations, calls NO Midaz LedgerPort, touches
+NO KYC/KYB/AML, and mutates NO ledger/state. Fail-closed (unknown key -> None). No monetary numerics
+(descriptive only); no float (I-01 trivially — there are no money values here).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+
+SANDBOX_SOURCE = "sandbox-mock"
+
+
+class AbsFieldType(str, Enum):
+    """Descriptive data-type of an ABS info-field (metadata only, not a value)."""
+
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    DATE = "date"
+    ENUM = "enum"
+
+
+@dataclass(frozen=True)
+class AbsInfoFieldDescriptor:
+    """Descriptive ABS info-field metadata (config-as-data; no live value, no numerics)."""
+
+    field_key: str
+    label: str
+    field_type: AbsFieldType
+    group: str
+    source: str = SANDBOX_SOURCE
+
+
+# Config-as-data descriptive field catalogue (sandbox; no live source, no balances).
+_ABS_INFO_FIELDS: tuple[dict[str, object], ...] = (
+    {
+        "field_key": "customer_ref",
+        "label": "Customer Reference",
+        "field_type": AbsFieldType.STRING,
+        "group": "customer",
+    },
+    {
+        "field_key": "agreement_no",
+        "label": "Agreement Number",
+        "field_type": AbsFieldType.STRING,
+        "group": "agreement",
+    },
+    {
+        "field_key": "legal_entity_country",
+        "label": "Legal Entity Country",
+        "field_type": AbsFieldType.STRING,
+        "group": "legal_entity",
+    },
+    {
+        "field_key": "onboarding_status",
+        "label": "Onboarding Status",
+        "field_type": AbsFieldType.ENUM,
+        "group": "lifecycle",
+    },
+    {
+        "field_key": "agreement_active",
+        "label": "Agreement Active",
+        "field_type": AbsFieldType.BOOLEAN,
+        "group": "agreement",
+    },
+)
+
+
+class AbsInfoFieldPort(ABC):
+    """Read-only advisory ABS info-field metadata contract (descriptive; fail-closed)."""
+
+    @abstractmethod
+    def list_fields(self) -> list[AbsInfoFieldDescriptor]: ...
+
+    @abstractmethod
+    def get_field(self, field_key: str) -> AbsInfoFieldDescriptor | None:
+        """Return the descriptor for a field_key, or None if unknown (fail-closed)."""
+
+
+class SandboxAbsInfoFieldProvider(AbsInfoFieldPort):
+    """Sandbox config-as-data provider (mock-safe; no live integration, no Midaz, no KYC)."""
+
+    def list_fields(self) -> list[AbsInfoFieldDescriptor]:
+        return [AbsInfoFieldDescriptor(source=SANDBOX_SOURCE, **f) for f in _ABS_INFO_FIELDS]  # type: ignore[arg-type]
+
+    def get_field(self, field_key: str) -> AbsInfoFieldDescriptor | None:
+        return next(
+            (f for f in self.list_fields() if f.field_key == field_key), None
+        )  # fail-closed

--- a/tests/test_abs_info_field.py
+++ b/tests/test_abs_info_field.py
@@ -1,0 +1,59 @@
+"""MIG genuine-gap #1 — advisory ABS info-field metadata (descriptive, no live/Midaz/KYC).
+
+characterization: AbsInfoFieldPort / AbsInfoFieldDescriptor / AbsFieldType shape; deterministic.
+contract: descriptors carry exactly {field_key,label,field_type,group,source}; fail-closed get_field.
+fence: module imports no midaz/ledger/kyc; no float; no monetary numerics.
+"""
+
+from dataclasses import fields
+from pathlib import Path
+
+from services.abs.info_field import (
+    AbsFieldType,
+    AbsInfoFieldDescriptor,
+    AbsInfoFieldPort,
+    SandboxAbsInfoFieldProvider,
+)
+
+
+def _provider() -> SandboxAbsInfoFieldProvider:
+    return SandboxAbsInfoFieldProvider()
+
+
+def test_port_and_descriptor_shape() -> None:
+    assert issubclass(SandboxAbsInfoFieldProvider, AbsInfoFieldPort)
+    names = {f.name for f in fields(AbsInfoFieldDescriptor)}
+    assert names == {"field_key", "label", "field_type", "group", "source"}
+    assert {t.value for t in AbsFieldType} == {"string", "number", "boolean", "date", "enum"}
+
+
+def test_list_fields_descriptive() -> None:
+    out = _provider().list_fields()
+    assert len(out) == 5
+    assert all(isinstance(d, AbsInfoFieldDescriptor) for d in out)
+    assert all(d.source == "sandbox-mock" for d in out)
+    assert all(isinstance(d.field_type, AbsFieldType) for d in out)
+
+
+def test_get_field_fail_closed() -> None:
+    p = _provider()
+    assert p.get_field("customer_ref") is not None
+    assert p.get_field("customer_ref").group == "customer"
+    assert p.get_field("nope") is None  # fail-closed
+
+
+def test_deterministic() -> None:
+    assert _provider().list_fields() == _provider().list_fields()
+
+
+def test_fence_no_midaz_ledger_kyc_no_float() -> None:
+    import services.abs.info_field as mod
+
+    text = Path(mod.__file__).read_text()
+    import_lines = "\n".join(
+        ln for ln in text.splitlines() if ln.strip().startswith(("import ", "from "))
+    ).lower()
+    for bad in ("midaz", "ledger", "kyc", "kyb", "sumsub", "httpx", "requests"):
+        assert bad not in import_lines, f"forbidden import token: {bad}"
+    # no float USAGE: descriptive metadata only (docstring may mention the word "float")
+    assert "float(" not in text and ": float" not in text and "-> float" not in text


### PR DESCRIPTION
## MIG abs-info-field — advisory descriptive ABS info-field metadata surface (genuine-gap #1, no live, no merge) [MIG-abs-info-field]

> **Genuine-gap #1** from the ABS/identity coverage-audit (IL-411). Server-side origin (evo1, isolated worktree). **Preflight clean** — no existing field-metadata surface in banxe-emi-stack. **Advisory/sandbox, descriptive only; no live/Midaz/KYC/ledger.** **Do NOT auto-merge** (CI-gated + operator-gated).

### Scope (`services/abs/info_field.py`)
`AbsInfoFieldPort` (ABC) + `AbsInfoFieldDescriptor` (`@dataclass`: `field_key`, `label`, `field_type` [`AbsFieldType` enum], `group`, `source`) + `SandboxAbsInfoFieldProvider` (config-as-data, **fail-closed** `get_field`). Semantic port for the legacy `abs-info-field.service.ts`. `services/abs/__init__.py` (new module).

### Duplication Audit (ADR-102)
**Additive descriptive ABS surface** — preflight confirmed **no existing field-metadata surface** (exact grep empty). **NOT a duplicate** of the operational ABS layer (`LegacyAbsPaymentAdapter`) or the GL/posting subsystem (`GLService`) — pure metadata. Existing ABS/ledger/auth/kyc surfaces **UNCHANGED (0 in diff)**.

### Invariants / fences (verified)
- **No live integration, no Midaz, no KYC/KYB/AML, no ledger mutation; fail-closed.**
- **I-01:** no monetary numerics, **no float usage** (descriptive metadata only).
- Tests: characterization + contract (exact descriptor fields; fail-closed) + fence (0 midaz/ledger/kyc imports; no float).
- **Global fence-check (M2.5-BIF lesson):** importing `abs.info_field` adds **no** bifrost/typeorm/redis/gcp to `sys.modules` (NONE).

### Validation (server-side evo1, isolated worktree)
`ruff check` + `ruff format --check` **clean**; `pytest tests/test_abs_info_field.py` **5 passed** (--noconftest, isolated); global-fence NONE. **Full 9-check Quality Gate runs in CI** (module test isolated locally; full suite first in CI; any Pytest/coverage/fence fail → remediation in-branch, no bypass).

> **Paired** with banxe-architecture arch IL-shard. **No merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
