### PR TITLE
feat(hitl): Sprint-3/GAP-078 — dept-head agent→role→gate wiring (org_roles.py + tests)

### DIFF
--- a/services/hitl/org_roles.py
+++ b/services/hitl/org_roles.py
@@ -426,3 +426,46 @@ class OrgRoleChecker:
     def critical_gates(self) -> list[HITLGate]:
         """Return all CRITICAL severity gates."""
         return [g for g in self.all_gates() if g.severity == "critical"]
+
+
+# ── Sprint-3 / GAP-078: department-head agent → approver role binding ──────────
+# Each canonical dept-head agent (banxe-architecture governance/CANONICAL-ORG-CHART-v2.md §9,
+# STAFF-MATRIX-v2 §2) acts as a HITL approver under exactly ONE OrgRole, or None for a
+# non-approver head (board reporting / independent assurance / legal). This binds the
+# now-activated agents to EXISTING roles + gates. HITL-MATRIX.yaml / GATE_REGISTRY are NOT
+# modified — wiring only.
+
+DEPT_HEAD_AGENTS: dict[str, OrgRole | None] = {
+    "ceo_orchestration_agent": OrgRole.CEO,
+    "board_reporting_agent": None,  # board/committee reporting — no approval gate
+    "internal_audit_agent": OrgRole.INTERNAL_AUDITOR,  # independent 3rd-line assurance
+    "risk_oversight_agent": OrgRole.CRO,
+    "compliance_monitoring_agent": OrgRole.COMPLIANCE_OFFICER,
+    "cfo_orchestration_agent": OrgRole.CFO,
+    "coo_operations_agent": OrgRole.COO,
+    "cto_platform_agent": OrgRole.CTO,
+    "front_office_agent": None,  # product input → CEO approves HITL-017
+    "legal_corporate_agent": None,  # agreements — no approval gate
+}
+
+
+def role_for_agent(agent_id: str) -> OrgRole | None:
+    """Return the approver OrgRole bound to a dept-head agent (None if non-approver).
+
+    Raises KeyError for an unknown agent.
+    """
+    if agent_id not in DEPT_HEAD_AGENTS:
+        raise KeyError(f"unknown dept-head agent: {agent_id}")
+    return DEPT_HEAD_AGENTS[agent_id]
+
+
+def gates_for_agent(agent_id: str) -> list[HITLGate]:
+    """Return the HITL gates a dept-head agent can act on via its bound role.
+
+    Reuses OrgRoleChecker.gates_for_role; returns [] for a non-approver head. The HITL
+    matrix is unchanged — this only resolves an activated agent to the existing gates.
+    """
+    role = role_for_agent(agent_id)
+    if role is None:
+        return []
+    return OrgRoleChecker().gates_for_role(role)

