### PR TITLE
feat(safeguarding): CASS 15 three-leg tie-out (A==B==C) + Leg C rail port [IL-CBS-DRECON-3LEG]

### DIFF
--- a/INSTRUCTION-LEDGER.md
+++ b/INSTRUCTION-LEDGER.md
@@ -468,3 +468,42 @@
   clean; semgrep banxe-rules clean; Decimal-only (I-01).
 - Landing: sandbox-autonomous mode — green PR auto-merged when CLEAN.
 - Anchors: D-GL-BUILD-SPEC (IL-484) §5 DoD #5; ADR-013; I-01, I-04, I-24, I-27.
+
+### IL-CBS-DRECON-3LEG-2026-06-26
+- Date: 2026-06-26
+- Status: DONE (offline; no live infra)
+- Scope: D-recon / E-safeguard runtime — first increment: CASS 15 three-leg
+  tie-out (D-RECON-BUILD-SPEC IL-474 §3). A (Midaz ledger) == B (safeguarding
+  account) == C (payment rail) within the penny-exact tolerance (£0.01),
+  reusing the shared `src/recon_core` mechanics (`evaluate_balances` +
+  `BreachEvaluator("BREAK")`). Adds the missing **Leg C** source
+  (`RailBalancePort` + `InMemoryRailBalancePort`) and the `three_leg_reconcile`
+  tie-out with signed-difference SHORTFALL detection (client-fund ledger > 
+  safeguarding account ⇒ under-safeguarded → escalate MLRO/CFO, CASS 15).
+- ADR-102 CANONICAL DECISION (live-audit, origin/main ebfeac6): the safeguarding
+  recon stack is consolidated onto **`src/recon_core/`** (shared mechanics, #164)
+  with a regime split — **CASS 15 = `src/safeguarding/`** (£0.01 BREAK), CASS 7.15
+  = `services/recon/reconciliation_engine_v2` (£100 HITL). Legacy/dormant
+  `reconciliation_engine.py` (old cron) + `recon_engine.py` (tests-only) are NOT
+  extended. This increment targets the CASS 15 (`src/safeguarding/`) path only.
+- BEST-DECISION REORDER (stated): the operator's recommended first increment
+  "SafeguardingAccountPort (Leg B)" ALREADY EXISTS as `BankStatementPort` in
+  `src/safeguarding/agent.py` (Leg A = `LedgerBalancePort`, Leg B =
+  `BankStatementPort`, A-vs-B recon + breach + audit already implemented).
+  Building it would duplicate (ADR-102). The genuine foundational gap is the
+  THIRD leg + the A==B==C tie-out — delivered here.
+- Files created:
+  - `src/safeguarding/three_leg.py` (RailBalancePort/InMemoryRailBalancePort,
+    ThreeLegStatus, ThreeLegResult, three_leg_reconcile)
+  - `tests/test_safeguarding_three_leg.py` (11 tests: MATCHED/BREAK/PENDING,
+    penny tolerance, shortfall vs surplus, signed diff, rail port)
+- Out of scope (next increments): wire 3-leg into SafeguardingAgent.run();
+  BreachNotifyPort + MLRO/CFO HITL escalation port; unified `safeguarding_events`
+  audit-table consolidation.
+- Verification: 11 new + 95 back-compat (src_safeguarding, src_safeguarding_agent,
+  recon_core) pass offline; ruff + format clean; semgrep banxe-rules clean;
+  Decimal-only (I-01). Additive — 2-leg `daily_reconciliation.py` / orchestrator
+  untouched.
+- Landing: sandbox-autonomous mode — green PR auto-merged when CLEAN.
+- Anchors: D-RECON-BUILD-SPEC (IL-474) §3 (3-leg); ADR-SAF-01; recon_core S6.2
+  boundary (#164); I-01, I-24.

--- a/src/safeguarding/three_leg.py
+++ b/src/safeguarding/three_leg.py
@@ -1,0 +1,153 @@
+"""Three-leg safeguarding tie-out (CASS 15) — D-RECON-BUILD-SPEC §3 (3-leg model).
+
+Extends the existing two-leg CASS 15 reconciliation (internal Midaz ledger vs
+safeguarding bank account, see ``daily_reconciliation.py``) with a THIRD leg —
+the payment-rail / operational bank balance — and a full A == B == C tie-out:
+
+  * Leg A — internal Midaz ledger client-fund total   (LedgerBalancePort, agent.py)
+  * Leg B — safeguarding bank account closing balance  (BankStatementPort, agent.py)
+  * Leg C — payment-rail / operational bank balance    (RailBalancePort, THIS module)
+
+The comparison MECHANICS are reused from ``src.recon_core`` (no duplication):
+each leg-pair is classified by the shared ``BreachEvaluator`` with the CASS 15
+penny-exact threshold (£0.01, ``breach_kind="BREAK"``) — thresholds remain a
+per-regime INPUT, never unified (S6.2 / ADR-SAF-01).
+
+Leg B (safeguarding account) already has a port — ``BankStatementPort`` in
+``agent.py`` — and is NOT redefined here (ADR-102): this module adds only the
+missing Leg C port and the 3-leg tie-out.
+
+Pure + offline: ``three_leg_reconcile`` takes raw Decimal balances (mirroring
+``DailyReconciliation``); ``RailBalancePort`` is the Leg-C source seam, wired by
+the orchestrator. Invariant I-01: Decimal money only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+from src.recon_core import BreachEvaluator, CoreReconResult, evaluate_balances
+
+# CASS 15 penny-exact tolerance (matches daily_reconciliation.RECON_TOLERANCE_GBP).
+RECON_TOLERANCE_GBP = Decimal("0.01")
+
+
+@runtime_checkable
+class RailBalancePort(Protocol):
+    """Fetch the payment-rail / operational bank balance (Leg C)."""
+
+    def get_rail_balance_gbp(self, as_of: date) -> Decimal | None:
+        """Return the rail/bank balance, or None if not yet available (PENDING)."""
+        ...
+
+
+class InMemoryRailBalancePort:
+    """Offline Leg-C stub: configurable rail balances by date (tests / sandbox)."""
+
+    def __init__(self, balances: dict[date, Decimal] | None = None) -> None:
+        self._balances: dict[date, Decimal] = dict(balances or {})
+
+    def set_balance(self, as_of: date, balance: Decimal) -> None:
+        self._balances[as_of] = balance
+
+    def get_rail_balance_gbp(self, as_of: date) -> Decimal | None:
+        return self._balances.get(as_of)
+
+
+class ThreeLegStatus(str, Enum):
+    MATCHED = "MATCHED"  # all three legs tie out within tolerance
+    BREAK = "BREAK"  # at least one leg-pair exceeds tolerance — escalate
+    PENDING = "PENDING"  # Leg B or Leg C not yet available
+
+
+@dataclass(frozen=True)
+class ThreeLegResult:
+    """Outcome of an A == B == C safeguarding tie-out (I-01 Decimal)."""
+
+    recon_date: date
+    leg_a_ledger: Decimal
+    leg_b_safeguarding: Decimal | None
+    leg_c_rail: Decimal | None
+    a_vs_b: CoreReconResult | None
+    b_vs_c: CoreReconResult | None
+    a_vs_c: CoreReconResult | None
+    status: ThreeLegStatus
+    # Shortfall (CASS 15 escalation trigger): client-fund ledger (A) exceeds the
+    # safeguarding account (B) beyond tolerance ⇒ client funds not fully safeguarded.
+    shortfall: bool
+    run_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    notes: str = ""
+
+    @property
+    def is_compliant(self) -> bool:
+        return self.status == ThreeLegStatus.MATCHED
+
+
+def three_leg_reconcile(
+    leg_a_ledger: Decimal,
+    leg_b_safeguarding: Decimal | None,
+    leg_c_rail: Decimal | None,
+    *,
+    recon_date: date | None = None,
+    tolerance: Decimal = RECON_TOLERANCE_GBP,
+) -> ThreeLegResult:
+    """Tie out A (ledger) == B (safeguarding) == C (rail) within ``tolerance``.
+
+    Returns PENDING if Leg B or Leg C is not yet available. Otherwise classifies
+    each leg-pair via the shared CASS 15 ``BreachEvaluator`` (£0.01 "BREAK") and
+    is BREAK if ANY pair exceeds tolerance. The signed A−B difference is used to
+    flag a *shortfall* (client funds under-safeguarded) distinct from a surplus.
+    """
+    recon_date = recon_date or date.today()
+
+    if leg_b_safeguarding is None or leg_c_rail is None:
+        missing = "safeguarding account" if leg_b_safeguarding is None else "payment rail"
+        return ThreeLegResult(
+            recon_date=recon_date,
+            leg_a_ledger=leg_a_ledger,
+            leg_b_safeguarding=leg_b_safeguarding,
+            leg_c_rail=leg_c_rail,
+            a_vs_b=None,
+            b_vs_c=None,
+            a_vs_c=None,
+            status=ThreeLegStatus.PENDING,
+            shortfall=False,
+            notes=f"Leg balance not yet available ({missing}).",
+        )
+
+    evaluator = BreachEvaluator(threshold=tolerance, breach_kind="BREAK")
+    a_vs_b = evaluate_balances(leg_a_ledger, leg_b_safeguarding, evaluator)
+    b_vs_c = evaluate_balances(leg_b_safeguarding, leg_c_rail, evaluator)
+    a_vs_c = evaluate_balances(leg_a_ledger, leg_c_rail, evaluator)
+
+    any_breach = a_vs_b.is_breach or b_vs_c.is_breach or a_vs_c.is_breach
+    status = ThreeLegStatus.BREAK if any_breach else ThreeLegStatus.MATCHED
+    # Shortfall iff ledger (A) > safeguarding (B) beyond tolerance (signed A−B).
+    shortfall = a_vs_b.difference > tolerance
+
+    if status == ThreeLegStatus.MATCHED:
+        notes = "Three-leg tie-out passed — A == B == C within tolerance."
+    elif shortfall:
+        notes = (
+            "Three-leg BREAK with SHORTFALL: client-fund ledger exceeds safeguarding "
+            "account — funds not fully safeguarded. Escalate to MLRO + CFO (CASS 15)."
+        )
+    else:
+        notes = "Three-leg BREAK: a leg-pair exceeds tolerance. Escalate (CASS 15)."
+
+    return ThreeLegResult(
+        recon_date=recon_date,
+        leg_a_ledger=leg_a_ledger,
+        leg_b_safeguarding=leg_b_safeguarding,
+        leg_c_rail=leg_c_rail,
+        a_vs_b=a_vs_b,
+        b_vs_c=b_vs_c,
+        a_vs_c=a_vs_c,
+        status=status,
+        shortfall=shortfall,
+        notes=notes,
+    )

--- a/tests/test_safeguarding_three_leg.py
+++ b/tests/test_safeguarding_three_leg.py
@@ -1,0 +1,104 @@
+"""
+tests/test_safeguarding_three_leg.py — CASS 15 three-leg tie-out.
+
+D-RECON-BUILD-SPEC §3 (3-leg model): A (Midaz ledger) == B (safeguarding account)
+== C (payment rail) within penny-exact tolerance (£0.01). Reuses src.recon_core
+mechanics; Leg B port (BankStatementPort) already exists — this adds Leg C
+(RailBalancePort) + the tie-out. Offline; Decimal-only (I-01).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from src.safeguarding.three_leg import (
+    InMemoryRailBalancePort,
+    RailBalancePort,
+    ThreeLegStatus,
+    three_leg_reconcile,
+)
+
+D = date(2026, 6, 26)
+
+
+def test_all_three_legs_match():
+    r = three_leg_reconcile(
+        Decimal("50000.00"), Decimal("50000.00"), Decimal("50000.00"), recon_date=D
+    )
+    assert r.status == ThreeLegStatus.MATCHED
+    assert r.is_compliant
+    assert not r.shortfall
+
+
+def test_within_penny_tolerance_matches():
+    # every leg-pair |diff| <= £0.01 → MATCHED (strict breach is > threshold)
+    r = three_leg_reconcile(
+        Decimal("50000.00"), Decimal("50000.01"), Decimal("50000.00"), recon_date=D
+    )
+    assert r.status == ThreeLegStatus.MATCHED
+
+
+def test_leg_break_escalates():
+    r = three_leg_reconcile(
+        Decimal("50000.00"), Decimal("50000.00"), Decimal("49000.00"), recon_date=D
+    )
+    assert r.status == ThreeLegStatus.BREAK
+    assert r.b_vs_c.is_breach
+    assert not r.shortfall  # A == B, so no client-fund shortfall
+
+
+def test_shortfall_flagged_when_ledger_exceeds_safeguarding():
+    # A (client-fund ledger) > B (safeguarding account) ⇒ under-safeguarded
+    r = three_leg_reconcile(
+        Decimal("60000.00"), Decimal("50000.00"), Decimal("60000.00"), recon_date=D
+    )
+    assert r.status == ThreeLegStatus.BREAK
+    assert r.shortfall is True
+    assert "SHORTFALL" in r.notes
+
+
+def test_surplus_is_not_shortfall():
+    # B (safeguarding) > A (ledger) ⇒ surplus, BREAK but not a shortfall
+    r = three_leg_reconcile(
+        Decimal("50000.00"), Decimal("60000.00"), Decimal("50000.00"), recon_date=D
+    )
+    assert r.status == ThreeLegStatus.BREAK
+    assert r.shortfall is False
+
+
+def test_pending_when_safeguarding_leg_missing():
+    r = three_leg_reconcile(Decimal("50000.00"), None, Decimal("50000.00"), recon_date=D)
+    assert r.status == ThreeLegStatus.PENDING
+    assert r.a_vs_b is None
+
+
+def test_pending_when_rail_leg_missing():
+    r = three_leg_reconcile(Decimal("50000.00"), Decimal("50000.00"), None, recon_date=D)
+    assert r.status == ThreeLegStatus.PENDING
+
+
+def test_signed_difference_preserved():
+    r = three_leg_reconcile(
+        Decimal("60000.00"), Decimal("50000.00"), Decimal("60000.00"), recon_date=D
+    )
+    assert r.a_vs_b.difference == Decimal("10000.00")  # A - B, signed
+    assert isinstance(r.a_vs_b.difference, Decimal)  # I-01
+
+
+# ── RailBalancePort (Leg C source) ────────────────────────────────────────────
+
+
+def test_rail_port_returns_configured_balance():
+    port = InMemoryRailBalancePort({D: Decimal("12345.67")})
+    assert port.get_rail_balance_gbp(D) == Decimal("12345.67")
+    assert isinstance(port.get_rail_balance_gbp(D), Decimal)
+
+
+def test_rail_port_missing_returns_none():
+    port = InMemoryRailBalancePort()
+    assert port.get_rail_balance_gbp(D) is None
+
+
+def test_rail_port_satisfies_protocol():
+    assert isinstance(InMemoryRailBalancePort(), RailBalancePort)


### PR DESCRIPTION
## Summary
First **E-safeguard / D-recon** runtime increment — the CASS 15 **three-leg tie-out** (D-RECON-BUILD-SPEC IL-474 §3). A (Midaz ledger) == B (safeguarding account) == C (payment rail) within the penny-exact tolerance (£0.01), reusing the shared `src/recon_core` mechanics.

## ADR-102 canonical decision (from live origin/main `ebfeac6`)
The safeguarding recon stack is consolidated onto **`src/recon_core/`** (shared mechanics, #164) with a regime split — **CASS 15 = `src/safeguarding/`** (£0.01 "BREAK"), CASS 7.15 = `services/recon/reconciliation_engine_v2` (£100 "HITL"). Legacy `reconciliation_engine.py` (old cron) + dormant `recon_engine.py` (tests-only) are **not extended**. This increment targets the CASS 15 path only.

## Best-decision reorder (stated)
The recommended first increment "SafeguardingAccountPort (Leg B)" **already exists** as `BankStatementPort` in `src/safeguarding/agent.py` (Leg A = `LedgerBalancePort`, Leg B = `BankStatementPort`, A-vs-B recon + breach + audit all implemented). Building it would duplicate (ADR-102). So the genuine foundational gap — the **third leg + A==B==C tie-out** — is delivered instead.

## Changes
- `src/safeguarding/three_leg.py` (new) — `RailBalancePort` + `InMemoryRailBalancePort` (Leg C source); `ThreeLegStatus` / `ThreeLegResult`; `three_leg_reconcile(a, b, c)` reusing `recon_core.evaluate_balances` + `BreachEvaluator("BREAK")`, with **signed-difference shortfall detection** (client-fund ledger > safeguarding account ⇒ under-safeguarded → escalate MLRO/CFO).
- `tests/test_safeguarding_three_leg.py` (new) — 11 tests: MATCHED/BREAK/PENDING, penny tolerance (strict `>`), shortfall vs surplus, signed diff, rail port.

## Out of scope (next increments)
Wire 3-leg into `SafeguardingAgent.run()`; `BreachNotifyPort` + MLRO/CFO HITL escalation port; unified `safeguarding_events` audit-table consolidation.

## Verification (offline)
11 new + 95 back-compat (`test_src_safeguarding`, `_agent`, `test_recon_core/`) pass; ruff + format clean; semgrep banxe-rules clean; Decimal-only (I-01). **Additive** — the 2-leg `daily_reconciliation.py` / orchestrator are untouched.

IL: `IL-CBS-DRECON-3LEG-2026-06-26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)