### PR TITLE
feat(safeguarding): wire three_leg_reconcile into SafeguardingAgent.run() [IL-CBS-DRECON-AGENT-2026-06-26]

### DIFF
--- a/src/safeguarding/agent.py
+++ b/src/safeguarding/agent.py
@@ -44,6 +44,7 @@ from typing import Protocol, runtime_checkable
 from .audit_trail import AuditEvent, AuditTrail
 from .breach_detector import BreachAlert, BreachDetector
 from .daily_reconciliation import DailyReconciliation, ReconciliationResult, ReconStatus
+from .three_leg import RailBalancePort, ThreeLegResult, three_leg_reconcile
 
 logger = logging.getLogger(__name__)
 
@@ -87,12 +88,17 @@ class StreakCounterPort(Protocol):
 
 @dataclass
 class SafeguardingAgentPorts:
-    """Dependency container passed to SafeguardingAgent."""
+    """Dependency container passed to SafeguardingAgent.
+
+    ``rail`` is optional (backward-compatible): when provided the agent runs a
+    full A==B==C three-leg tie-out after the two-leg reconciliation.
+    """
 
     ledger: LedgerBalancePort
     bank: BankStatementPort
     audit: AuditTrail
     streak_counter: StreakCounterPort
+    rail: RailBalancePort | None = None
 
 
 @dataclass
@@ -113,6 +119,7 @@ class SafeguardingRunResult:
     breach_alert: BreachAlert | None
     audit_event_id: str
     exit_code: int
+    three_leg_result: ThreeLegResult | None = None
     run_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     @property
@@ -129,6 +136,12 @@ class SafeguardingRunResult:
         lines = [f"[{self.run_date}] SafeguardingAgent → {self.status_label}"]
         if self.recon_result:
             lines.append(f"  Recon: {self.recon_result.summary()}")
+        if self.three_leg_result:
+            tlr = self.three_leg_result
+            lines.append(
+                f"  3-leg: {tlr.status.value}"
+                f"{' SHORTFALL' if tlr.shortfall else ''}"
+            )
         if self.breach_alert:
             lines.append(
                 f"  Breach: {self.breach_alert.reference} "
@@ -203,6 +216,18 @@ class SafeguardingAgent:
         )
         result = recon.run()
 
+        # Step 2.5: Three-leg tie-out (if Leg C rail port wired)
+        three_leg: ThreeLegResult | None = None
+        if self._ports.rail is not None:
+            rail_balance = self._ports.rail.get_rail_balance_gbp(run_date)
+            three_leg = three_leg_reconcile(
+                leg_a_ledger=internal_balance,
+                leg_b_safeguarding=external_balance,
+                leg_c_rail=rail_balance,
+                recon_date=run_date,
+            )
+            logger.info("SafeguardingAgent: 3-leg %s", three_leg.status.value)
+
         # Step 3: Streak + breach detection
         streak = self._ports.streak_counter.get_streak(run_date)
         breach_alert = self._detector.assess(result, consecutive_break_days=streak)
@@ -232,6 +257,8 @@ class SafeguardingAgent:
                 "fca_notification_required": breach_alert.fca_notification_required
                 if breach_alert
                 else False,
+                "three_leg_status": three_leg.status.value if three_leg else None,
+                "three_leg_shortfall": three_leg.shortfall if three_leg else None,
             },
             severity=severity,
         )
@@ -261,12 +288,17 @@ class SafeguardingAgent:
         else:
             exit_code = EXIT_MATCHED
 
+        # Step 7.5: Escalate if 3-leg detects BREAK (2-leg alone may be MATCHED)
+        if three_leg and three_leg.status.value == "BREAK" and exit_code == EXIT_MATCHED:
+            exit_code = EXIT_BREACH
+
         run_result = SafeguardingRunResult(
             run_date=run_date,
             recon_result=result,
             breach_alert=breach_alert,
             audit_event_id=event.event_id,
             exit_code=exit_code,
+            three_leg_result=three_leg,
         )
         log_fn = logger.critical if exit_code == EXIT_BREACH else logger.info
         log_fn("SafeguardingAgent: %s", run_result.summary())

--- a/src/safeguarding/agent.py
+++ b/src/safeguarding/agent.py
@@ -138,10 +138,7 @@ class SafeguardingRunResult:
             lines.append(f"  Recon: {self.recon_result.summary()}")
         if self.three_leg_result:
             tlr = self.three_leg_result
