### PR TITLE
fix(ledger): Midaz adapter fail-closed on infra failure — surface, no silent zero [IL-CBS-DGL-FAILCLOSED]

### DIFF
--- a/INSTRUCTION-LEDGER.md
+++ b/INSTRUCTION-LEDGER.md
@@ -341,3 +341,42 @@
 - Production deploy + first LIVE run remain gated by Central + operator +
   MLRO sign-off; no evo1 deploy, no live Modulr API calls, no live DB
   writes, no `ssh evo1`, no `systemctl daemon-reload` performed.
+
+### IL-CBS-DGL-FAILCLOSED-2026-06-26
+- Date: 2026-06-26
+- Status: DONE (offline; no live infra)
+- Scope: D-gl GL-core fail-closed fix — first cross-repo runtime increment
+  promoting the `banxe-architecture` D-GL-BUILD-SPEC (IL-484) DoD #8
+  (`test_midaz_unavailable_surfaces_infra_failure`). The Midaz ledger adapter
+  previously swallowed transport/HTTP failures and returned a SILENT
+  `Decimal("0")` / `None` / `[]` — a false zero balance that can drive a wrong
+  reconciliation tie-out or safeguarding figure. Now an unreachable backend /
+  transport-timeout / 5xx raises `LedgerInfrastructureError` (the failure
+  SURFACES); a reachable, definite answer (4xx, or HTTP-200 with no GBP item)
+  keeps the safe default. The reconciliation engine (confirmed direct consumer)
+  maps the surfaced error per-account to a fail-closed `ERROR` result — never a
+  false `MATCHED`/`DISCREPANCY`.
+- Files modified:
+  - `services/ledger/ledger_port.py` (new `LedgerInfrastructureError`)
+  - `services/ledger/midaz_adapter.py` (3 methods fail-closed: get_balance /
+    create_transaction / list_transactions)
+  - `services/recon/reconciliation_engine.py` (per-account fail-closed `ERROR`)
+  - `tests/test_ledger_adapter.py` (3 silent-fallback assertions → `raises`)
+- Files created:
+  - `tests/test_midaz_fail_closed.py`
+  - `tests/test_recon_failclosed.py`
+- Out of scope (deferred): transaction lifecycle (commit/cancel/revert),
+  Fineract fallback adapter + ledger factory, high-value approval persistence,
+  and the `api/routers/ledger.py` 503 mapping (separate `midaz_client` path,
+  `# pragma: no cover` — follow-up). Protocol method set unchanged; only the
+  exception is added → no adapter-wide ripple.
+- Verification: 238 tests pass offline (44 fail-closed/updated + 194
+  back-compat: gl_service / payment_posting / reconciliation / api_ledger /
+  api_recon); ruff + ruff-format clean; semgrep banxe-rules clean; Decimal-only
+  (I-01); no secrets; no live Midaz/ClickHouse calls.
+- Landing discipline: cross-repo runtime authorized by operator; D-gl chosen as
+  first block; narrow first increment per operator directive. No live infra
+  activation. No self-merge — PR opened for operator review/merge.
+- Anchors: `banxe-architecture` D-GL-BUILD-SPEC (IL-484) §5 DoD #8; ADR-013
+  (Midaz CBS primary); FCA CASS 7.15 daily reconciliation; I-01 (Decimal),
+  I-24 (audit append-only), I-28 (LedgerPort-only).

--- a/services/ledger/ledger_port.py
+++ b/services/ledger/ledger_port.py
@@ -13,6 +13,17 @@ from typing import Protocol
 from services.ledger.ledger_models import Account, JournalEntry
 
 
+class LedgerInfrastructureError(RuntimeError):
+    """Ledger backend is unreachable / returned a server error.
+
+    Raised so an infrastructure failure SURFACES (fail-closed) instead of being
+    silently masked as a zero balance / empty result. Distinct from a genuine
+    "not found" or "no balance" answer from a reachable backend (which stays
+    ``None`` / ``Decimal("0")`` / ``[]``). Consumers (e.g. reconciliation) must
+    treat this as fail-closed — never as a real ``0`` tie-out.
+    """
+
+
 class LedgerPort(Protocol):
     """Port for General Ledger operations."""
 

