### PR TITLE
feat(open-banking): MIG-M2.4d international-scheduled OB payment surface (genuine gap, advisory, no live, no merge) [MIG-M2.4d]

### DIFF
--- a/services/open_banking/intl_scheduled.py
+++ b/services/open_banking/intl_scheduled.py
@@ -1,0 +1,190 @@
+"""services/open_banking/intl_scheduled.py — Advisory international-scheduled OB payment surface (MIG-M2.4d).
+
+Genuine OB-delta gap: the **international + scheduled + OB-consent** combination is not covered —
+`services/scheduled_payments/*` is domestic-only (no cross-border / currency / jurisdiction fields) and
+`api/routers/payments.py` is non-scheduled / non-OB-consent. This adds the descriptive OB surface for
+OBIE `international-scheduled-payment-consents` + `international-scheduled-payments` (TPP-initiated,
+consent-gated, future-dated, cross-border).
+
+Advisory / sandbox: it **consumes** the M2.4-INT contract (`PaymentEngineContract` + accounts SoT
+projection by `account_ref`, no balance) and tracks the consent + schedule state-machine. NO live
+initiation/execution, NO Midaz LedgerPort, NO KYC/KYB/AML. `execution_date` + `timestamp` are
+caller-supplied (no wall-clock). amount Decimal (I-01) -> minor units int (I-05) via the bridge. DI
+id-generator (collision-safe) + fail-closed.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+import secrets
+
+from services.open_banking.m24_int_bridge import AccountSoTProjection, to_minor_units
+
+SANDBOX_SOURCE = "sandbox-mock"
+_MAX_ID_ATTEMPTS = 5
+
+
+def _default_intent_id() -> str:
+    """Safe default intent-id generator (overridable via constructor DI)."""
+    return f"INTLSCHED-{secrets.token_hex(6)}"
+
+
+class IntlScheduledStage(str, Enum):
+    """OB international-scheduled consent + schedule state-machine (advisory)."""
+
+    CONSENT_AWAITING = "consent_awaiting_authorisation"
+    CONSENT_AUTHORISED = "consent_authorised"
+    SCHEDULED = "scheduled"
+    EXECUTED = "executed"
+    REJECTED = "rejected"
+    CANCELLED = "cancelled"
+
+
+#: Allowed advisory stage transitions (no live side effects).
+STAGE_TRANSITIONS: dict[IntlScheduledStage, tuple[IntlScheduledStage, ...]] = {
+    IntlScheduledStage.CONSENT_AWAITING: (
+        IntlScheduledStage.CONSENT_AUTHORISED,
+        IntlScheduledStage.REJECTED,
+    ),
+    IntlScheduledStage.CONSENT_AUTHORISED: (
+        IntlScheduledStage.SCHEDULED,
+        IntlScheduledStage.CANCELLED,
+    ),
+    IntlScheduledStage.SCHEDULED: (IntlScheduledStage.EXECUTED, IntlScheduledStage.CANCELLED),
+    IntlScheduledStage.EXECUTED: (),
+    IntlScheduledStage.REJECTED: (),
+    IntlScheduledStage.CANCELLED: (),
+}
+
+
+@dataclass(frozen=True)
+class IntlScheduledIntent:
+    """Advisory OB international-scheduled payment intent (consumes payment-engine; accounts projection).
+
+    amount_minor: int minor units (I-05). account refs are projections (no balance). Cross-border fields
+    (creditor_country, fx_indicator) distinguish this from the domestic scheduled_payments surface.
+    """
+
+    intent_id: str
+    file_dedup_key: str  # consent/file idempotency
+    payment_intent_ref: str  # consumed from PaymentEngineContract (M2.1 / M2.4-INT)
+    debtor_account_ref: str  # accounts SoT projection (no balance)
+    creditor_account_ref: str
+    creditor_iban: str
+    creditor_country: str  # cross-border (ISO 3166)
+    amount_minor: int
+    currency: str  # ISO 4217
+    fx_indicator: bool  # cross-currency settlement involved
+    execution_date: str  # future-dated (caller-supplied, ISO-8601)
+    stage: IntlScheduledStage = IntlScheduledStage.CONSENT_AWAITING
+    source: str = SANDBOX_SOURCE
+
+
+class IntlScheduledPort(ABC):
+    """Read-only advisory OB international-scheduled contract (no live execution; fail-closed)."""
+
+    @abstractmethod
+    def create_consent(
+        self,
+        *,
+        file_dedup_key: str,
+        payment_intent_ref: str,
+        debtor_account_ref: str,
+        creditor_account_ref: str,
+        creditor_iban: str,
+        creditor_country: str,
+        amount: Decimal,
+        currency: str,
+        fx_indicator: bool,
+        execution_date: str,
+    ) -> IntlScheduledIntent:
+        """Create (idempotently) an advisory intl-scheduled consent. No live initiation/FX."""
+
+    @abstractmethod
+    def advance(self, *, intent_id: str, to_stage: IntlScheduledStage) -> IntlScheduledIntent:
+        """Advance the consent/schedule state-machine (validated; fail-closed)."""
+
+    @abstractmethod
+    def get_intent(self, intent_id: str) -> IntlScheduledIntent | None:
+        """Return the intent, or None if unknown (fail-closed)."""
+
+
+class SandboxIntlScheduledProvider(IntlScheduledPort):
+    """Sandbox config-as-data provider; consumes accounts SoT projection; no live; idempotent."""
+
+    def __init__(self, *, id_generator: Callable[[], str] | None = None) -> None:
+        self._by_key: dict[str, IntlScheduledIntent] = {}
+        self._by_id: dict[str, IntlScheduledIntent] = {}
+        self._gen_id: Callable[[], str] = id_generator or _default_intent_id
+        self._accounts = AccountSoTProjection()  # M2.2 projection (balance-free)
+
+    def create_consent(
+        self,
+        *,
+        file_dedup_key: str,
+        payment_intent_ref: str,
+        debtor_account_ref: str,
+        creditor_account_ref: str,
+        creditor_iban: str,
+        creditor_country: str,
+        amount: Decimal,
+        currency: str,
+        fx_indicator: bool,
+        execution_date: str,
+    ) -> IntlScheduledIntent:
+        existing = self._by_key.get(file_dedup_key)
+        if existing is not None:  # consent/file idempotency
+            return existing
+        intent_id = self._gen_id()
+        attempts = 0
+        while intent_id in self._by_id:
+            attempts += 1
+            if attempts >= _MAX_ID_ATTEMPTS:
+                raise RuntimeError(
+                    "intl-scheduled: could not generate a unique intent_id (fail-closed)"
+                )
+            intent_id = self._gen_id()
+        intent = IntlScheduledIntent(
+            intent_id=intent_id,
+            file_dedup_key=file_dedup_key,
+            payment_intent_ref=payment_intent_ref,
+            debtor_account_ref=debtor_account_ref,
+            creditor_account_ref=creditor_account_ref,
+            creditor_iban=creditor_iban,
+            creditor_country=creditor_country,
+            amount_minor=to_minor_units(amount, currency),  # Decimal (I-01) -> int minor (I-05)
+            currency=currency,
+            fx_indicator=fx_indicator,
+            execution_date=execution_date,
+            stage=IntlScheduledStage.CONSENT_AWAITING,
+            source=SANDBOX_SOURCE,
+        )
+        self._by_key[file_dedup_key] = intent
+        self._by_id[intent_id] = intent
+        return intent
+
+    def advance(self, *, intent_id: str, to_stage: IntlScheduledStage) -> IntlScheduledIntent:
+        cur = self._by_id.get(intent_id)
+        if cur is None:
+            raise KeyError(f"intl-scheduled intent not found: {intent_id!r}")  # fail-closed
+        if to_stage not in STAGE_TRANSITIONS[cur.stage]:
+            raise ValueError(
+                f"illegal transition {cur.stage.value} -> {to_stage.value}"
+            )  # fail-closed
+        import dataclasses
+
+        nxt = dataclasses.replace(cur, stage=to_stage)
+        self._by_id[intent_id] = nxt
+        self._by_key[cur.file_dedup_key] = nxt
+        return nxt
+
+    def get_intent(self, intent_id: str) -> IntlScheduledIntent | None:
+        return self._by_id.get(intent_id)  # fail-closed
+
+    def known_account_refs(self) -> list[str]:
+        """Balance-free account-ref projection (accounts SoT, M2.2)."""
+        return self._accounts.account_refs()

--- a/tests/test_intl_scheduled.py
+++ b/tests/test_intl_scheduled.py
@@ -1,0 +1,95 @@
+"""MIG-M2.4d — advisory OB international-scheduled payment surface (genuine gap; descriptive, no live).
+
+characterization: IntlScheduledPort / IntlScheduledIntent / IntlScheduledStage state-machine + cross-border
+fields. contract: consume M2.4-INT bridge (to_minor_units; accounts projection by account_ref, no balance);
+file idempotency; Decimal->minor int. fence: no midaz/ledger/kyc; no live initiation; no wall-clock; no float.
+"""
+
+from dataclasses import fields
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from services.open_banking.intl_scheduled import (
+    STAGE_TRANSITIONS,
+    IntlScheduledIntent,
+    IntlScheduledPort,
+    IntlScheduledStage,
+    SandboxIntlScheduledProvider,
+)
+
+_BALANCE_FIELDS = {"balance", "available", "ledger_balance", "balance_minor"}
+
+
+def _p() -> SandboxIntlScheduledProvider:
+    return SandboxIntlScheduledProvider()
+
+
+def _mk(p, key="f1"):
+    return p.create_consent(
+        file_dedup_key=key,
+        payment_intent_ref="PI-1",
+        debtor_account_ref="INTERNAL",
+        creditor_account_ref="EXTERNAL",
+        creditor_iban="DE89370400440532013000",
+        creditor_country="DE",
+        amount=Decimal("100.00"),
+        currency="EUR",
+        fx_indicator=True,
+        execution_date="2026-07-01",
+    )
+
+
+def test_port_dto_state_machine_and_cross_border() -> None:
+    assert issubclass(SandboxIntlScheduledProvider, IntlScheduledPort)
+    names = {f.name for f in fields(IntlScheduledIntent)}
+    assert {
+        "creditor_country",
+        "fx_indicator",
+        "execution_date",
+        "payment_intent_ref",
+    } <= names  # cross-border
+    assert _BALANCE_FIELDS.isdisjoint(names)  # accounts projection, no balance
+    assert STAGE_TRANSITIONS[IntlScheduledStage.EXECUTED] == ()
+
+
+def test_create_consume_bridge_and_minor_units() -> None:
+    i = _mk(_p())
+    assert i.payment_intent_ref == "PI-1"  # consumed engine intent ref
+    assert i.amount_minor == 10000 and isinstance(i.amount_minor, int)  # Decimal->minor (I-05)
+    assert i.creditor_country == "DE" and i.fx_indicator is True
+    assert i.stage is IntlScheduledStage.CONSENT_AWAITING
+
+
+def test_file_idempotency_and_state_machine() -> None:
+    p = _p()
+    a = _mk(p, "dup")
+    b = _mk(p, "dup")
+    assert a.intent_id == b.intent_id  # idempotent
+    c = p.advance(intent_id=a.intent_id, to_stage=IntlScheduledStage.CONSENT_AUTHORISED)
+    assert c.stage is IntlScheduledStage.CONSENT_AUTHORISED
+    with pytest.raises(ValueError):  # illegal: authorised -> executed (must go via scheduled)
+        p.advance(intent_id=a.intent_id, to_stage=IntlScheduledStage.EXECUTED)
+
+
+def test_fail_closed_and_accounts_projection() -> None:
+    p = _p()
+    assert p.get_intent("INTLSCHED-nope") is None
+    with pytest.raises(KeyError):
+        p.advance(intent_id="INTLSCHED-nope", to_stage=IntlScheduledStage.SCHEDULED)
+    assert "INTERNAL" in p.known_account_refs()  # accounts SoT projection (M2.2)
+
+
+def test_fence_no_midaz_ledger_kyc_no_wallclock_no_float() -> None:
+    import services.open_banking.intl_scheduled as mod
+
+    text = Path(mod.__file__).read_text()
+    low = text.lower()
+    import_lines = "\n".join(
+        ln for ln in text.splitlines() if ln.strip().startswith(("import ", "from "))
+    ).lower()
+    for bad in ("midaz", "ledger", "kyc", "kyb", "sumsub", "httpx", "requests"):
+        assert bad not in import_lines, f"forbidden import: {bad}"
+    assert "datetime.now(" not in low and ".utcnow(" not in low and "date.now(" not in low
+    assert "float(" not in text and ": float" not in text and "-> float" not in text


### PR DESCRIPTION
## MIG-M2.4d — international-scheduled OB payment surface (genuine gap, advisory, no live, no merge) [MIG-M2.4d]

> **OB-delta — GENUINE GAP** (first OB-delta scaffold; M2.4a/c were covered). Server-side origin (evo1, isolated worktree). **Advisory/sandbox; no live initiation/FX/execution.** **Do NOT auto-merge** (CI-gated + operator-gated).

### Preflight — why genuine gap (not covered)
The **international + scheduled + OB-consent** combination is **not** covered: `services/scheduled_payments/*` is **domestic-only** (no cross-border/currency/jurisdiction fields — grep empty); `api/routers/payments.py` is international-capable but **non-scheduled / non-OB-consent**. No existing intl-scheduled consent surface. Legacy `banxe-open-banking/src/international/` has the full module (international-scheduled-consents + payments).

### Scope (`services/open_banking/intl_scheduled.py`)
`IntlScheduledPort` (ABC) + `IntlScheduledIntent` (`@dataclass`: **cross-border** creditor_country/fx_indicator + execution_date + `payment_intent_ref` + account refs [projection, no balance] + `amount_minor` int) + `IntlScheduledStage` state-machine (consent_awaiting→authorised→scheduled→executed/rejected/cancelled) + `SandboxIntlScheduledProvider`. **Consumes M2.4-INT bridge** (`to_minor_units`; `AccountSoTProjection` M2.2). DI id-gen + collision-safe + file idempotency + fail-closed.

### Duplication Audit (ADR-102)
Additive OB delta; **NOT a duplicate** of `scheduled_payments` (domestic) / `payments.py` (non-scheduled) / PISP — the intl+scheduled+OB-consent slice was **genuinely absent**. Existing surfaces **UNCHANGED (0 in diff)**. KYC carve-out intact.

### Invariants / fences (verified)
No live initiation/FX/execution; no Midaz/KYC/ledger; amount Decimal (I-01) → minor int (I-05); execution_date/timestamp caller-supplied (no wall-clock); fail-closed. Tests: characterization + contract + fence; **global fence-check NONE**.

### Validation (server-side evo1, isolated worktree)
`ruff check` + `ruff format --check` **clean**; `pytest tests/test_intl_scheduled.py` **5 passed** (--noconftest, isolated); global-fence NONE. **Full 9-check Quality Gate in CI** (any fail → remediation in-branch, no bypass).

> **Paired** with banxe-architecture arch IL-shard. **No merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
