### PR TITLE
feat(open-banking): MIG-M2.4e CBPII funds-confirmation-consent lifecycle (partial OB-delta facade, advisory, no live, no merge) [MIG-M2.4e]

### DIFF
--- a/services/open_banking/cbpii_consent.py
+++ b/services/open_banking/cbpii_consent.py
@@ -1,0 +1,162 @@
+"""services/open_banking/cbpii_consent.py — Advisory CBPII funds-confirmation-consent lifecycle (MIG-M2.4e).
+
+PARTIAL OB-delta: the CBPII funds-confirmation **check** already exists
+(`consent_management` → `handle_cbpii_check(consent_id, amount)`), and the generic consent-grant
+lifecycle exists. The only missing slice is the **dedicated OBIE `funds-confirmation-consents`
+lifecycle** (create / get / revoke of a CBPII funds-confirmation consent, distinct from the generic
+grant). This adds that thin facade — it **references** the existing check by name (descriptive), it does
+**NOT** re-implement it and does **NOT** perform funds-confirmation against live balances.
+
+Advisory / sandbox: consumes accounts SoT projection (M2.2) by `account_ref` (no balance). NO live
+funds-confirmation, NO Midaz LedgerPort, NO KYC/KYB/AML. `timestamp` caller-supplied (no wall-clock).
+DI id-generator (collision-safe) + fail-closed. No monetary numerics here (amounts belong to the
+existing check); no float (I-01 trivially).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+import secrets
+
+from services.open_banking.m24_int_bridge import AccountSoTProjection
+
+SANDBOX_SOURCE = "sandbox-mock"
+_MAX_ID_ATTEMPTS = 5
+#: The existing funds-confirmation check this facade references (NOT re-implemented here).
+EXISTING_CHECK_REF = "consent_management.handle_cbpii_check"
+
+
+def _default_consent_id() -> str:
+    """Safe default consent-id generator (overridable via constructor DI)."""
+    return f"CBPII-{secrets.token_hex(6)}"
+
+
+class CbpiiConsentStage(str, Enum):
+    """OBIE funds-confirmation-consent lifecycle stages (advisory)."""
+
+    AWAITING_AUTHORISATION = "awaiting_authorisation"
+    AUTHORISED = "authorised"
+    REVOKED = "revoked"
+    EXPIRED = "expired"
+
+
+#: Allowed advisory transitions (no live side effects).
+CONSENT_TRANSITIONS: dict[CbpiiConsentStage, tuple[CbpiiConsentStage, ...]] = {
+    CbpiiConsentStage.AWAITING_AUTHORISATION: (
+        CbpiiConsentStage.AUTHORISED,
+        CbpiiConsentStage.REVOKED,
+    ),
+    CbpiiConsentStage.AUTHORISED: (CbpiiConsentStage.REVOKED, CbpiiConsentStage.EXPIRED),
+    CbpiiConsentStage.REVOKED: (),
+    CbpiiConsentStage.EXPIRED: (),
+}
+
+
+@dataclass(frozen=True)
+class CbpiiFundsConfirmationConsent:
+    """Descriptive CBPII funds-confirmation-consent (OBIE shape; no live balance access)."""
+
+    consent_id: str
+    idempotency_key: str
+    debtor_account_ref: str  # accounts SoT projection (no balance)
+    stage: CbpiiConsentStage
+    timestamp: str  # caller-supplied (no wall-clock)
+    source: str = SANDBOX_SOURCE
+
+
+@dataclass(frozen=True)
+class FundsConfirmationRef:
+    """Descriptive pointer to the EXISTING funds-confirmation check (no live execution here)."""
+
+    consent_id: str
+    delegates_to: str  # EXISTING_CHECK_REF — the live check lives there, not duplicated
+    note: str = "advisory descriptor; not evaluated against live balances in this facade"
+
+
+class CbpiiPort(ABC):
+    """Read-only advisory CBPII funds-confirmation-consent lifecycle contract (fail-closed)."""
+
+    @abstractmethod
+    def create_consent(
+        self, *, idempotency_key: str, debtor_account_ref: str, timestamp: str
+    ) -> CbpiiFundsConfirmationConsent:
+        """Create (idempotently) a CBPII funds-confirmation consent (no live balance access)."""
+
+    @abstractmethod
+    def advance(
+        self, *, consent_id: str, to_stage: CbpiiConsentStage
+    ) -> CbpiiFundsConfirmationConsent:
+        """Advance the consent lifecycle (validated; fail-closed)."""
+
+    @abstractmethod
+    def get_consent(self, consent_id: str) -> CbpiiFundsConfirmationConsent | None:
+        """Return the consent, or None if unknown (fail-closed)."""
+
+    @abstractmethod
+    def funds_confirmation_ref(self, consent_id: str) -> FundsConfirmationRef:
+        """Return a descriptive pointer to the existing funds-confirmation check (no live exec)."""
+
+
+class SandboxCbpiiProvider(CbpiiPort):
+    """Sandbox config-as-data CBPII consent facade; references existing check; no live balances."""
+
+    def __init__(self, *, id_generator: Callable[[], str] | None = None) -> None:
+        self._by_key: dict[str, CbpiiFundsConfirmationConsent] = {}
+        self._by_id: dict[str, CbpiiFundsConfirmationConsent] = {}
+        self._gen_id: Callable[[], str] = id_generator or _default_consent_id
+        self._accounts = AccountSoTProjection()
+
+    def create_consent(
+        self, *, idempotency_key: str, debtor_account_ref: str, timestamp: str
+    ) -> CbpiiFundsConfirmationConsent:
+        existing = self._by_key.get(idempotency_key)
+        if existing is not None:
+            return existing
+        consent_id = self._gen_id()
+        attempts = 0
+        while consent_id in self._by_id:
+            attempts += 1
+            if attempts >= _MAX_ID_ATTEMPTS:
+                raise RuntimeError("cbpii: could not generate a unique consent_id (fail-closed)")
+            consent_id = self._gen_id()
+        c = CbpiiFundsConfirmationConsent(
+            consent_id=consent_id,
+            idempotency_key=idempotency_key,
+            debtor_account_ref=debtor_account_ref,
+            stage=CbpiiConsentStage.AWAITING_AUTHORISATION,
+            timestamp=timestamp,
+            source=SANDBOX_SOURCE,
+        )
+        self._by_key[idempotency_key] = c
+        self._by_id[consent_id] = c
+        return c
+
+    def advance(
+        self, *, consent_id: str, to_stage: CbpiiConsentStage
+    ) -> CbpiiFundsConfirmationConsent:
+        cur = self._by_id.get(consent_id)
+        if cur is None:
+            raise KeyError(f"cbpii consent not found: {consent_id!r}")  # fail-closed
+        if to_stage not in CONSENT_TRANSITIONS[cur.stage]:
+            raise ValueError(
+                f"illegal transition {cur.stage.value} -> {to_stage.value}"
+            )  # fail-closed
+        import dataclasses
+
+        nxt = dataclasses.replace(cur, stage=to_stage)
+        self._by_id[consent_id] = nxt
+        self._by_key[cur.idempotency_key] = nxt
+        return nxt
+
+    def get_consent(self, consent_id: str) -> CbpiiFundsConfirmationConsent | None:
+        return self._by_id.get(consent_id)  # fail-closed
+
+    def funds_confirmation_ref(self, consent_id: str) -> FundsConfirmationRef:
+        # descriptive only — the actual check is the existing handle_cbpii_check (not duplicated)
+        return FundsConfirmationRef(consent_id=consent_id, delegates_to=EXISTING_CHECK_REF)
+
+    def known_account_refs(self) -> list[str]:
+        return self._accounts.account_refs()

--- a/tests/test_cbpii_funds_confirmation.py
+++ b/tests/test_cbpii_funds_confirmation.py
@@ -1,0 +1,100 @@
+"""MIG-M2.4e — advisory CBPII funds-confirmation-consent lifecycle (partial OB-delta facade).
+
+characterization: CbpiiPort / consent DTO / lifecycle state-machine. contract: idempotent consent;
+funds_confirmation_ref DELEGATES to the existing check (not re-implemented; no live balance); accounts
+projection by account_ref. fence: no midaz/ledger/kyc; no live funds-confirmation; no wall-clock; no float.
+"""
+
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from services.open_banking.cbpii_consent import (
+    CONSENT_TRANSITIONS,
+    EXISTING_CHECK_REF,
+    CbpiiConsentStage,
+    CbpiiFundsConfirmationConsent,
+    CbpiiPort,
+    FundsConfirmationRef,
+    SandboxCbpiiProvider,
+)
+
+_BALANCE_FIELDS = {"balance", "available", "ledger_balance", "amount", "balance_minor"}
+
+
+def _p() -> SandboxCbpiiProvider:
+    return SandboxCbpiiProvider()
+
+
+def test_port_dto_state_machine() -> None:
+    assert issubclass(SandboxCbpiiProvider, CbpiiPort)
+    assert {f.name for f in fields(CbpiiFundsConfirmationConsent)} == {
+        "consent_id",
+        "idempotency_key",
+        "debtor_account_ref",
+        "stage",
+        "timestamp",
+        "source",
+    }
+    assert {s.value for s in CbpiiConsentStage} == {
+        "awaiting_authorisation",
+        "authorised",
+        "revoked",
+        "expired",
+    }
+    assert CONSENT_TRANSITIONS[CbpiiConsentStage.REVOKED] == ()
+    # no balance/amount fields on the consent DTO (funds-confirmation is delegated, not stored)
+    assert _BALANCE_FIELDS.isdisjoint({f.name for f in fields(CbpiiFundsConfirmationConsent)})
+
+
+def test_create_idempotent_and_lifecycle() -> None:
+    p = _p()
+    a = p.create_consent(
+        idempotency_key="k1", debtor_account_ref="INTERNAL", timestamp="2026-06-22T01:00:00Z"
+    )
+    b = p.create_consent(
+        idempotency_key="k1", debtor_account_ref="INTERNAL", timestamp="2026-06-22T01:00:00Z"
+    )
+    assert a.consent_id == b.consent_id and a.stage is CbpiiConsentStage.AWAITING_AUTHORISATION
+    c = p.advance(consent_id=a.consent_id, to_stage=CbpiiConsentStage.AUTHORISED)
+    assert c.stage is CbpiiConsentStage.AUTHORISED
+    with pytest.raises(ValueError):  # illegal: revoked is terminal -> cannot re-authorise
+        p.advance(
+            consent_id=p.advance(
+                consent_id=a.consent_id, to_stage=CbpiiConsentStage.REVOKED
+            ).consent_id,
+            to_stage=CbpiiConsentStage.AUTHORISED,
+        )
+
+
+def test_funds_confirmation_delegates_not_reimplemented() -> None:
+    p = _p()
+    c = p.create_consent(idempotency_key="k", debtor_account_ref="INTERNAL", timestamp="t")
+    ref = p.funds_confirmation_ref(c.consent_id)
+    assert isinstance(ref, FundsConfirmationRef)
+    assert (
+        ref.delegates_to == EXISTING_CHECK_REF == "consent_management.handle_cbpii_check"
+    )  # not duplicated
+
+
+def test_fail_closed_and_accounts_projection() -> None:
+    p = _p()
+    assert p.get_consent("CBPII-nope") is None
+    with pytest.raises(KeyError):
+        p.advance(consent_id="CBPII-nope", to_stage=CbpiiConsentStage.AUTHORISED)
+    assert "INTERNAL" in p.known_account_refs()
+
+
+def test_fence_no_midaz_ledger_kyc_no_wallclock_no_float() -> None:
+    import services.open_banking.cbpii_consent as mod
+
+    text = Path(mod.__file__).read_text()
+    low = text.lower()
+    import_lines = "\n".join(
+        ln for ln in text.splitlines() if ln.strip().startswith(("import ", "from "))
+    ).lower()
+    for bad in ("midaz", "ledger", "kyc", "kyb", "sumsub", "httpx", "requests"):
+        assert bad not in import_lines, f"forbidden import: {bad}"
+    assert "datetime.now(" not in low and ".utcnow(" not in low and "date.now(" not in low
+    assert "float(" not in text and ": float" not in text and "-> float" not in text


### PR DESCRIPTION
## MIG-M2.4e — CBPII funds-confirmation-consent lifecycle (partial OB-delta facade, advisory, no live, no merge) [MIG-M2.4e]

> **FINAL OB-delta** — **PARTIAL** (thin facade). Server-side origin (evo1, isolated worktree). **Advisory/sandbox; no live funds-confirmation against live balances.** **Do NOT auto-merge** (CI-gated + operator-gated).

### Preflight classification — PARTIAL
- **Present:** CBPII funds-confirmation **CHECK** (`/v1/consent/cbpii/check` → `handle_cbpii_check`) + generic consent-grant lifecycle (`consent_management`).
- **Absent:** dedicated OBIE **`funds-confirmation-consents` lifecycle** (distinct from generic grant). → thin facade for the missing slice; **the check is referenced, not re-implemented.**

### Scope (`services/open_banking/cbpii_consent.py`)
`CbpiiPort` (ABC) + `CbpiiFundsConfirmationConsent` (`@dataclass`: consent_id, idempotency_key, debtor_account_ref [projection, no balance], stage, timestamp) + `CbpiiConsentStage` lifecycle (awaiting→authorised→revoked/expired) + `FundsConfirmationRef` (**descriptive pointer to `EXISTING_CHECK_REF = consent_management.handle_cbpii_check`**) + `SandboxCbpiiProvider`. Consumes accounts SoT projection (M2.2). DI id-gen + collision-safe + idempotency + fail-closed.

### Duplication Audit (ADR-102)
Additive thin facade; **NOT a duplicate** of `/cbpii/check` (referenced, not re-implemented), generic `consent_management` grants, or PISP — only the dedicated CBPII consent-lifecycle shape. Existing surfaces **UNCHANGED (0 in diff)**. KYC carve-out intact.

### Invariants / fences (verified)
**No live funds-confirmation against live balances** (the check is delegated/descriptive); no Midaz/KYC/ledger; timestamp caller-supplied (no wall-clock); no float; fail-closed. Tests: characterization + contract + fence; **global fence-check NONE**.

### Validation (server-side evo1)
`ruff` + `ruff format --check` **clean**; `pytest` **5 passed** (--noconftest, isolated); global-fence NONE. **Full 9-check Quality Gate in CI** (any fail → remediation in-branch, no bypass).

> **Paired** with arch IL-shard. **FINAL OB-delta substep** — after this, OB-delta backlog is exhausted. **No merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CBPII funds-confirmation-consent lifecycle management with idempotent consent creation and stage transitions in sandbox environment.
  * Added account references exposure for consent management.

* **Tests**
  * Added comprehensive test suite validating consent creation, state transitions, delegation patterns, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->