--- a/tests/test_org_roles_dept_heads.py
+++ b/tests/test_org_roles_dept_heads.py
@@ -1,0 +1,88 @@
+"""
+test_org_roles_dept_heads.py — Sprint-3 / GAP-078 dept-head agent → role → gate wiring
+banxe-emi-stack | services/hitl/org_roles.py
+
+Verifies the 10 activated department-head agents resolve to the correct approver
+OrgRole and to the correct existing HITL gates (HITL-MATRIX.yaml unchanged).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.hitl.org_roles import (
+    DEPT_HEAD_AGENTS,
+    HITLTrigger,
+    OrgRole,
+    OrgRoleChecker,
+    gates_for_agent,
+    role_for_agent,
+)
+
+# Expected agent → role binding (STAFF-MATRIX-v2 §2).
+_EXPECTED = {
+    "ceo_orchestration_agent": OrgRole.CEO,
+    "board_reporting_agent": None,
+    "internal_audit_agent": OrgRole.INTERNAL_AUDITOR,
+    "risk_oversight_agent": OrgRole.CRO,
+    "compliance_monitoring_agent": OrgRole.COMPLIANCE_OFFICER,
+    "cfo_orchestration_agent": OrgRole.CFO,
+    "coo_operations_agent": OrgRole.COO,
+    "cto_platform_agent": OrgRole.CTO,
+    "front_office_agent": None,
+    "legal_corporate_agent": None,
+}
+
+_APPROVERS = [a for a, r in _EXPECTED.items() if r is not None]
+_NON_APPROVERS = [a for a, r in _EXPECTED.items() if r is None]
+
+
+class TestRegistry:
+    def test_all_ten_agents_registered(self) -> None:
+        assert set(DEPT_HEAD_AGENTS) == set(_EXPECTED)
+        assert len(DEPT_HEAD_AGENTS) == 10
+
+    @pytest.mark.parametrize("agent,role", list(_EXPECTED.items()))
+    def test_role_binding(self, agent: str, role: OrgRole | None) -> None:
+        assert role_for_agent(agent) == role
+
+    def test_unknown_agent_raises(self) -> None:
+        with pytest.raises(KeyError):
+            role_for_agent("nonexistent_agent")
+
+
+class TestGatesForApprovers:
+    @pytest.mark.parametrize("agent", _APPROVERS)
+    def test_approver_resolves_to_its_role_gates(self, agent: str) -> None:
+        role = role_for_agent(agent)
+        gates = gates_for_agent(agent)
+        # Every gate returned must list this agent's role as required or sufficient.
+        for g in gates:
+            assert role in g.required_roles or role in g.any_of_roles
+        # Resolution matches the role-level resolver (single source of truth).
+        assert gates == OrgRoleChecker().gates_for_role(role)
+
+    def test_ceo_can_act_on_new_product_launch(self) -> None:
+        ids = {g.trigger for g in gates_for_agent("ceo_orchestration_agent")}
+        assert HITLTrigger.NEW_PRODUCT_LAUNCH in ids  # HITL-017 (CEO required)
+
+    def test_cfo_can_act_on_fca_regdata(self) -> None:
+        ids = {g.trigger for g in gates_for_agent("cfo_orchestration_agent")}
+        assert HITLTrigger.FCA_REGDATA_SUBMISSION in ids  # HITL-010 (CFO required)
+
+    def test_cto_can_act_on_production_deploy(self) -> None:
+        ids = {g.trigger for g in gates_for_agent("cto_platform_agent")}
+        assert HITLTrigger.PRODUCTION_DEPLOY in ids  # HITL-013 (CTO required)
+
+
+class TestNonApprovers:
+    @pytest.mark.parametrize("agent", _NON_APPROVERS)
+    def test_non_approver_has_no_gates(self, agent: str) -> None:
+        assert gates_for_agent(agent) == []
+
+
+class TestMlroNotDuplicated:
+    def test_no_dept_head_binds_to_mlro(self) -> None:
+        # MLRO / Financial Crime is the independent banxe_aml_orchestrator line —
+        # NOT one of the 10 dept-heads (canon de-duplication).
+        assert OrgRole.MLRO not in DEPT_HEAD_AGENTS.values()


### PR DESCRIPTION
Sprint-3 / GAP-078 (emi-stack half — paired with banxe-architecture PR #664 passport activation).

**Append-only to `services/hitl/org_roles.py`** (0 removed lines): adds `DEPT_HEAD_AGENTS` registry (10 dept-head agents → OrgRole) + `role_for_agent()` + `gates_for_agent()`, reusing the existing `OrgRoleChecker.gates_for_role` and `GATE_REGISTRY`. **HITL-MATRIX.yaml / GATE_REGISTRY NOT modified** — wiring only.

Role bindings (STAFF-MATRIX-v2 §2): ceo→CEO · risk_oversight→CRO · compliance_monitoring→COMPLIANCE_OFFICER · cfo→CFO · coo→COO · cto→CTO · internal_audit→INTERNAL_AUDITOR · board_reporting/front_office/legal_corporate→None (non-approver). **MLRO not duplicated** (independent banxe_aml_orchestrator line).

`tests/test_org_roles_dept_heads.py` — **26 passed** (role binding, gate resolution per agent, non-approver=[], MLRO-not-dup, unknown→KeyError). ruff ✓ mypy ✓ semgrep ✓. No secrets.

Pairs with arch PR #664 (10 passports PROPOSED→active). Merge after operator OK.