--- a/services/ledger/midaz_adapter.py
+++ b/services/ledger/midaz_adapter.py
@@ -34,6 +34,8 @@ from typing import Any
 
 import httpx
 
+from services.ledger.ledger_port import LedgerInfrastructureError
+
 logger = logging.getLogger(__name__)
 
 MIDAZ_BASE_URL = os.environ.get("MIDAZ_BASE_URL", "http://localhost:8095")
@@ -86,8 +88,13 @@ class MidazLedgerAdapter:
     Thread safety: one asyncio.run() per call — safe for cron / CLI use.
     Not intended for high-frequency async contexts (use midaz_client.py directly).
 
-    Fallback: if MIDAZ_TOKEN is not set, all calls return safe defaults (0 / [])
-    and log a warning. Swap in StubLedgerAdapter for tests.
+    Fail-closed (DoD #8): an unreachable backend, a transport/timeout error or a
+    5xx server response raises ``LedgerInfrastructureError`` — the failure
+    SURFACES rather than being masked as a silent zero balance (a false ``0``
+    can drive wrong reconciliation / safeguarding figures). A reachable backend
+    that gives a definite answer — a 4xx response, or a 200 with no GBP item —
+    is NOT an infra failure and keeps returning the safe default
+    (``Decimal("0")`` / ``None`` / ``[]``). Swap in StubLedgerAdapter for tests.
     """
 
     def __init__(
@@ -108,24 +115,49 @@ class MidazLedgerAdapter:
         """
         Return GBP available balance for account_id as Decimal (never float).
 
-        Returns Decimal("0") if:
-          - Account not found in Midaz
-          - Asset code is not GBP
-          - Midaz is unreachable (logs error, returns 0 → PENDING in engine)
+        Returns Decimal("0") only for a reachable, definite answer:
+          - Asset code is not GBP / no GBP item (HTTP 200)
+          - 4xx response (e.g. account not found) — backend responded
+
+        Raises ``LedgerInfrastructureError`` (fail-closed, DoD #8) when Midaz is
+        unreachable or returns a 5xx — never a silent ``0`` that could become a
+        false reconciliation tie-out.
 
         FCA invariant: amounts MUST be Decimal, never float (I-05).
         """
         try:
             return asyncio.run(self._fetch_balance(org_id, ledger_id, account_id))
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code < 500:
+                logger.warning(
+                    "MidazLedgerAdapter.get_balance %s for org=%s ledger=%s account=%s",
+                    exc.response.status_code,
+                    org_id,
+                    ledger_id,
+                    account_id,
+                )
+                return Decimal("0")
+            logger.error(
+                "MidazLedgerAdapter.get_balance infra failure (%s): org=%s ledger=%s account=%s",
+                exc.response.status_code,
+                org_id,
+                ledger_id,
+                account_id,
+            )
+            raise LedgerInfrastructureError(
+                f"Midaz unavailable fetching balance for account={account_id}"
+            ) from exc
         except Exception as exc:
             logger.error(
-                "MidazLedgerAdapter.get_balance failed: org=%s ledger=%s account=%s error=%s",
+                "MidazLedgerAdapter.get_balance infra failure: org=%s ledger=%s account=%s error=%s",
                 org_id,
                 ledger_id,
                 account_id,
                 exc,
             )
-            return Decimal("0")
+            raise LedgerInfrastructureError(
+                f"Midaz unavailable fetching balance for account={account_id}"
+            ) from exc
 
     def create_transaction(
         self,
@@ -137,22 +169,48 @@ class MidazLedgerAdapter:
         POST /v1/organizations/{org_id}/ledgers/{ledger_id}/transactions
 
         Create a double-entry transaction in Midaz GL.
-        Returns TransactionRecord on success, None on failure (logs error).
+        Returns TransactionRecord on success; None on a definite 4xx rejection
+        (reachable backend rejected the request). Raises
+        ``LedgerInfrastructureError`` (fail-closed, DoD #8) when Midaz is
+        unreachable or returns a 5xx — never a silent None that masks an
+        unposted transaction as a backend rejection.
 
         I-05: amount_gbp MUST be Decimal — never float.
         I-24: all transaction events append-only in Midaz (no UPDATE/DELETE).
         """
         try:
             return asyncio.run(self._post_transaction(org_id, ledger_id, request))
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code < 500:
+                logger.warning(
+                    "MidazLedgerAdapter.create_transaction rejected (%s): org=%s ledger=%s ext_id=%s",
+                    exc.response.status_code,
+                    org_id,
+                    ledger_id,
+                    request.external_id,
+                )
+                return None
+            logger.error(
+                "MidazLedgerAdapter.create_transaction infra failure (%s): org=%s ledger=%s ext_id=%s",
+                exc.response.status_code,
+                org_id,
+                ledger_id,
+                request.external_id,
+            )
+            raise LedgerInfrastructureError(
+                f"Midaz unavailable creating transaction ext_id={request.external_id}"
+            ) from exc
         except Exception as exc:
             logger.error(
-                "MidazLedgerAdapter.create_transaction failed: org=%s ledger=%s ext_id=%s error=%s",
+                "MidazLedgerAdapter.create_transaction infra failure: org=%s ledger=%s ext_id=%s error=%s",
                 org_id,
                 ledger_id,
                 request.external_id,
                 exc,
             )
-            return None
+            raise LedgerInfrastructureError(
+                f"Midaz unavailable creating transaction ext_id={request.external_id}"
+            ) from exc
 
     def list_transactions(
         self,
@@ -164,20 +222,44 @@ class MidazLedgerAdapter:
         """
         GET /v1/organizations/{org_id}/ledgers/{ledger_id}/transactions?account_id={account_id}
 
-        Returns transactions for account_id, newest first.
-        Returns [] on failure.
+        Returns transactions for account_id, newest first. Returns [] on a
+        reachable, definite answer (4xx, or 200 with no items). Raises
+        ``LedgerInfrastructureError`` (fail-closed, DoD #8) when Midaz is
+        unreachable or returns a 5xx — never a silent [] that masks an outage.
         """
         try:
             return asyncio.run(self._fetch_transactions(org_id, ledger_id, account_id, limit))
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code < 500:
+                logger.warning(
+                    "MidazLedgerAdapter.list_transactions %s for org=%s ledger=%s account=%s",
+                    exc.response.status_code,
+                    org_id,
+                    ledger_id,
+                    account_id,
+                )
+                return []
+            logger.error(
+                "MidazLedgerAdapter.list_transactions infra failure (%s): org=%s ledger=%s account=%s",
+                exc.response.status_code,
+                org_id,
+                ledger_id,
+                account_id,
+            )
+            raise LedgerInfrastructureError(
+                f"Midaz unavailable listing transactions for account={account_id}"
+            ) from exc
         except Exception as exc:
             logger.error(
-                "MidazLedgerAdapter.list_transactions failed: org=%s ledger=%s account=%s error=%s",
+                "MidazLedgerAdapter.list_transactions infra failure: org=%s ledger=%s account=%s error=%s",
                 org_id,
                 ledger_id,
                 account_id,
                 exc,
             )
-            return []
+            raise LedgerInfrastructureError(
+                f"Midaz unavailable listing transactions for account={account_id}"
+            ) from exc
 
     # ── internal async implementations ───────────────────────────────────────
 

--- a/services/recon/reconciliation_engine.py
+++ b/services/recon/reconciliation_engine.py
@@ -15,6 +15,8 @@ from decimal import Decimal
 import logging
 from typing import Protocol
 
+from services.ledger.ledger_port import LedgerInfrastructureError
+
 logger = logging.getLogger(__name__)
 
 # Discrepancy threshold: differences <= threshold are MATCHED.
@@ -121,7 +123,19 @@ class ReconciliationEngine:
         account_type: str,
         ext_map: dict,
     ) -> ReconResult:
-        internal = self._port.get_balance(self._org_id, self._ledger_id, account_id)
+        try:
+            internal = self._port.get_balance(self._org_id, self._ledger_id, account_id)
+        except LedgerInfrastructureError as exc:
+            # Fail-closed (DoD #8): the internal ledger is unavailable, so we
+            # CANNOT reconcile this account. Surface it as ERROR — never let a
+            # masked zero balance produce a false MATCHED/DISCREPANCY tie-out.
+            logger.error(
+                "CASS 7.15 recon fail-closed: ledger unavailable account=%s type=%s error=%s",
+                account_id,
+                account_type,
+                exc,
+            )
+            return self._error_result(recon_date, account_id, account_type)
 
         if account_id not in ext_map:
             return self._pending_result(recon_date, account_id, account_type, internal)
@@ -159,6 +173,30 @@ class ReconciliationEngine:
             external_balance=Decimal("0"),
             discrepancy=Decimal("0"),
             status="PENDING",
+            source_file="",
+        )
+
+    @staticmethod
+    def _error_result(
+        recon_date: date,
+        account_id: str,
+        account_type: str,
+    ) -> ReconResult:
+        """Internal ledger unavailable → ERROR (fail-closed, DoD #8).
+
+        The internal balance is unknown, so NO tie-out is computed: status is
+        ERROR (never MATCHED/DISCREPANCY) and discrepancy is left at zero. This
+        surfaces the outage instead of masking it as a false zero-balance match.
+        """
+        return ReconResult(
+            recon_date=recon_date,
+            account_id=account_id,
+            account_type=account_type,
+            currency="GBP",
+            internal_balance=Decimal("0"),
+            external_balance=Decimal("0"),
+            discrepancy=Decimal("0"),
+            status="ERROR",
             source_file="",
         )
 

--- a/tests/test_ledger_adapter.py
+++ b/tests/test_ledger_adapter.py
@@ -12,6 +12,9 @@ from datetime import datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from services.ledger.ledger_port import LedgerInfrastructureError
 from services.ledger.midaz_adapter import (
     MidazLedgerAdapter,
     StubLedgerAdapter,
@@ -236,8 +239,8 @@ class TestMidazAdapterHTTP:
         assert result == Decimal("125000.00")
         assert isinstance(result, Decimal)
 
-    def test_get_balance_http_error_returns_zero(self):
-        """On HTTP error, get_balance returns Decimal("0") — safe fallback."""
+    def test_get_balance_http_5xx_raises_infra_error(self):
+        """On a 5xx, get_balance fails closed (DoD #8) — never a silent zero."""
         adapter = _make_adapter()
         mock_resp = _mock_response({}, status_code=500)
 
@@ -245,20 +248,18 @@ class TestMidazAdapterHTTP:
             mock_client = AsyncMock()
             mock_cls.return_value.__aenter__.return_value = mock_client
             mock_client.get = AsyncMock(return_value=mock_resp)
-            result = adapter.get_balance(ORG, LEDGER, ACCOUNT)
+            with pytest.raises(LedgerInfrastructureError):
+                adapter.get_balance(ORG, LEDGER, ACCOUNT)
 
-        assert result == Decimal("0")
-
-    def test_get_balance_network_error_returns_zero(self):
-        """On network failure, get_balance returns Decimal("0")."""
+    def test_get_balance_network_error_raises_infra_error(self):
+        """On network failure, get_balance fails closed (DoD #8) — never a silent zero."""
         adapter = _make_adapter()
         with patch("httpx.AsyncClient") as mock_cls:
             mock_client = AsyncMock()
             mock_cls.return_value.__aenter__.return_value = mock_client
             mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
-            result = adapter.get_balance(ORG, LEDGER, ACCOUNT)
-
-        assert result == Decimal("0")
+            with pytest.raises(LedgerInfrastructureError):
+                adapter.get_balance(ORG, LEDGER, ACCOUNT)
 
     def test_create_transaction_happy_path(self):
         """create_transaction POSTs to Midaz and returns TransactionRecord."""
@@ -292,8 +293,8 @@ class TestMidazAdapterHTTP:
         assert record.amount_gbp == Decimal("100.00")
         assert isinstance(record.amount_gbp, Decimal)
 
-    def test_create_transaction_error_returns_none(self):
-        """On HTTP error, create_transaction returns None (log + safe fallback)."""
+    def test_create_transaction_4xx_returns_none(self):
+        """A 4xx is a reachable, definite rejection → None (not an infra failure)."""
 
         adapter = _make_adapter()
         mock_resp = _mock_response({}, status_code=400)
@@ -343,8 +344,8 @@ class TestMidazAdapterHTTP:
         assert txns[0].transaction_id == "tx-a"
         assert txns[0].amount_gbp == Decimal("50.00")
 
-    def test_list_transactions_error_returns_empty(self):
-        """On HTTP error, list_transactions returns []."""
+    def test_list_transactions_5xx_raises_infra_error(self):
+        """On a 5xx, list_transactions fails closed (DoD #8) — never a silent []."""
 
         adapter = _make_adapter()
         mock_resp = _mock_response({}, status_code=503)
@@ -353,9 +354,8 @@ class TestMidazAdapterHTTP:
             mock_client = AsyncMock()
             mock_cls.return_value.__aenter__.return_value = mock_client
             mock_client.get = AsyncMock(return_value=mock_resp)
-            txns = adapter.list_transactions(ORG, LEDGER, ACCOUNT)
-
-        assert txns == []
+            with pytest.raises(LedgerInfrastructureError):
+                adapter.list_transactions(ORG, LEDGER, ACCOUNT)
 
     def test_adapter_sets_auth_header_when_token_set(self):
         """Authorization header is set when token provided."""

--- a/tests/test_midaz_fail_closed.py
+++ b/tests/test_midaz_fail_closed.py
@@ -1,0 +1,157 @@
+"""
+tests/test_midaz_fail_closed.py — MidazLedgerAdapter fail-closed behaviour.
+
+D-gl build-spec DoD #8 (`test_midaz_unavailable_surfaces_infra_failure`):
+an unreachable Midaz / transport error / 5xx MUST surface as
+LedgerInfrastructureError (no silent zero balance — a false 0 can drive a wrong
+reconciliation / safeguarding figure). A reachable, definite answer (4xx, or a
+200 with no GBP item) is NOT an infra failure and keeps the safe default.
+
+All offline — httpx.AsyncClient is mocked; no live Midaz.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from services.ledger.ledger_port import LedgerInfrastructureError
+from services.ledger.midaz_adapter import MidazLedgerAdapter, TransactionRequest
+
+ORG = "org-001"
+LEDGER = "ledger-001"
+ACCOUNT = "acct-001"
+
+
+def _adapter() -> MidazLedgerAdapter:
+    return MidazLedgerAdapter(base_url="http://test-midaz:8095", token="t", timeout=5.0)
+
+
+def _resp(json_data: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+# ── get_balance ───────────────────────────────────────────────────────────────
+
+
+def test_get_balance_network_error_raises_infra_error():
+    adapter = _adapter()
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(LedgerInfrastructureError):
+            adapter.get_balance(ORG, LEDGER, ACCOUNT)
+
+
+def test_get_balance_timeout_raises_infra_error():
+    adapter = _adapter()
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.get = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+        with pytest.raises(LedgerInfrastructureError):
+            adapter.get_balance(ORG, LEDGER, ACCOUNT)
+
+
+def test_get_balance_http_500_raises_infra_error():
+    adapter = _adapter()
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.get = AsyncMock(return_value=_resp({}, status_code=500))
+        with pytest.raises(LedgerInfrastructureError):
+            adapter.get_balance(ORG, LEDGER, ACCOUNT)
+
+
+def test_get_balance_200_no_gbp_returns_zero_not_error():
+    """Reachable backend, no GBP item → genuine Decimal('0'), NOT an infra failure."""
+    adapter = _adapter()
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.get = AsyncMock(
+            return_value=_resp({"items": [{"assetCode": "USD", "available": 999}]})
+        )
+        result = adapter.get_balance(ORG, LEDGER, ACCOUNT)
+    assert result == Decimal("0")
+    assert isinstance(result, Decimal)
+
+
+def test_get_balance_4xx_returns_zero_not_error():
+    """A 4xx is a reachable, definite answer (e.g. not found) → 0, not infra failure."""
+    adapter = _adapter()
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.get = AsyncMock(return_value=_resp({}, status_code=404))
+        result = adapter.get_balance(ORG, LEDGER, ACCOUNT)
+    assert result == Decimal("0")
+
+
+# ── create_transaction ────────────────────────────────────────────────────────
+
+
+def test_create_transaction_5xx_raises_infra_error():
+    adapter = _adapter()
+    req = TransactionRequest(amount_gbp=Decimal("100.00"), description="X")
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.post = AsyncMock(return_value=_resp({}, status_code=502))
+        with pytest.raises(LedgerInfrastructureError):
+            adapter.create_transaction(ORG, LEDGER, req)
+
+
+def test_create_transaction_network_error_raises_infra_error():
+    adapter = _adapter()
+    req = TransactionRequest(amount_gbp=Decimal("100.00"), description="X")
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(LedgerInfrastructureError):
+            adapter.create_transaction(ORG, LEDGER, req)
+
+
+# ── list_transactions ─────────────────────────────────────────────────────────
+
+
+def test_list_transactions_5xx_raises_infra_error():
+    adapter = _adapter()
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.get = AsyncMock(return_value=_resp({}, status_code=503))
+        with pytest.raises(LedgerInfrastructureError):
+            adapter.list_transactions(ORG, LEDGER, ACCOUNT)
+
+
+def test_list_transactions_network_error_raises_infra_error():
+    adapter = _adapter()
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(LedgerInfrastructureError):
+            adapter.list_transactions(ORG, LEDGER, ACCOUNT)
+
+
+def test_list_transactions_4xx_returns_empty_not_error():
+    adapter = _adapter()
+    with patch("httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        mock_cls.return_value.__aenter__.return_value = client
+        client.get = AsyncMock(return_value=_resp({}, status_code=404))
+        assert adapter.list_transactions(ORG, LEDGER, ACCOUNT) == []

--- a/tests/test_recon_failclosed.py
+++ b/tests/test_recon_failclosed.py
@@ -1,0 +1,94 @@
+"""
+tests/test_recon_failclosed.py — ReconciliationEngine fail-closed behaviour.
+
+D-gl build-spec DoD #8 consumer side: when the internal ledger (Midaz) is
+unavailable, ``get_balance`` now raises ``LedgerInfrastructureError`` instead of
+returning a silent ``Decimal("0")``. The recon engine must surface this as an
+ERROR result — it must NEVER let a masked zero balance become a false MATCHED
+tie-out against an external statement of 0.
+
+All offline — no live Midaz, no ClickHouse.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from services.ledger.ledger_port import LedgerInfrastructureError
+from services.recon.reconciliation_engine import (
+    SAFEGUARDING_ACCOUNTS,
+    ReconciliationEngine,
+)
+
+ACCOUNT_IDS = list(SAFEGUARDING_ACCOUNTS.keys())
+
+
+@dataclass(frozen=True)
+class _ExtBalance:
+    account_id: str
+    balance: Decimal
+    currency: str = "GBP"
+    source_file: str = "stmt.csv"
+
+
+class _UnavailableLedger:
+    """LedgerPort whose get_balance always fails closed (Midaz unreachable)."""
+
+    def get_balance(self, org_id: str, ledger_id: str, account_id: str) -> Decimal:
+        raise LedgerInfrastructureError(f"Midaz unavailable for {account_id}")
+
+
+class _FakeCH:
+    def __init__(self) -> None:
+        self.rows: list[dict] = []
+
+    def execute(self, _sql: str, params: dict) -> None:
+        self.rows.append(params)
+
+
+class _FakeFetcher:
+    def __init__(self, balances: list[_ExtBalance]) -> None:
+        self._balances = balances
+
+    def fetch(self, _recon_date: date) -> list[_ExtBalance]:
+        return self._balances
+
+
+def _engine(fetcher: _FakeFetcher) -> ReconciliationEngine:
+    return ReconciliationEngine(
+        ledger_port=_UnavailableLedger(),
+        ch_client=_FakeCH(),
+        statement_fetcher=fetcher,
+    )
+
+
+def test_recon_infra_error_yields_error_status_not_match():
+    """External 0 present + internal unavailable → ERROR, never a false MATCHED."""
+    external = [_ExtBalance(account_id=aid, balance=Decimal("0")) for aid in ACCOUNT_IDS]
+    results = _engine(_FakeFetcher(external)).reconcile(date(2026, 6, 26))
+
+    assert results, "expected one result per safeguarding account"
+    assert all(r.status == "ERROR" for r in results)
+    assert not any(r.status in {"MATCHED", "DISCREPANCY"} for r in results)
+
+
+def test_recon_infra_error_no_external_statement_still_error():
+    """Even with no external statement, infra failure is ERROR (not PENDING)."""
+    results = _engine(_FakeFetcher([])).reconcile(date(2026, 6, 26))
+    assert all(r.status == "ERROR" for r in results)
+    assert not any(r.status == "PENDING" for r in results)
+
+
+def test_recon_error_result_is_surfaced_to_clickhouse():
+    """Fail-closed ERROR rows are still written out (surfaced, not swallowed)."""
+    ch = _FakeCH()
+    engine = ReconciliationEngine(
+        ledger_port=_UnavailableLedger(),
+        ch_client=ch,
+        statement_fetcher=_FakeFetcher([]),
+    )
+    engine.reconcile(date(2026, 6, 26))
+    assert ch.rows, "ERROR results must be persisted (surfaced), not dropped"
+    assert all(row["status"] == "ERROR" for row in ch.rows)


### PR DESCRIPTION
## Summary
First cross-repo runtime increment for **D-gl (General Ledger core)**, promoting the `banxe-architecture` **D-GL-BUILD-SPEC (IL-484) DoD #8** — `test_midaz_unavailable_surfaces_infra_failure`. Narrow, single-purpose safety fix (operator-directed scope).

**Problem:** `MidazLedgerAdapter` swallowed transport/HTTP failures and returned a **silent `Decimal("0")` / `None` / `[]`**. For a ledger this is dangerous — a false £0 balance can produce a wrong reconciliation tie-out or safeguarding figure.

**Fix:** an unreachable backend / transport-timeout / **5xx** now raises `LedgerInfrastructureError` (the failure **surfaces**). A reachable, definite answer — a **4xx**, or an **HTTP-200 with no GBP item** — is **not** an infra failure and keeps the safe default. The reconciliation engine (confirmed direct consumer of `get_balance`) maps the surfaced error **per-account to a fail-closed `ERROR`** result — never a false `MATCHED`/`DISCREPANCY`.

## Changes
**Modified**
- `services/ledger/ledger_port.py` — new `LedgerInfrastructureError`
- `services/ledger/midaz_adapter.py` — `get_balance` / `create_transaction` / `list_transactions` fail closed (5xx + transport → raise; 4xx + 200-empty → safe default)
- `services/recon/reconciliation_engine.py` — per-account `LedgerInfrastructureError` → `ERROR` result (surfaced, written out; other accounts continue)
- `tests/test_ledger_adapter.py` — **3 silent-fallback assertions flipped to `pytest.raises`** (500/503/network). ⚠️ deliberate behavior change. The 400-create test stays `None` (4xx = reachable rejection).

**Added**
- `tests/test_midaz_fail_closed.py` — adapter fail-closed matrix (network/timeout/5xx → raise; 4xx/200-empty → safe default)
- `tests/test_recon_failclosed.py` — recon surfaces `ERROR`, never a false `0` tie-out even with an external 0 statement

## Out of scope (deferred to later increments)
Transaction lifecycle (commit/cancel/revert), Fineract fallback adapter + ledger factory, high-value approval persistence, and the `api/routers/ledger.py` 503 mapping (separate `midaz_client` path, `# pragma: no cover`). LedgerPort **Protocol method set is unchanged** (only the exception added) → no adapter-wide ripple.

## Verification (offline, no live infra)
- **238 tests pass**: 44 fail-closed/updated + 194 back-compat (gl_service, payment_posting, reconciliation, api_ledger, api_recon).
- `ruff check` + `ruff format --check` clean; **semgrep banxe-rules clean**; Decimal-only (I-01); no secrets; no live Midaz/ClickHouse calls.

## Notes
- Cross-repo runtime authorized by operator; D-gl chosen as first block; narrowed to this single fix per operator directive.
- No live infra activation. **No self-merge** — opened for operator review/merge.
- IL: `IL-CBS-DGL-FAILCLOSED-2026-06-26` in `INSTRUCTION-LEDGER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)