-            lines.append(
-                f"  3-leg: {tlr.status.value}"
-                f"{' SHORTFALL' if tlr.shortfall else ''}"
-            )
+            lines.append(f"  3-leg: {tlr.status.value}{' SHORTFALL' if tlr.shortfall else ''}")
         if self.breach_alert:
             lines.append(
                 f"  Breach: {self.breach_alert.reference} "

--- a/tests/test_src_safeguarding_agent.py
+++ b/tests/test_src_safeguarding_agent.py
@@ -23,6 +23,7 @@ from src.safeguarding.agent import (
 from src.safeguarding.audit_trail import AuditTrail
 from src.safeguarding.breach_detector import BreachAlert, BreachDetector, BreachSeverity
 from src.safeguarding.daily_reconciliation import ReconStatus
+from src.safeguarding.three_leg import InMemoryRailBalancePort, ThreeLegStatus
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -274,3 +275,132 @@ class TestFCANotification:
         agent = SafeguardingAgent(ports, fca_notify=True, detector=mock_detector)
         agent.run(date(2026, 4, 13))
         mock_detector.notify_fca.assert_called_once_with(mock_alert, dry_run=False)
+
+
+# ── Three-leg wiring in SafeguardingAgent ─────────────────────────────────────
+
+
+RUN_DATE = date(2026, 6, 26)
+
+
+def _make_ports_with_rail(
+    ledger_bal: Decimal = Decimal("100000"),
+    bank_bal: Decimal | None = Decimal("100000"),
+    rail_bal: Decimal | None = Decimal("100000"),
+    streak: int = 0,
+) -> SafeguardingAgentPorts:
+    rail_port = InMemoryRailBalancePort()
+    if rail_bal is not None:
+        rail_port.set_balance(RUN_DATE, rail_bal)
+    return SafeguardingAgentPorts(
+        ledger=StubLedgerPort(ledger_bal),
+        bank=StubBankStatementPort(bank_bal),
+        audit=AuditTrail(clickhouse_url="", dry_run=True),
+        streak_counter=InMemoryStreakCounter(streak),
+        rail=rail_port,
+    )
+
+
+class TestThreeLegWiring:
+    def test_no_rail_port_skips_three_leg(self):
+        """rail=None → three_leg_result is None (backward-compatible)."""
+        ports = _make_ports()
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is None
+
+    def test_three_legs_all_match(self):
+        """A == B == C → three_leg_result.status MATCHED, exit MATCHED."""
+        ports = _make_ports_with_rail(Decimal("100000"), Decimal("100000"), Decimal("100000"))
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is not None
+        assert result.three_leg_result.status == ThreeLegStatus.MATCHED
+        assert result.exit_code == EXIT_MATCHED
+
+    def test_three_leg_break_escalates_to_breach(self):
+        """2-leg MATCHED but Leg C diverges → 3-leg BREAK → exit BREACH."""
+        ports = _make_ports_with_rail(
+            Decimal("100000"), Decimal("100000"), Decimal("80000")  # C differs by £20k
+        )
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is not None
+        assert result.three_leg_result.status == ThreeLegStatus.BREAK
+        assert result.exit_code == EXIT_BREACH
+
+    def test_three_leg_shortfall_flagged(self):
+        """A (ledger) > B (safeguarding) → shortfall=True in three_leg_result."""
+        ports = _make_ports_with_rail(
+            Decimal("120000"), Decimal("100000"), Decimal("120000")
+        )
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is not None
+        assert result.three_leg_result.shortfall is True
+        assert result.exit_code == EXIT_BREACH
+
+    def test_three_leg_pending_when_rail_missing(self):
+        """Leg C balance unavailable → three_leg_result.status PENDING."""
+        ports = _make_ports_with_rail(Decimal("100000"), Decimal("100000"), rail_bal=None)
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is not None
+        assert result.three_leg_result.status == ThreeLegStatus.PENDING
+
+    def test_summary_includes_three_leg_status(self):
+        """summary() shows 3-leg status line when rail port is wired."""
+        ports = _make_ports_with_rail(Decimal("100000"), Decimal("100000"), Decimal("100000"))
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert "3-leg" in result.summary()
+        assert "MATCHED" in result.summary()
+
+    def test_summary_shows_shortfall_label(self):
+        """summary() includes SHORTFALL when three_leg_result.shortfall=True."""
+        ports = _make_ports_with_rail(Decimal("120000"), Decimal("100000"), Decimal("120000"))
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert "SHORTFALL" in result.summary()
+
+    def test_audit_payload_includes_three_leg_status(self):
+        """AuditEvent payload carries three_leg_status when rail is wired."""
+        captured: list[object] = []
+
+        class CapturingAuditTrail(AuditTrail):
+            def log(self, event):  # type: ignore[override]
+                captured.append(event)
+
+        rail_port = InMemoryRailBalancePort()
+        rail_port.set_balance(RUN_DATE, Decimal("100000"))
+        ports = SafeguardingAgentPorts(
+            ledger=StubLedgerPort(Decimal("100000")),
+            bank=StubBankStatementPort(Decimal("100000")),
+            audit=CapturingAuditTrail(clickhouse_url="", dry_run=True),
+            streak_counter=InMemoryStreakCounter(),
+            rail=rail_port,
+        )
+        agent = _make_agent(ports)
+        agent.run(RUN_DATE)
+        assert captured
+        event = captured[0]
+        assert event.payload["three_leg_status"] == "MATCHED"
+        assert event.payload["three_leg_shortfall"] is False
+
+    def test_fatal_does_not_propagate_three_leg_error(self):
+        """If rail port raises, agent catches and returns EXIT_FATAL (never raises)."""
+
+        class BrokenRailPort:
+            def get_rail_balance_gbp(self, as_of):
+                raise RuntimeError("rail timeout")
+
+        ports = SafeguardingAgentPorts(
+            ledger=StubLedgerPort(Decimal("100000")),
+            bank=StubBankStatementPort(Decimal("100000")),
+            audit=AuditTrail(clickhouse_url="", dry_run=True),
+            streak_counter=InMemoryStreakCounter(),
+            rail=BrokenRailPort(),
+        )
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.exit_code == EXIT_FATAL

--- a/tests/test_src_safeguarding_agent.py
+++ b/tests/test_src_safeguarding_agent.py
@@ -321,7 +321,9 @@ class TestThreeLegWiring:
     def test_three_leg_break_escalates_to_breach(self):
         """2-leg MATCHED but Leg C diverges → 3-leg BREAK → exit BREACH."""
         ports = _make_ports_with_rail(
-            Decimal("100000"), Decimal("100000"), Decimal("80000")  # C differs by £20k
+            Decimal("100000"),
+            Decimal("100000"),
+            Decimal("80000"),  # C differs by £20k
         )
         agent = _make_agent(ports)
         result = agent.run(RUN_DATE)
@@ -331,9 +333,7 @@ class TestThreeLegWiring:
 
     def test_three_leg_shortfall_flagged(self):
         """A (ledger) > B (safeguarding) → shortfall=True in three_leg_result."""
-        ports = _make_ports_with_rail(
-            Decimal("120000"), Decimal("100000"), Decimal("120000")
-        )
+        ports = _make_ports_with_rail(Decimal("120000"), Decimal("100000"), Decimal("120000"))
         agent = _make_agent(ports)
         result = agent.run(RUN_DATE)
         assert result.three_leg_result is not None


### PR DESCRIPTION
## Summary
- Add `RailBalancePort | None = None` to `SafeguardingAgentPorts` — backward-compatible; existing callers unaffected
- Invoke `three_leg_reconcile()` in `_run_internal()` when rail port is wired; escalate to `EXIT_BREACH` when 3-leg BREAK overrides a 2-leg MATCHED result
- Include `three_leg_status` / `three_leg_shortfall` in `AuditEvent` payload (I-24 append-only audit)
- Surface `ThreeLegResult` in `SafeguardingRunResult.summary()` with SHORTFALL label

## Tests
`TestThreeLegWiring` (9 new tests) covers: all-legs-match, leg-C break escalation, shortfall flag, pending-on-missing-rail, summary labels, audit payload fields, fatal-on-rail-error.
11 478 tests green, 7 skipped (live infra), 0 failures.

## Compliance
- CASS 15 A==B==C tie-out fully wired; shortfall → `EXIT_BREACH` triggers MLRO/CFO HITL gate (I-27)
- ADR-102 dedup respected: no engine duplication, reuses `src.recon_core` via `three_leg.py`
- I-01: Decimal-only throughout

## Test plan
- [ ] CI quality gate green (ruff + semgrep + pytest)
- [ ] 3-leg BREAK with all-legs-match: exit 0
- [ ] 3-leg BREAK with Leg C divergence: exit 1
- [ ] rail=None: three_leg_result=None (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)