### PR TITLE
feat(ledger): high-value approval audit — named-human approve/reject, append-only [IL-CBS-DGL-APPROVAL]

### DIFF
--- a/INSTRUCTION-LEDGER.md
+++ b/INSTRUCTION-LEDGER.md
@@ -439,3 +439,32 @@
 - Landing: sandbox-autonomous mode — green PR auto-merged when CLEAN.
 - Anchors: D-GL-BUILD-SPEC (IL-484) §5 DoD #8 (API edge); ADR-013; FCA CASS
   7.15; I-01, I-28.
+
+### IL-CBS-DGL-APPROVAL-2026-06-26
+- Date: 2026-06-26
+- Status: DONE (offline; no live infra)
+- Scope: D-gl high-value approval audit (fourth cross-repo runtime increment,
+  D-GL-BUILD-SPEC IL-484 DoD #5 `test_high_value_posting_requires_approval`).
+  A posting ≥ HIGH_VALUE_THRESHOLD (£50k) is staged (never auto-posted, I-04)
+  and recorded PENDING in an append-only approval store (I-24). A NAMED human
+  must `approve_high_value` (posts the entry) or `reject_high_value` (does not);
+  both raise on a blank approver (I-27 — AI proposes, never auto-approves). The
+  bool `high_value_approved` fast-path is unchanged (back-compat).
+- Files created:
+  - `services/ledger/approval_models.py` (ApprovalDecision, HighValueApproval
+    Decimal model, ApprovalStorePort, append-only InMemoryApprovalStore)
+  - `tests/test_high_value_approval.py` (8 tests: PENDING recorded, approve
+    requires human + posts, reject requires human + no post, append-only store,
+    below-threshold direct post, unknown raises)
+- Files modified:
+  - `services/ledger/gl_service.py` (stage high-value entry + record PENDING;
+    `approve_high_value` / `reject_high_value` with named-approver guard + audit;
+    builds the JournalEntry before the high-value branch)
+- Out of scope (deferred / operator-gated): Fineract fallback (no API ref).
+  This completes the in-codebase D-gl runtime increments; next per critical
+  path = E-safeguard / D-recon runtime (recon_port + D-gl Leg A now landed).
+- Verification: 146 ledger/api tests pass offline (incl. back-compat
+  gl_service / payment_posting / lifecycle / adapter / api); ruff + format
+  clean; semgrep banxe-rules clean; Decimal-only (I-01).
+- Landing: sandbox-autonomous mode — green PR auto-merged when CLEAN.
+- Anchors: D-GL-BUILD-SPEC (IL-484) §5 DoD #5; ADR-013; I-01, I-04, I-24, I-27.

--- a/services/ledger/approval_models.py
+++ b/services/ledger/approval_models.py
@@ -1,0 +1,68 @@
+"""
+services/ledger/approval_models.py
+High-value posting approval audit (I-04 high-value, I-24 append-only, I-27 HITL).
+
+A high-value journal entry (>= HIGH_VALUE_THRESHOLD) is never auto-posted: it is
+recorded PENDING and requires a named human approver to APPROVE (which posts it)
+or REJECT (which does not). The store is append-only — a decision appends a new
+row, never mutating the PENDING record (I-24).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Protocol
+
+
+class ApprovalDecision(str, Enum):
+    """State of a high-value approval."""
+
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class HighValueApproval:
+    """Immutable audit row for a high-value approval (I-01 Decimal, I-24)."""
+
+    proposal_id: str
+    entry_id: str
+    total_amount: Decimal  # I-01
+    currency: str
+    requested_by: str
+    decision: ApprovalDecision = ApprovalDecision.PENDING
+    approver: str | None = None
+    reason: str = ""
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    decided_at: str | None = None
+
+
+class ApprovalStorePort(Protocol):
+    """Append-only store for high-value approval audit rows (I-24)."""
+
+    def record(self, approval: HighValueApproval) -> None: ...
+
+    def get(self, proposal_id: str) -> HighValueApproval | None: ...
+
+
+class InMemoryApprovalStore:
+    """Append-only in-memory approval audit trail (I-24)."""
+
+    def __init__(self) -> None:
+        self._records: list[HighValueApproval] = []
+
+    def record(self, approval: HighValueApproval) -> None:
+        # Append-only: a decision is a NEW row; the PENDING row is never mutated.
+        self._records.append(approval)
+
+    def get(self, proposal_id: str) -> HighValueApproval | None:
+        matches = [r for r in self._records if r.proposal_id == proposal_id]
+        return matches[-1] if matches else None
+
+    @property
+    def records(self) -> list[HighValueApproval]:
+        return list(self._records)

--- a/services/ledger/gl_service.py
+++ b/services/ledger/gl_service.py
@@ -13,10 +13,17 @@ I-24: Immutable audit trail for every GL operation.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Protocol
 from uuid import uuid4
 
+from services.ledger.approval_models import (
+    ApprovalDecision,
+    ApprovalStorePort,
+    HighValueApproval,
+    InMemoryApprovalStore,
+)
 from services.ledger.ledger_models import (
     BLOCKED_JURISDICTIONS,
     HIGH_VALUE_THRESHOLD,
@@ -101,9 +108,17 @@ class GLService:
         self,
         ledger: LedgerPort,
         audit: GLAuditPort | None = None,
+        approval_store: ApprovalStorePort | None = None,
     ) -> None:
         self._ledger = ledger
         self._audit: GLAuditPort = audit or InMemoryGLAuditPort()
+        self._approval_store: ApprovalStorePort = approval_store or InMemoryApprovalStore()
+        # High-value entries staged awaiting a human approval decision (I-27).
+        self._pending_high_value: dict[str, JournalEntry] = {}
+
+    @property
+    def approval_store(self) -> ApprovalStorePort:
+        return self._approval_store
 
     # ── Account Operations ───────────────────────────────────────────────────
 
@@ -201,7 +216,25 @@ class GLService:
         currencies = {p.currency for p in posting_objs}
         primary_currency = next(iter(currencies))
 
+        entry = JournalEntry(
+            entry_id=entry_id,
+            description=description,
+            postings=tuple(posting_objs),
+        )
+
         if total_debit >= HIGH_VALUE_THRESHOLD and not high_value_approved:
+            # I-04/I-27: do NOT auto-post. Stage the entry and record a PENDING
+            # approval row (I-24) — a named human must approve/reject.
+            self._pending_high_value[entry_id] = entry
+            self._approval_store.record(
+                HighValueApproval(
+                    proposal_id=entry_id,
+                    entry_id=entry_id,
+                    total_amount=total_debit,
+                    currency=primary_currency,
+                    requested_by="SYSTEM",
+                )
+            )
             return HighValueHITLProposal(
                 entry_id=entry_id,
                 total_amount=str(total_debit),
@@ -212,12 +245,6 @@ class GLService:
                     "MLRO approval required (I-04, I-27)."
                 ),
             )
-
-        entry = JournalEntry(
-            entry_id=entry_id,
-            description=description,
-            postings=tuple(posting_objs),
-        )
 
         posted = self._ledger.post_journal_entry(entry)
 
@@ -272,6 +299,92 @@ class GLService:
             currency=entry.postings[0].currency,
             actor=actor,
             details=f"status={entry.status.value}",
+        )
+
+    # ── High-value approval (I-04 / I-24 / I-27: named human approver only) ────
+
+    def approve_high_value(self, entry_id: str, approver: str, reason: str = "") -> JournalEntry:
+        """Approve a staged high-value entry and post it.
+
+        Requires a non-empty human approver (I-27 — AI proposes, never
+        auto-approves). Appends an APPROVED row to the approval store (I-24).
+        """
+        entry = self._require_approver_and_pending(entry_id, approver, "approve")
+        posted = self._ledger.post_journal_entry(entry)
+        total_debit = self._total_debit(entry)
+        self._approval_store.record(
+            HighValueApproval(
+                proposal_id=entry_id,
+                entry_id=entry_id,
+                total_amount=total_debit,
+                currency=entry.postings[0].currency,
+                requested_by="SYSTEM",
+                decision=ApprovalDecision.APPROVED,
+                approver=approver,
+                reason=reason,
+                decided_at=datetime.now(UTC).isoformat(),
+            )
+        )
+        self._record_audit(
+            entry_id=entry_id,
+            action="APPROVE_HIGH_VALUE",
+            status=posted.status,
+            total_amount=total_debit,
+            currency=entry.postings[0].currency,
+            actor=approver,
+            details=reason,
+        )
+        del self._pending_high_value[entry_id]
+        return posted
+
+    def reject_high_value(
+        self, entry_id: str, approver: str, reason: str = ""
+    ) -> HighValueApproval:
+        """Reject a staged high-value entry (it is NOT posted).
+
+        Requires a non-empty human approver (I-27). Appends a REJECTED row (I-24).
+        """
+        entry = self._require_approver_and_pending(entry_id, approver, "reject")
+        total_debit = self._total_debit(entry)
+        rejection = HighValueApproval(
+            proposal_id=entry_id,
+            entry_id=entry_id,
+            total_amount=total_debit,
+            currency=entry.postings[0].currency,
+            requested_by="SYSTEM",
+            decision=ApprovalDecision.REJECTED,
+            approver=approver,
+            reason=reason,
+            decided_at=datetime.now(UTC).isoformat(),
+        )
+        self._approval_store.record(rejection)
+        self._record_audit(
+            entry_id=entry_id,
+            action="REJECT_HIGH_VALUE",
+            status=PostingStatus.CANCELLED,
+            total_amount=total_debit,
+            currency=entry.postings[0].currency,
+            actor=approver,
+            details=reason,
+        )
+        del self._pending_high_value[entry_id]
+        return rejection
+
+    def _require_approver_and_pending(
+        self, entry_id: str, approver: str, action: str
+    ) -> JournalEntry:
+        if not approver or not approver.strip():
+            raise ValueError(f"High-value {action} requires a named human approver (I-27)")
+        entry = self._pending_high_value.get(entry_id)
+        if entry is None:
+            raise ValueError(f"No pending high-value entry {entry_id!r} to {action}")
+        return entry
+
+    @staticmethod
+    def _total_debit(entry: JournalEntry) -> Decimal:
+        return sum(
+            (p.amount for p in entry.postings if p.direction == PostingDirection.DEBIT),
+            Decimal("0"),
         )
 
     # ── Private helpers ──────────────────────────────────────────────────────

--- a/tests/test_high_value_approval.py
+++ b/tests/test_high_value_approval.py
@@ -1,0 +1,119 @@
+"""
+tests/test_high_value_approval.py — high-value approval audit (D-gl DoD #5).
+
+A posting >= HIGH_VALUE_THRESHOLD (£50k) is never auto-posted (I-04): it is
+staged + recorded PENDING. A named human must approve (which posts it) or reject
+(which does not) — I-27, no auto-approve. The approval store is append-only
+(I-24). All offline; Decimal-only (I-01).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.ledger.approval_models import ApprovalDecision
+from services.ledger.gl_service import GLService, HighValueHITLProposal
+from services.ledger.inmemory_ledger import InMemoryLedger
+from services.ledger.ledger_models import AccountType, PostingDirection
+
+
+def _service() -> GLService:
+    svc = GLService(ledger=InMemoryLedger())
+    svc.create_account("Ops", AccountType.ASSET, "GBP")
+    svc.create_account("Liab", AccountType.LIABILITY, "GBP")
+    return svc
+
+
+def _accounts(svc: GLService) -> tuple[str, str]:
+    ids = list(svc._ledger.accounts.keys())  # type: ignore[attr-defined]
+    return ids[0], ids[1]
+
+
+def _high_value_postings(a: str, b: str):
+    amt = Decimal("60000.00")  # >= £50k threshold
+    return [
+        (a, PostingDirection.DEBIT, amt, "GBP"),
+        (b, PostingDirection.CREDIT, amt, "GBP"),
+    ]
+
+
+def test_high_value_proposal_recorded_pending():
+    svc = _service()
+    a, b = _accounts(svc)
+    result = svc.post_journal_entry("big", _high_value_postings(a, b))
+    assert isinstance(result, HighValueHITLProposal)
+    # not posted yet
+    assert svc.get_balance(a) == Decimal("0")
+    # PENDING approval row recorded (I-24)
+    rec = svc.approval_store.get(result.entry_id)
+    assert rec is not None
+    assert rec.decision == ApprovalDecision.PENDING
+    assert rec.total_amount == Decimal("60000.00")  # Decimal (I-01)
+
+
+def test_approve_requires_human_approver():
+    svc = _service()
+    a, b = _accounts(svc)
+    proposal = svc.post_journal_entry("big", _high_value_postings(a, b))
+    for blank in ("", "   "):
+        with pytest.raises(ValueError, match="named human approver"):
+            svc.approve_high_value(proposal.entry_id, blank)
+
+
+def test_approve_posts_entry_and_records_approved():
+    svc = _service()
+    a, b = _accounts(svc)
+    proposal = svc.post_journal_entry("big", _high_value_postings(a, b))
+    posted = svc.approve_high_value(proposal.entry_id, "mlro-alice", "verified")
+    assert posted.entry_id == proposal.entry_id
+    assert svc.get_balance(a) == Decimal("60000.00")  # now posted
+    rec = svc.approval_store.get(proposal.entry_id)
+    assert rec.decision == ApprovalDecision.APPROVED
+    assert rec.approver == "mlro-alice"
+
+
+def test_reject_does_not_post():
+    svc = _service()
+    a, b = _accounts(svc)
+    proposal = svc.post_journal_entry("big", _high_value_postings(a, b))
+    rejection = svc.reject_high_value(proposal.entry_id, "mlro-bob", "suspicious")
+    assert rejection.decision == ApprovalDecision.REJECTED
+    assert svc.get_balance(a) == Decimal("0")  # never posted
+
+
+def test_reject_requires_human_approver():
+    svc = _service()
+    a, b = _accounts(svc)
+    proposal = svc.post_journal_entry("big", _high_value_postings(a, b))
+    with pytest.raises(ValueError, match="named human approver"):
+        svc.reject_high_value(proposal.entry_id, "")
+
+
+def test_approval_store_append_only():
+    svc = _service()
+    a, b = _accounts(svc)
+    proposal = svc.post_journal_entry("big", _high_value_postings(a, b))
+    svc.approve_high_value(proposal.entry_id, "mlro-alice")
+    rows = [r for r in svc.approval_store.records if r.proposal_id == proposal.entry_id]
+    # PENDING row retained + APPROVED row appended (never mutated in place)
+    assert [r.decision for r in rows] == [ApprovalDecision.PENDING, ApprovalDecision.APPROVED]
+
+
+def test_approve_unknown_raises():
+    svc = _service()
+    with pytest.raises(ValueError, match="No pending high-value"):
+        svc.approve_high_value("je-nope", "mlro-alice")
+
+
+def test_below_threshold_posts_directly_no_approval():
+    svc = _service()
+    a, b = _accounts(svc)
+    amt = Decimal("100.00")
+    result = svc.post_journal_entry(
+        "small",
+        [(a, PostingDirection.DEBIT, amt, "GBP"), (b, PostingDirection.CREDIT, amt, "GBP")],
+    )
+    assert not isinstance(result, HighValueHITLProposal)
+    assert svc.get_balance(a) == Decimal("100.00")


### PR DESCRIPTION
## Summary
Fourth D-gl runtime increment — **DoD #5** (`test_high_value_posting_requires_approval`). Makes the ≥£50k high-value path **auditable + human-gated** (I-04 / I-24 / I-27).

A posting ≥ `HIGH_VALUE_THRESHOLD` is **staged, never auto-posted**, and recorded **PENDING** in an **append-only** approval store. A **named human** must `approve_high_value` (which posts the entry) or `reject_high_value` (which does not) — both **raise on a blank approver** (I-27: AI proposes, never auto-approves). The legacy `high_value_approved=True` fast-path is unchanged (back-compat).

## Changes
- `services/ledger/approval_models.py` (new) — `ApprovalDecision` (PENDING/APPROVED/REJECTED); `HighValueApproval` (Decimal amount, ids, approver, timestamps); `ApprovalStorePort`; append-only `InMemoryApprovalStore`.
- `services/ledger/gl_service.py` — build the JournalEntry before the high-value branch; stage + record PENDING; `approve_high_value` / `reject_high_value` with named-approver guard + audit (I-24).
- `tests/test_high_value_approval.py` (new) — 8 tests: PENDING recorded, approve requires human + posts, reject requires human + no post, **append-only store** (PENDING row retained), below-threshold direct post, unknown raises.

## Out of scope (operator-gated)
Fineract fallback (no API reference — per the C steer). This completes the in-codebase D-gl runtime increments; next per critical path = **E-safeguard / D-recon** runtime.

## Verification (offline)
146 ledger/api tests pass (incl. back-compat gl_service / payment_posting / lifecycle / adapter / api); ruff + format clean; semgrep banxe-rules clean; Decimal-only (I-01).

IL: `IL-CBS-DGL-APPROVAL-2026-06-26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a high-value approval workflow for large journal entries, keeping them pending until a human approves or rejects them.
  * Approval decisions now retain an audit trail with requester, approver, status, and timestamps.

* **Bug Fixes**
  * Ensured high-value entries are not posted automatically.
  * Added validation so approvals and rejections require a non-empty approver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->