### PR TITLE
feat(ledger): GL transaction lifecycle — create/commit/cancel/revert/annotate [IL-CBS-DGL-LIFECYCLE]

### DIFF
--- a/INSTRUCTION-LEDGER.md
+++ b/INSTRUCTION-LEDGER.md
@@ -380,3 +380,35 @@
 - Anchors: `banxe-architecture` D-GL-BUILD-SPEC (IL-484) §5 DoD #8; ADR-013
   (Midaz CBS primary); FCA CASS 7.15 daily reconciliation; I-01 (Decimal),
   I-24 (audit append-only), I-28 (LedgerPort-only).
+
+### IL-CBS-DGL-LIFECYCLE-2026-06-26
+- Date: 2026-06-26
+- Status: DONE (offline; no live infra)
+- Scope: D-gl GL-core transaction lifecycle (second cross-repo runtime
+  increment promoting D-GL-BUILD-SPEC IL-484 DoD #4 `test_transaction_lifecycle`).
+  Mirrors the Midaz transaction lifecycle, additive over the legacy immediate
+  `post_journal_entry`: stage `create_journal_entry` (PENDING) → `commit`
+  (COMMITTED, counts) | `cancel` (CANCELLED, no balance); `revert` a
+  POSTED/COMMITTED entry (original → REVERSED, dropped from balance, plus a
+  lineage reversing entry — single mechanism, no double-count); `annotate`
+  (records-only NOTED, never a balance impact). Balance now derives from
+  POSTED + COMMITTED (`BALANCE_AFFECTING_STATUSES`); legacy POSTED still counts.
+- Files modified:
+  - `services/ledger/ledger_models.py` (PostingStatus += COMMITTED/CANCELLED/
+    NOTED; `BALANCE_AFFECTING_STATUSES`)
+  - `services/ledger/ledger_port.py` (5 lifecycle methods on the Protocol)
+  - `services/ledger/inmemory_ledger.py` (lifecycle impl + balance derivation)
+  - `services/ledger/gl_service.py` (commit/cancel/revert/annotate wrappers,
+    each records a GLAuditEntry — I-24)
+- Files created:
+  - `tests/test_ledger_lifecycle.py` (14 tests: create→commit, cancel,
+    revert-nets-to-zero, annotate-no-balance, legacy back-compat, audit rows)
+- Out of scope (deferred): Fineract fallback + ledger factory; api-router 503
+  mapping; high-value approval audit persistence.
+- Verification: 226 ledger/recon tests pass offline (incl. back-compat
+  gl_service / payment_posting / ledger_adapter / reconciliation / api_ledger);
+  ruff + format clean; semgrep banxe-rules clean; Decimal-only (I-01); no live
+  Midaz/ClickHouse. LedgerPort Protocol additive; only InMemoryLedger implements
+  it (Midaz/Stub adapters are recon-shaped, unaffected).
+- Landing: sandbox-autonomous mode — green PR auto-merged when CLEAN.
+- Anchors: D-GL-BUILD-SPEC (IL-484) §3.3/§5 DoD #4; ADR-013; I-01, I-24, I-28.

--- a/services/ledger/gl_service.py
+++ b/services/ledger/gl_service.py
@@ -233,6 +233,47 @@ class GLService:
 
         return posted
 
+    # ── Transaction lifecycle (mirrors Midaz; each records an audit row, I-24) ──
+
+    def commit_entry(self, entry_id: str, actor: str = "SYSTEM") -> JournalEntry:
+        """PENDING -> COMMITTED (now counts toward balance)."""
+        committed = self._ledger.commit_journal_entry(entry_id)
+        self._record_lifecycle_audit("COMMIT_JOURNAL_ENTRY", committed, actor)
+        return committed
+
+    def cancel_entry(self, entry_id: str, actor: str = "SYSTEM") -> JournalEntry:
+        """PENDING -> CANCELLED (voided, no balance impact)."""
+        cancelled = self._ledger.cancel_journal_entry(entry_id)
+        self._record_lifecycle_audit("CANCEL_JOURNAL_ENTRY", cancelled, actor)
+        return cancelled
+
+    def revert_entry(self, entry_id: str, actor: str = "SYSTEM") -> JournalEntry:
+        """Revert a POSTED/COMMITTED entry; returns the lineage reversing entry."""
+        reversing = self._ledger.revert_journal_entry(entry_id)
+        self._record_lifecycle_audit("REVERT_JOURNAL_ENTRY", reversing, actor)
+        return reversing
+
+    def annotate_entry(self, entry_id: str, note: str) -> GLAuditEntry:
+        """Attach a records-only NOTED annotation (never a balance impact, I-24)."""
+        annotation = self._ledger.annotate_journal_entry(entry_id, note)
+        self._audit.record(annotation)
+        return annotation
+
+    def _record_lifecycle_audit(self, action: str, entry: JournalEntry, actor: str) -> None:
+        total_debit = sum(
+            (p.amount for p in entry.postings if p.direction == PostingDirection.DEBIT),
+            Decimal("0"),
+        )
+        self._record_audit(
+            entry_id=entry.entry_id,
+            action=action,
+            status=entry.status,
+            total_amount=total_debit,
+            currency=entry.postings[0].currency,
+            actor=actor,
+            details=f"status={entry.status.value}",
+        )
+
     # ── Private helpers ──────────────────────────────────────────────────────
 
     def _validate_balance(self, postings: list[Posting]) -> None:

--- a/services/ledger/inmemory_ledger.py
+++ b/services/ledger/inmemory_ledger.py
@@ -8,11 +8,15 @@ I-01: All monetary values are Decimal.
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import UTC, datetime
 from decimal import Decimal
 
 from services.ledger.ledger_models import (
+    BALANCE_AFFECTING_STATUSES,
     Account,
+    GLAuditEntry,
     JournalEntry,
+    Posting,
     PostingDirection,
     PostingStatus,
 )
@@ -24,6 +28,7 @@ class InMemoryLedger:
     def __init__(self) -> None:
         self._accounts: dict[str, Account] = {}
         self._entries: dict[str, JournalEntry] = {}
+        self._annotations: list[GLAuditEntry] = []
 
     def create_account(self, account: Account) -> Account:
         if account.account_id in self._accounts:
@@ -49,12 +54,16 @@ class InMemoryLedger:
         return self._entries.get(entry_id)
 
     def get_account_balance(self, account_id: str) -> Decimal:
-        """Compute balance from posted journal entries (I-01: Decimal)."""
+        """Compute balance from balance-affecting entries (POSTED + COMMITTED).
+
+        PENDING / CANCELLED / REVERSED / NOTED / FAILED entries are excluded
+        (I-01: Decimal).
+        """
         if account_id not in self._accounts:
             raise ValueError(f"Account {account_id!r} not found")
         balance = Decimal("0")
         for entry in self._entries.values():
-            if entry.status != PostingStatus.POSTED:
+            if entry.status not in BALANCE_AFFECTING_STATUSES:
                 continue
             for posting in entry.postings:
                 if posting.account_id == account_id:
@@ -63,6 +72,105 @@ class InMemoryLedger:
                     else:
                         balance -= posting.amount
         return balance
+
+    # ── transaction lifecycle (mirrors Midaz; additive over post_journal_entry) ──
+
+    def create_journal_entry(self, entry: JournalEntry) -> JournalEntry:
+        """Stage a balanced entry as PENDING (not yet counted toward balance)."""
+        if entry.entry_id in self._entries:
+            raise ValueError(f"Journal entry {entry.entry_id!r} already exists")
+        for posting in entry.postings:
+            if posting.account_id not in self._accounts:
+                raise ValueError(f"Account {posting.account_id!r} not found for posting")
+        pending = replace(entry, status=PostingStatus.PENDING)
+        self._entries[entry.entry_id] = pending
+        return pending
+
+    def commit_journal_entry(self, entry_id: str) -> JournalEntry:
+        """PENDING -> COMMITTED (now counts toward balance)."""
+        committed = replace(
+            self._require_status(entry_id, "commit", PostingStatus.PENDING),
+            status=PostingStatus.COMMITTED,
+        )
+        self._entries[entry_id] = committed
+        return committed
+
+    def cancel_journal_entry(self, entry_id: str) -> JournalEntry:
+        """PENDING -> CANCELLED (voided, no balance impact)."""
+        cancelled = replace(
+            self._require_status(entry_id, "cancel", PostingStatus.PENDING),
+            status=PostingStatus.CANCELLED,
+        )
+        self._entries[entry_id] = cancelled
+        return cancelled
+
+    def revert_journal_entry(self, entry_id: str) -> JournalEntry:
+        """Revert a POSTED/COMMITTED entry.
+
+        The original flips to REVERSED (dropped from balance). A lineage
+        reversing entry (postings with directions swapped) is recorded — also
+        REVERSED, so it never re-adds to a balance. Net effect: the original
+        entry's contribution is removed exactly once (no double-count).
+        """
+        original = self._require_status(
+            entry_id, "revert", PostingStatus.POSTED, PostingStatus.COMMITTED
+        )
+        self._entries[entry_id] = replace(original, status=PostingStatus.REVERSED)
+
+        reversing = JournalEntry(
+            entry_id=f"{entry_id}-rev",
+            description=f"Reversal of {entry_id}",
+            postings=tuple(self._swap(p) for p in original.postings),
+            status=PostingStatus.REVERSED,
+            metadata={**original.metadata, "reverses": entry_id},
+        )
+        self._entries[reversing.entry_id] = reversing
+        return reversing
+
+    def annotate_journal_entry(self, entry_id: str, note: str) -> GLAuditEntry:
+        """Attach a records-only NOTED annotation (never a balance impact)."""
+        entry = self._entries.get(entry_id)
+        if entry is None:
+            raise ValueError(f"Cannot annotate unknown journal entry {entry_id!r}")
+        annotation = GLAuditEntry(
+            entry_id=entry_id,
+            action="ANNOTATE",
+            status=PostingStatus.NOTED,
+            total_amount=Decimal("0"),
+            currency=entry.postings[0].currency,
+            actor="system",
+            timestamp=datetime.now(UTC).isoformat(),
+            details=note,
+        )
+        self._annotations.append(annotation)
+        return annotation
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _require_status(self, entry_id: str, action: str, *allowed: PostingStatus) -> JournalEntry:
+        entry = self._entries.get(entry_id)
+        if entry is None:
+            raise ValueError(f"Cannot {action} unknown journal entry {entry_id!r}")
+        if entry.status not in allowed:
+            allowed_names = "/".join(s.value for s in allowed)
+            raise ValueError(
+                f"Cannot {action} entry {entry_id!r} in status {entry.status.value} "
+                f"(requires {allowed_names})"
+            )
+        return entry
+
+    @staticmethod
+    def _swap(posting: Posting) -> Posting:
+        flipped = (
+            PostingDirection.CREDIT
+            if posting.direction == PostingDirection.DEBIT
+            else PostingDirection.DEBIT
+        )
+        return replace(posting, posting_id=f"{posting.posting_id}-rev", direction=flipped)
+
+    @property
+    def annotations(self) -> list[GLAuditEntry]:
+        return list(self._annotations)
 
     @property
     def accounts(self) -> dict[str, Account]:

--- a/services/ledger/ledger_models.py
+++ b/services/ledger/ledger_models.py
@@ -17,12 +17,31 @@ from enum import Enum
 
 
 class PostingStatus(str, Enum):
-    """Status of a journal entry posting."""
+    """Status of a journal entry posting.
+
+    Lifecycle (mirrors Midaz, additive over the legacy PENDING/POSTED/REVERSED/
+    FAILED): a staged entry is PENDING, then COMMITTED (counts toward balance)
+    or CANCELLED (voided, no balance impact). A POSTED/COMMITTED entry may be
+    REVERSED (dropped from balance, with a lineage reversing entry). NOTED marks
+    an annotation record — records-only, never a balance impact. The legacy
+    immediate ``post_journal_entry`` path still uses POSTED (also counts).
+    """
 
     PENDING = "PENDING"
     POSTED = "POSTED"
+    COMMITTED = "COMMITTED"
+    CANCELLED = "CANCELLED"
     REVERSED = "REVERSED"
+    NOTED = "NOTED"
     FAILED = "FAILED"
+
+
+# Statuses that contribute to an account balance (POSTED = legacy immediate
+# post; COMMITTED = committed lifecycle entry). PENDING/CANCELLED/REVERSED/
+# NOTED/FAILED are excluded.
+BALANCE_AFFECTING_STATUSES: frozenset[PostingStatus] = frozenset(
+    {PostingStatus.POSTED, PostingStatus.COMMITTED}
+)
 
 
 class AccountType(str, Enum):

--- a/services/ledger/ledger_port.py
+++ b/services/ledger/ledger_port.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Protocol
 
-from services.ledger.ledger_models import Account, JournalEntry
+from services.ledger.ledger_models import Account, GLAuditEntry, JournalEntry
 
 
 class LedgerInfrastructureError(RuntimeError):
@@ -45,4 +45,27 @@ class LedgerPort(Protocol):
 
     def get_account_balance(self, account_id: str) -> Decimal:
         """Return current balance for account (Decimal, I-01)."""
+        ...
+
+    # ── transaction lifecycle (mirrors Midaz; additive over post_journal_entry) ──
+
+    def create_journal_entry(self, entry: JournalEntry) -> JournalEntry:
+        """Stage a balanced entry as PENDING (not yet counted toward balance)."""
+        ...
+
+    def commit_journal_entry(self, entry_id: str) -> JournalEntry:
+        """PENDING -> COMMITTED (now counts toward balance). Raises if not PENDING."""
+        ...
+
+    def cancel_journal_entry(self, entry_id: str) -> JournalEntry:
+        """PENDING -> CANCELLED (voided, no balance impact). Raises if not PENDING."""
+        ...
+
+    def revert_journal_entry(self, entry_id: str) -> JournalEntry:
+        """Revert a POSTED/COMMITTED entry: original -> REVERSED (dropped from
+        balance); returns the lineage reversing entry. Raises if not revertible."""
+        ...
+
+    def annotate_journal_entry(self, entry_id: str, note: str) -> GLAuditEntry:
+        """Attach a records-only NOTED annotation. Never a balance impact."""
         ...

--- a/tests/test_ledger_lifecycle.py
+++ b/tests/test_ledger_lifecycle.py
@@ -1,0 +1,189 @@
+"""
+tests/test_ledger_lifecycle.py — GL transaction lifecycle (D-gl build-spec DoD #4).
+
+`test_transaction_lifecycle`: create -> commit (PENDING -> COMMITTED, counts);
+cancel a PENDING (no balance impact); revert a POSTED/COMMITTED entry (nets the
+balance back, with a lineage reversing entry); annotation = records-only, never
+a balance impact. Legacy immediate `post_journal_entry` (POSTED) still counts —
+backward compatible. All offline; Decimal-only (I-01).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.ledger.gl_service import GLService, InMemoryGLAuditPort
+from services.ledger.inmemory_ledger import InMemoryLedger
+from services.ledger.ledger_models import (
+    Account,
+    AccountType,
+    JournalEntry,
+    Posting,
+    PostingDirection,
+    PostingStatus,
+)
+
+A = "acct-asset"
+B = "acct-liability"
+
+
+def _ledger() -> InMemoryLedger:
+    led = InMemoryLedger()
+    led.create_account(
+        Account(account_id=A, name="Asset", account_type=AccountType.ASSET, currency="GBP")
+    )
+    led.create_account(
+        Account(account_id=B, name="Liab", account_type=AccountType.LIABILITY, currency="GBP")
+    )
+    return led
+
+
+def _entry(entry_id: str, amount: str = "100.00") -> JournalEntry:
+    return JournalEntry(
+        entry_id=entry_id,
+        description="test",
+        postings=(
+            Posting(f"{entry_id}-d", A, PostingDirection.DEBIT, Decimal(amount), "GBP"),
+            Posting(f"{entry_id}-c", B, PostingDirection.CREDIT, Decimal(amount), "GBP"),
+        ),
+    )
+
+
+# ── create -> commit ──────────────────────────────────────────────────────────
+
+
+def test_create_stages_pending_not_counted():
+    led = _ledger()
+    staged = led.create_journal_entry(_entry("e1"))
+    assert staged.status == PostingStatus.PENDING
+    assert led.get_account_balance(A) == Decimal("0")  # PENDING not counted
+
+
+def test_commit_pending_to_committed_counts():
+    led = _ledger()
+    led.create_journal_entry(_entry("e1"))
+    committed = led.commit_journal_entry("e1")
+    assert committed.status == PostingStatus.COMMITTED
+    assert led.get_account_balance(A) == Decimal("100.00")  # COMMITTED counts
+
+
+def test_commit_non_pending_raises():
+    led = _ledger()
+    led.post_journal_entry(_entry("e1"))  # POSTED, not PENDING
+    with pytest.raises(ValueError, match="Cannot commit"):
+        led.commit_journal_entry("e1")
+
+
+def test_commit_unknown_raises():
+    led = _ledger()
+    with pytest.raises(ValueError, match="unknown"):
+        led.commit_journal_entry("nope")
+
+
+# ── cancel ──────────────────────────────────────────────────────────────────
+
+
+def test_cancel_pending_no_balance_impact():
+    led = _ledger()
+    led.create_journal_entry(_entry("e1"))
+    cancelled = led.cancel_journal_entry("e1")
+    assert cancelled.status == PostingStatus.CANCELLED
+    assert led.get_account_balance(A) == Decimal("0")
+
+
+def test_cancel_committed_raises():
+    led = _ledger()
+    led.create_journal_entry(_entry("e1"))
+    led.commit_journal_entry("e1")
+    with pytest.raises(ValueError, match="Cannot cancel"):
+        led.cancel_journal_entry("e1")
+
+
+# ── revert ────────────────────────────────────────────────────────────────────
+
+
+def test_revert_posted_nets_balance_to_zero():
+    led = _ledger()
+    led.post_journal_entry(_entry("e1"))  # POSTED, +100
+    assert led.get_account_balance(A) == Decimal("100.00")
+    reversing = led.revert_journal_entry("e1")
+    assert reversing.entry_id == "e1-rev"
+    assert reversing.metadata["reverses"] == "e1"
+    assert led.get_journal_entry("e1").status == PostingStatus.REVERSED
+    assert reversing.status == PostingStatus.REVERSED
+    assert led.get_account_balance(A) == Decimal("0")  # no double-count
+
+
+def test_revert_committed_nets_balance_to_zero():
+    led = _ledger()
+    led.create_journal_entry(_entry("e1"))
+    led.commit_journal_entry("e1")
+    assert led.get_account_balance(A) == Decimal("100.00")
+    led.revert_journal_entry("e1")
+    assert led.get_account_balance(A) == Decimal("0")
+
+
+def test_revert_pending_raises():
+    led = _ledger()
+    led.create_journal_entry(_entry("e1"))  # PENDING — not revertible
+    with pytest.raises(ValueError, match="Cannot revert"):
+        led.revert_journal_entry("e1")
+
+
+def test_revert_unknown_raises():
+    led = _ledger()
+    with pytest.raises(ValueError, match="unknown"):
+        led.revert_journal_entry("nope")
+
+
+# ── annotate ──────────────────────────────────────────────────────────────────
+
+
+def test_annotate_noted_no_balance_impact():
+    led = _ledger()
+    led.post_journal_entry(_entry("e1"))
+    before = led.get_account_balance(A)
+    annotation = led.annotate_journal_entry("e1", "reviewed by ops")
+    assert annotation.status == PostingStatus.NOTED
+    assert annotation.details == "reviewed by ops"
+    assert led.get_account_balance(A) == before  # unchanged
+    assert led.annotations and led.annotations[0].entry_id == "e1"
+
+
+def test_annotate_unknown_raises():
+    led = _ledger()
+    with pytest.raises(ValueError, match="unknown"):
+        led.annotate_journal_entry("nope", "x")
+
+
+# ── backward compatibility ────────────────────────────────────────────────────
+
+
+def test_legacy_posted_still_counts():
+    led = _ledger()
+    led.post_journal_entry(_entry("e1"))  # legacy immediate POSTED
+    assert led.get_journal_entry("e1").status == PostingStatus.POSTED
+    assert led.get_account_balance(A) == Decimal("100.00")
+
+
+# ── GLService wrappers record audit (I-24) ────────────────────────────────────
+
+
+def test_gl_service_lifecycle_records_audit():
+    led = _ledger()
+    audit = InMemoryGLAuditPort()
+    svc = GLService(ledger=led, audit=audit)
+
+    led.create_journal_entry(_entry("e1"))
+    svc.commit_entry("e1", actor="ops")
+    svc.annotate_entry("e1", "note")
+    svc.revert_entry("e1", actor="ops")
+
+    actions = [a.action for a in audit.entries]
+    assert "COMMIT_JOURNAL_ENTRY" in actions
+    assert "ANNOTATE" in actions
+    assert "REVERT_JOURNAL_ENTRY" in actions
+    # commit counted, then revert netted back to zero
+    assert led.get_account_balance(A) == Decimal("0")


### PR DESCRIPTION
## Summary
Second cross-repo D-gl runtime increment — **transaction lifecycle** (D-GL-BUILD-SPEC IL-484 **DoD #4** `test_transaction_lifecycle`). Mirrors the Midaz transaction lifecycle, **additive** over the legacy immediate `post_journal_entry` and **backward-compatible**.

## Changes
- `services/ledger/ledger_models.py` — `PostingStatus` += `COMMITTED` / `CANCELLED` / `NOTED`; `BALANCE_AFFECTING_STATUSES = {POSTED, COMMITTED}` (legacy POSTED still counts).
- `services/ledger/ledger_port.py` — 5 lifecycle methods added to the Protocol.
- `services/ledger/inmemory_ledger.py` — implementation + balance derivation:
  - `create_journal_entry` → **PENDING** (staged, not counted)
  - `commit_journal_entry` → **COMMITTED** (counts) · `cancel_journal_entry` → **CANCELLED** (no balance)
  - `revert_journal_entry` → original **REVERSED** (dropped from balance) + lineage reversing entry — **single mechanism, no double-count**, nets balance to zero
  - `annotate_journal_entry` → **NOTED** records-only, never a balance impact
- `services/ledger/gl_service.py` — `commit_entry` / `cancel_entry` / `revert_entry` / `annotate_entry` wrappers, each records a `GLAuditEntry` (**I-24**).
- `tests/test_ledger_lifecycle.py` — 14 tests (create→commit, cancel, revert-nets-to-zero, annotate-no-balance, illegal-transition raises, **legacy POSTED back-compat**, audit rows).

## Out of scope (deferred to later increments)
Fineract fallback + ledger factory; api-router 503 mapping; high-value approval persistence.

## Verification (offline, no live infra)
- **226 ledger/recon tests pass** (14 new lifecycle + back-compat gl_service / payment_posting / ledger_adapter / reconciliation / api_ledger).
- ruff + format clean; semgrep banxe-rules clean; Decimal-only (I-01).
- LedgerPort Protocol additive — only `InMemoryLedger` implements it (Midaz/Stub adapters are recon-shaped, unaffected).

IL: `IL-CBS-DGL-LIFECYCLE-2026-06-26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)