### PR TITLE
fix(api): ledger API maps LedgerInfrastructureError to HTTP 503 (fail-closed edge) [IL-CBS-DGL-API503]

### DIFF
--- a/INSTRUCTION-LEDGER.md
+++ b/INSTRUCTION-LEDGER.md
@@ -412,3 +412,30 @@
   it (Midaz/Stub adapters are recon-shaped, unaffected).
 - Landing: sandbox-autonomous mode — green PR auto-merged when CLEAN.
 - Anchors: D-GL-BUILD-SPEC (IL-484) §3.3/§5 DoD #4; ADR-013; I-01, I-24, I-28.
+
+### IL-CBS-DGL-API503-2026-06-26
+- Date: 2026-06-26
+- Status: DONE (offline; no live infra)
+- Scope: D-gl API fail-closed mapping (third cross-repo runtime increment),
+  completing DoD #8 at the API edge. The ledger API production branch
+  previously surfaced raw httpx errors (and `midaz_client` swallowed nothing
+  explicitly); now `midaz_client.get_balance`/`list_accounts` fail closed
+  (transport/5xx → `LedgerInfrastructureError`; 4xx / no-GBP → safe default),
+  and `api/routers/ledger.py` maps `LedgerInfrastructureError` → **HTTP 503**
+  (Ledger temporarily unavailable), keeping reachable "not found" → **404**.
+  The previously `# pragma: no cover` production paths are now covered.
+- Files modified:
+  - `services/ledger/midaz_client.py` (fail-closed get_balance/list_accounts;
+    removed a dead un-awaited client.get line in the rewritten get_balance body)
+  - `api/routers/ledger.py` (LedgerInfrastructureError → 503; None → 404)
+- Files created:
+  - `tests/test_api_ledger_failclosed.py` (503 on infra error, 404 on None,
+    200 happy, for both balance + list endpoints; fake midaz_client injected,
+    `_is_sandbox` forced False — offline)
+- Out of scope (deferred): Fineract fallback (operator-gated, no API ref — see
+  C steer); high-value approval audit (next increment).
+- Verification: API + ledger suites pass offline (incl. existing sandbox API
+  tests); ruff + format clean; semgrep banxe-rules clean; Decimal-only (I-01).
+- Landing: sandbox-autonomous mode — green PR auto-merged when CLEAN.
+- Anchors: D-GL-BUILD-SPEC (IL-484) §5 DoD #8 (API edge); ADR-013; FCA CASS
+  7.15; I-01, I-28.

--- a/api/routers/ledger.py
+++ b/api/routers/ledger.py
@@ -21,6 +21,10 @@ from api.models.ledger import (
     AccountListResponse,
     AccountResponse,
 )
+from services.ledger.ledger_port import LedgerInfrastructureError
+
+# Returned when the ledger backend (Midaz) is unreachable / 5xx — fail-closed.
+_LEDGER_UNAVAILABLE = "Ledger temporarily unavailable"
 
 router = APIRouter(tags=["Ledger"])
 
@@ -77,10 +81,13 @@ async def list_accounts() -> AccountListResponse:
         accounts = [AccountResponse(**a) for a in _MOCK_ACCOUNTS]
         return AccountListResponse(accounts=accounts, total=len(accounts))
 
-    from services.ledger import midaz_client  # pragma: no cover
+    from services.ledger import midaz_client
 
-    raw = await midaz_client.list_accounts()  # pragma: no cover
-    accounts = [  # pragma: no cover
+    try:
+        raw = await midaz_client.list_accounts()
+    except LedgerInfrastructureError as exc:
+        raise HTTPException(status_code=503, detail=_LEDGER_UNAVAILABLE) from exc
+    accounts = [
         AccountResponse(
             account_id=a.get("id", ""),
             name=a.get("name", ""),
@@ -90,9 +97,7 @@ async def list_accounts() -> AccountListResponse:
         )
         for a in raw
     ]
-    return AccountListResponse(  # pragma: no cover
-        accounts=accounts, total=len(accounts)
-    )
+    return AccountListResponse(accounts=accounts, total=len(accounts))
 
 
 @router.get(
@@ -121,12 +126,15 @@ async def get_balance(account_id: str) -> AccountBalanceResponse:
             currency=data["currency"],
         )
 
-    from services.ledger import midaz_client  # pragma: no cover
+    from services.ledger import midaz_client
 
-    balance = await midaz_client.get_balance(account_id)  # pragma: no cover
-    if balance is None:  # pragma: no cover
+    try:
+        balance = await midaz_client.get_balance(account_id)
+    except LedgerInfrastructureError as exc:
+        raise HTTPException(status_code=503, detail=_LEDGER_UNAVAILABLE) from exc
+    if balance is None:
         raise HTTPException(status_code=404, detail=f"Account {account_id} not found")
-    return AccountBalanceResponse(  # pragma: no cover
+    return AccountBalanceResponse(
         account_id=account_id,
         available=str(balance),
         total=str(balance),

--- a/services/ledger/midaz_client.py
+++ b/services/ledger/midaz_client.py
@@ -9,6 +9,8 @@ import os
 
 import httpx
 
+from services.ledger.ledger_port import LedgerInfrastructureError
+
 MIDAZ_BASE_URL = os.environ["MIDAZ_BASE_URL"]
 MIDAZ_ORG_ID = os.environ["MIDAZ_ORG_ID"]
 MIDAZ_LEDGER_ID = os.environ["MIDAZ_LEDGER_ID"]
@@ -24,18 +26,30 @@ async def get_balance(account_id: str) -> Decimal | None:
     """
     Fetch GBP available balance for *account_id* from Midaz.
 
-    Returns Decimal amount or None if the account is not found.
-    NEVER returns float — FCA CASS invariant.
+    Returns Decimal amount, or None if the account is not found / no GBP balance
+    (reachable backend, definite answer). Raises LedgerInfrastructureError
+    (fail-closed) if Midaz is unreachable or returns a 5xx — never a silent
+    balance that masks an outage. NEVER returns float — FCA CASS invariant.
     """
     url = (
         f"{MIDAZ_BASE_URL}/v1/organizations/{MIDAZ_ORG_ID}"
         f"/ledgers/{MIDAZ_LEDGER_ID}/accounts/{account_id}/balances"
     )
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = client.get(url, headers=_HEADERS)  # type: ignore[attr-defined]
-        resp = await client.get(url, headers=_HEADERS)
-        resp.raise_for_status()
-        data = resp.json()
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(url, headers=_HEADERS)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code < 500:
+            return None  # reachable, definite (e.g. 404 not found)
+        raise LedgerInfrastructureError(
+            f"Midaz unavailable fetching balance for account={account_id}"
+        ) from exc
+    except httpx.RequestError as exc:
+        raise LedgerInfrastructureError(
+            f"Midaz unavailable fetching balance for account={account_id}"
+        ) from exc
 
     # Midaz returns available balance as integer cents in "available" field
     items = data.get("items", [data])
@@ -48,9 +62,21 @@ async def get_balance(account_id: str) -> Decimal | None:
 
 
 async def list_accounts() -> list[dict]:
-    """Return all accounts for the safeguarding ledger."""
+    """Return all accounts for the safeguarding ledger.
+
+    Raises LedgerInfrastructureError (fail-closed) if Midaz is unreachable or
+    returns a 5xx; a 4xx returns [] (reachable, definite).
+    """
     url = f"{MIDAZ_BASE_URL}/v1/organizations/{MIDAZ_ORG_ID}/ledgers/{MIDAZ_LEDGER_ID}/accounts"
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.get(url, headers=_HEADERS)
-        resp.raise_for_status()
-    return resp.json().get("items", [])
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(url, headers=_HEADERS)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code < 500:
+            return []
+        raise LedgerInfrastructureError("Midaz unavailable listing accounts") from exc
+    except httpx.RequestError as exc:
+        raise LedgerInfrastructureError("Midaz unavailable listing accounts") from exc
+    return data.get("items", [])

--- a/tests/test_api_ledger_failclosed.py
+++ b/tests/test_api_ledger_failclosed.py
@@ -1,0 +1,88 @@
+"""
+tests/test_api_ledger_failclosed.py — ledger API fail-closed mapping.
+
+Production branch (non-sandbox) of api/routers/ledger.py: a
+LedgerInfrastructureError from midaz_client (Midaz unreachable / 5xx) maps to
+HTTP 503 — never a silent 200/zero. A reachable "not found" (None) stays 404.
+
+Offline — no live Midaz; a fake midaz_client module is injected and
+`_is_sandbox` is forced False.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import sys
+import types
+
+from fastapi.testclient import TestClient
+import pytest
+
+from api.main import app
+from services.ledger.ledger_port import LedgerInfrastructureError
+
+client = TestClient(app)
+
+
+def _fake_midaz(*, balance=None, accounts=None, raise_infra=False) -> types.ModuleType:
+    mod = types.ModuleType("services.ledger.midaz_client")
+
+    async def get_balance(account_id: str):
+        if raise_infra:
+            raise LedgerInfrastructureError("Midaz down")
+        return balance
+
+    async def list_accounts():
+        if raise_infra:
+            raise LedgerInfrastructureError("Midaz down")
+        return accounts or []
+
+    mod.get_balance = get_balance  # type: ignore[attr-defined]
+    mod.list_accounts = list_accounts  # type: ignore[attr-defined]
+    return mod
+
+
+@pytest.fixture
+def production(monkeypatch):
+    """Force the production (non-sandbox) router branch."""
+    monkeypatch.setattr("api.routers.ledger._is_sandbox", lambda: False)
+    return monkeypatch
+
+
+def _inject(production, module: types.ModuleType) -> None:
+    production.setitem(sys.modules, "services.ledger.midaz_client", module)
+
+
+def test_balance_infra_error_returns_503(production):
+    _inject(production, _fake_midaz(raise_infra=True))
+    resp = client.get("/v1/ledger/accounts/acc-x/balance")
+    assert resp.status_code == 503
+
+
+def test_balance_unknown_account_returns_404(production):
+    _inject(production, _fake_midaz(balance=None))
+    resp = client.get("/v1/ledger/accounts/acc-x/balance")
+    assert resp.status_code == 404
+
+
+def test_balance_production_happy_200(production):
+    _inject(production, _fake_midaz(balance=Decimal("123.45")))
+    resp = client.get("/v1/ledger/accounts/acc-x/balance")
+    assert resp.status_code == 200
+    assert resp.json()["available"] == "123.45"
+
+
+def test_list_accounts_infra_error_returns_503(production):
+    _inject(production, _fake_midaz(raise_infra=True))
+    resp = client.get("/v1/ledger/accounts")
+    assert resp.status_code == 503
+
+
+def test_list_accounts_production_happy_200(production):
+    accts = [
+        {"id": "a1", "name": "A", "type": "OPERATIONAL", "assetCode": "GBP", "status": "ACTIVE"}
+    ]
+    _inject(production, _fake_midaz(accounts=accts))
+    resp = client.get("/v1/ledger/accounts")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1


### PR DESCRIPTION
## Summary
Third D-gl runtime increment — completes **DoD #8 at the API edge**. Deferred from PR #214.

**Before:** the ledger API production branch surfaced raw httpx errors; `midaz_client` did no explicit fail-closed handling. **Now:** `midaz_client.get_balance`/`list_accounts` fail closed (transport/5xx → `LedgerInfrastructureError`; 4xx / no-GBP → safe default), and `api/routers/ledger.py` maps `LedgerInfrastructureError` → **HTTP 503** ("Ledger temporarily unavailable"), keeping a reachable "not found" → **404**. The previously `# pragma: no cover` production paths are now covered.

## Changes
- `services/ledger/midaz_client.py` — fail-closed `get_balance` / `list_accounts` (mirrors the #214 adapter split: transport/5xx raise; 4xx → `None`/`[]`). Also drops a dead un-awaited `client.get(...)` line in the rewritten `get_balance` body.
- `api/routers/ledger.py` — `LedgerInfrastructureError` → `HTTPException(503)`; `None` → `404`; happy path unchanged.
- `tests/test_api_ledger_failclosed.py` — 503-on-infra-error, 404-on-None, 200-happy for both balance + list endpoints (fake `midaz_client` injected, `_is_sandbox` forced False; offline).

## Out of scope (deferred)
Fineract fallback (operator-gated, no API reference — per the C steer); high-value approval audit (next increment).

## Verification (offline)
API + ledger suites pass (incl. existing sandbox API tests); ruff + format clean; semgrep banxe-rules clean; Decimal-only (I-01).

IL: `IL-CBS-DGL-API503-2026-06-26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)