### PR TITLE
feat(safeguarding): wire SafeguardingAgent into cron entrypoint — production adapters + 15 tests [IL-CBS-DRECON-CRON-2026-06-26]

### DIFF
--- a/services/recon/cron_daily_recon.py
+++ b/services/recon/cron_daily_recon.py
@@ -90,6 +90,52 @@ def _parse_args() -> tuple[date | None, bool]:
     return recon_date, dry_run
 
 
+def _run_safeguarding_agent(recon_date: date, dry_run: bool) -> int:
+    """Run SafeguardingAgent (CASS 15 aggregate + 3-leg tie-out).
+
+    Returns one of EXIT_MATCHED / EXIT_DISCREPANCY / EXIT_PENDING / EXIT_FATAL.
+    Never raises — exceptions are caught and returned as EXIT_FATAL.
+    """
+    try:
+        from src.safeguarding.agent import (  # noqa: PLC0415
+            SafeguardingAgent,
+            SafeguardingAgentPorts,
+        )
+        from src.safeguarding.audit_trail import AuditTrail  # noqa: PLC0415
+        from src.safeguarding.three_leg import InMemoryRailBalancePort  # noqa: PLC0415
+
+        from services.recon.safeguarding_adapters import (  # noqa: PLC0415
+            MidazClientFundsPort,
+            StatementBankPort,
+            ZeroStreakCounter,
+        )
+
+        clickhouse_url = __import__("os").environ.get("CLICKHOUSE_URL", "")
+        ports = SafeguardingAgentPorts(
+            ledger=MidazClientFundsPort(),
+            bank=StatementBankPort(),
+            audit=AuditTrail(clickhouse_url=clickhouse_url, dry_run=dry_run),
+            streak_counter=ZeroStreakCounter(),
+            # Leg C rail: starts as InMemoryRailBalancePort (PENDING path).
+            # Wire a real RailBalancePort when the payment-rail adapter is ready.
+            rail=InMemoryRailBalancePort(),
+        )
+        agent = SafeguardingAgent(ports, fca_notify=not dry_run)
+        result = agent.run(recon_date)
+        logger.info(
+            "SafeguardingAgent: %s exit=%d three_leg=%s",
+            result.status_label,
+            result.exit_code,
+            result.three_leg_result.status.value if result.three_leg_result else "skipped",
+        )
+        # Map SafeguardingAgent exit codes to cron constants
+        # EXIT_BREACH → EXIT_DISCREPANCY (same semantics, different constant names)
+        return EXIT_DISCREPANCY if result.exit_code == 1 else result.exit_code
+    except Exception as exc:
+        logger.error("SafeguardingAgent failed (non-fatal to cron): %s", exc, exc_info=True)
+        return EXIT_FATAL
+
+
 def main() -> int:
     # ── 1. Locate repo root ───────────────────────────────────────────────────
     # This file lives at  <repo>/services/recon/cron_daily_recon.py
@@ -109,44 +155,57 @@ def main() -> int:
     if dry_run:
         logger.info("DRY RUN: no ClickHouse writes, no webhooks")
 
-    # ── 5. Run reconciliation pipeline ───────────────────────────────────────
+    # ── 5. Run reconciliation pipeline (legacy per-account path) ─────────────
+    legacy_exit = EXIT_FATAL
     try:
         from services.recon.midaz_reconciliation import run_daily_recon  # noqa: PLC0415
 
         summary = run_daily_recon(recon_date=recon_date, dry_run=dry_run)
-    except Exception as exc:
-        logger.critical("FATAL — reconciliation pipeline crashed: %s", exc, exc_info=True)
-        return EXIT_FATAL
-
-    # ── 6. Structured summary for journald ───────────────────────────────────
-    status = summary.get("overall_status", "FATAL")
-    logger.info(
-        "STATUS=%s date=%s matched=%d discrepancy=%d pending=%d total=%d",
-        status,
-        summary.get("recon_date", "?"),
-        summary.get("matched", 0),
-        summary.get("discrepancy", 0),
-        summary.get("pending", 0),
-        summary.get("total_accounts", 0),
-    )
-
-    # ── 7. Exit code → systemd service result / on-failure alerting ─────────
-    if status == "DISCREPANCY":
-        logger.warning(
-            "CASS 7.15.29R: shortfall detected — MLRO must investigate within 1 business day"
+        status = summary.get("overall_status", "FATAL")
+        logger.info(
+            "STATUS=%s date=%s matched=%d discrepancy=%d pending=%d total=%d",
+            status,
+            summary.get("recon_date", "?"),
+            summary.get("matched", 0),
+            summary.get("discrepancy", 0),
+            summary.get("pending", 0),
+            summary.get("total_accounts", 0),
         )
-        return EXIT_DISCREPANCY
+        if status == "DISCREPANCY":
+            logger.warning(
+                "CASS 7.15.29R: shortfall detected — MLRO must investigate within 1 business day"
+            )
+            legacy_exit = EXIT_DISCREPANCY
+        elif status == "PENDING":
+            legacy_exit = EXIT_PENDING
+        elif status == "MATCHED":
+            legacy_exit = EXIT_MATCHED
+        else:
+            logger.error("Unknown status: %s", status)
+            legacy_exit = EXIT_FATAL
+    except Exception as exc:
+        logger.critical("FATAL — legacy reconciliation pipeline crashed: %s", exc, exc_info=True)
+        legacy_exit = EXIT_FATAL
 
-    if status == "PENDING":
-        logger.info("No bank statement available — PENDING (non-critical for sandbox)")
-        return EXIT_PENDING
+    # ── 6. Run SafeguardingAgent (CASS 15 aggregate + 3-leg tie-out) ──────────
+    agent_exit = _run_safeguarding_agent(recon_date or date.today(), dry_run)
 
-    if status == "MATCHED":
-        logger.info("All accounts matched — safeguarding requirement satisfied")
-        return EXIT_MATCHED
+    # ── 7. Worst-case exit: escalate if either path detected a problem ────────
+    # EXIT_DISCREPANCY (1) > EXIT_PENDING (2) in severity ordering, but both
+    # are non-zero and non-fatal. Use max() with custom ordering:
+    #   FATAL(3) > DISCREPANCY(1) > PENDING(2) > MATCHED(0)
+    severity = {EXIT_MATCHED: 0, EXIT_PENDING: 1, EXIT_DISCREPANCY: 2, EXIT_FATAL: 3}
+    worst = max(legacy_exit, agent_exit, key=lambda c: severity.get(c, 3))
 
-    logger.error("Unknown status: %s", status)
-    return EXIT_FATAL
+    if worst != legacy_exit:
+        logger.warning(
+            "SafeguardingAgent detected additional issue: legacy=%d agent=%d → exit=%d",
+            legacy_exit,
+            agent_exit,
+            worst,
+        )
+
+    return worst
 
 
 if __name__ == "__main__":

--- a/services/recon/safeguarding_adapters.py
+++ b/services/recon/safeguarding_adapters.py
@@ -1,0 +1,107 @@
+"""Production port adapters for SafeguardingAgent (CASS 15 daily cron).
+
+Bridges existing infrastructure (MidazLedgerAdapter, StatementFetcher) to the
+three SafeguardingAgent port protocols, so cron_daily_recon.py can assemble a
+production SafeguardingAgentPorts without changing the agent or core adapters.
+
+Ports implemented:
+  LedgerBalancePort  → MidazClientFundsPort  (client-fund total from Midaz CBS)
+  BankStatementPort  → StatementBankPort     (safeguarding closing balance via CAMT.053)
+  StreakCounterPort  → ZeroStreakCounter      (stateless stub; ClickHouse streak is P1)
+
+All amounts: Decimal only (I-01). No float.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# ── Midaz account constants (from reconciliation_engine.py) ───────────────────
+_ORG_ID = "019d6301-32d7-70a1-bc77-0a05379ee510"
+_LEDGER_ID = "019d632f-519e-7865-8a30-3c33991bba9c"
+_CLIENT_FUNDS_ACCOUNT_ID = "019d6332-da7f-752f-b9fd-fa1c6fc777ec"
+
+
+class MidazClientFundsPort:
+    """LedgerBalancePort — total client-fund balance from Midaz CBS.
+
+    Wraps MidazLedgerAdapter using the CASS 15 client-funds liability account.
+    Env overrides: MIDAZ_ORG_ID, MIDAZ_LEDGER_ID, MIDAZ_CLIENT_FUNDS_ACCOUNT_ID.
+    """
+
+    def __init__(
+        self,
+        org_id: str | None = None,
+        ledger_id: str | None = None,
+        account_id: str | None = None,
+    ) -> None:
+        self._org_id = org_id or os.environ.get("MIDAZ_ORG_ID", _ORG_ID)
+        self._ledger_id = ledger_id or os.environ.get("MIDAZ_LEDGER_ID", _LEDGER_ID)
+        self._account_id = account_id or os.environ.get(
+            "MIDAZ_CLIENT_FUNDS_ACCOUNT_ID", _CLIENT_FUNDS_ACCOUNT_ID
+        )
+        # Lazy import: avoids pulling httpx at module import time
+        from services.ledger.midaz_adapter import MidazLedgerAdapter  # noqa: PLC0415
+
+        self._midaz = MidazLedgerAdapter()
+
+    def get_client_funds_gbp(self, as_of: date) -> Decimal:  # noqa: ARG002
+        balance = self._midaz.get_balance(self._org_id, self._ledger_id, self._account_id)
+        logger.debug(
+            "MidazClientFundsPort: org=%s ledger=%s account=%s balance=%s",
+            self._org_id,
+            self._ledger_id,
+            self._account_id,
+            balance,
+        )
+        return balance
+
+
+class StatementBankPort:
+    """BankStatementPort — safeguarding closing balance via StatementFetcher (CAMT.053/CSV).
+
+    Fetches all GBP balances for the date and sums them. Returns None (PENDING)
+    if StatementFetcher returns no GBP rows (statement not yet received).
+    Env override: STATEMENT_DIR.
+    """
+
+    def __init__(self, statement_dir: str | None = None) -> None:
+        from services.recon.statement_fetcher import StatementFetcher  # noqa: PLC0415
+
+        self._fetcher = StatementFetcher(
+            statement_dir=statement_dir or os.environ.get("STATEMENT_DIR")
+        )
+
+    def get_closing_balance_gbp(self, statement_date: date) -> Decimal | None:
+        balances = self._fetcher.fetch(statement_date)
+        gbp = [b for b in balances if b.currency == "GBP"]
+        if not gbp:
+            logger.info("StatementBankPort: no GBP statement for %s → PENDING", statement_date)
+            return None
+        total = sum((b.balance for b in gbp), Decimal("0"))
+        logger.debug("StatementBankPort: %d GBP account(s) total=%s", len(gbp), total)
+        return total
+
+
+class ZeroStreakCounter:
+    """StreakCounterPort — stateless stub always returning streak=0.
+
+    Used until a ClickHouse-backed streak counter is implemented (P1).
+    Streak-based breach escalation is disabled; CRITICAL shortfall detection
+    still works via BreachDetector (streak-independent path).
+    """
+
+    def get_streak(self, as_of: date) -> int:  # noqa: ARG002
+        return 0
+
+    def reset_streak(self, as_of: date) -> None:  # noqa: ARG002
+        pass

--- a/src/safeguarding/agent.py
+++ b/src/safeguarding/agent.py
@@ -44,6 +44,7 @@ from typing import Protocol, runtime_checkable
 from .audit_trail import AuditEvent, AuditTrail
 from .breach_detector import BreachAlert, BreachDetector
 from .daily_reconciliation import DailyReconciliation, ReconciliationResult, ReconStatus
+from .three_leg import RailBalancePort, ThreeLegResult, three_leg_reconcile
 
 logger = logging.getLogger(__name__)
 
@@ -87,12 +88,17 @@ class StreakCounterPort(Protocol):
 
 @dataclass
 class SafeguardingAgentPorts:
-    """Dependency container passed to SafeguardingAgent."""
+    """Dependency container passed to SafeguardingAgent.
+
+    ``rail`` is optional (backward-compatible): when provided the agent runs a
+    full A==B==C three-leg tie-out after the two-leg reconciliation.
+    """
 
     ledger: LedgerBalancePort
     bank: BankStatementPort
     audit: AuditTrail
     streak_counter: StreakCounterPort
+    rail: RailBalancePort | None = None
 
 
 @dataclass
@@ -113,6 +119,7 @@ class SafeguardingRunResult:
     breach_alert: BreachAlert | None
     audit_event_id: str
     exit_code: int
+    three_leg_result: ThreeLegResult | None = None
     run_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     @property
@@ -129,6 +136,12 @@ class SafeguardingRunResult:
         lines = [f"[{self.run_date}] SafeguardingAgent → {self.status_label}"]
         if self.recon_result:
             lines.append(f"  Recon: {self.recon_result.summary()}")
+        if self.three_leg_result:
+            tlr = self.three_leg_result
+            lines.append(
+                f"  3-leg: {tlr.status.value}"
+                f"{' SHORTFALL' if tlr.shortfall else ''}"
+            )
         if self.breach_alert:
             lines.append(
                 f"  Breach: {self.breach_alert.reference} "
@@ -203,6 +216,18 @@ class SafeguardingAgent:
         )
         result = recon.run()
 
+        # Step 2.5: Three-leg tie-out (if Leg C rail port wired)
+        three_leg: ThreeLegResult | None = None
+        if self._ports.rail is not None:
+            rail_balance = self._ports.rail.get_rail_balance_gbp(run_date)
+            three_leg = three_leg_reconcile(
+                leg_a_ledger=internal_balance,
+                leg_b_safeguarding=external_balance,
+                leg_c_rail=rail_balance,
+                recon_date=run_date,
+            )
+            logger.info("SafeguardingAgent: 3-leg %s", three_leg.status.value)
+
         # Step 3: Streak + breach detection
         streak = self._ports.streak_counter.get_streak(run_date)
         breach_alert = self._detector.assess(result, consecutive_break_days=streak)
@@ -232,6 +257,8 @@ class SafeguardingAgent:
                 "fca_notification_required": breach_alert.fca_notification_required
                 if breach_alert
                 else False,
+                "three_leg_status": three_leg.status.value if three_leg else None,
+                "three_leg_shortfall": three_leg.shortfall if three_leg else None,
             },
             severity=severity,
         )
@@ -261,12 +288,17 @@ class SafeguardingAgent:
         else:
             exit_code = EXIT_MATCHED
 
+        # Step 7.5: Escalate if 3-leg detects BREAK (2-leg alone may be MATCHED)
+        if three_leg and three_leg.status.value == "BREAK" and exit_code == EXIT_MATCHED:
+            exit_code = EXIT_BREACH
+
         run_result = SafeguardingRunResult(
             run_date=run_date,
             recon_result=result,
             breach_alert=breach_alert,
             audit_event_id=event.event_id,
             exit_code=exit_code,
+            three_leg_result=three_leg,
         )
         log_fn = logger.critical if exit_code == EXIT_BREACH else logger.info
         log_fn("SafeguardingAgent: %s", run_result.summary())

--- a/src/safeguarding/agent.py
+++ b/src/safeguarding/agent.py
@@ -138,10 +138,7 @@ class SafeguardingRunResult:
             lines.append(f"  Recon: {self.recon_result.summary()}")
         if self.three_leg_result:
             tlr = self.three_leg_result
-            lines.append(
-                f"  3-leg: {tlr.status.value}"
-                f"{' SHORTFALL' if tlr.shortfall else ''}"
-            )
+            lines.append(f"  3-leg: {tlr.status.value}{' SHORTFALL' if tlr.shortfall else ''}")
         if self.breach_alert:
             lines.append(
                 f"  Breach: {self.breach_alert.reference} "

--- a/tests/test_recon/test_safeguarding_adapters.py
+++ b/tests/test_recon/test_safeguarding_adapters.py
@@ -1,0 +1,201 @@
+"""Tests for services/recon/safeguarding_adapters.py and
+_run_safeguarding_agent() in cron_daily_recon.py.
+
+All tests are offline (no Midaz, no ClickHouse). Adapters are unit-tested by
+stubbing the underlying MidazLedgerAdapter / StatementFetcher via monkeypatch
+or direct stub injection.
+
+Coverage targets:
+  - MidazClientFundsPort.get_client_funds_gbp()
+  - StatementBankPort.get_closing_balance_gbp() — summing, PENDING on empty
+  - ZeroStreakCounter.get_streak() / reset_streak()
+  - _run_safeguarding_agent() — matched, fatal paths, exit code mapping
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from services.recon.safeguarding_adapters import (
+    MidazClientFundsPort,
+    StatementBankPort,
+    ZeroStreakCounter,
+)
+
+D = date(2026, 6, 26)
+
+
+# ── ZeroStreakCounter ─────────────────────────────────────────────────────────
+
+
+class TestZeroStreakCounter:
+    def test_get_streak_always_zero(self):
+        assert ZeroStreakCounter().get_streak(D) == 0
+
+    def test_reset_streak_is_noop(self):
+        sc = ZeroStreakCounter()
+        sc.reset_streak(D)  # should not raise
+        assert sc.get_streak(D) == 0
+
+
+# ── MidazClientFundsPort ──────────────────────────────────────────────────────
+
+
+class TestMidazClientFundsPort:
+    def _make_port(self, balance: Decimal) -> MidazClientFundsPort:
+        mock_adapter = MagicMock()
+        mock_adapter.get_balance.return_value = balance
+        port = MidazClientFundsPort.__new__(MidazClientFundsPort)
+        port._org_id = "org-1"
+        port._ledger_id = "led-1"
+        port._account_id = "acct-1"
+        port._midaz = mock_adapter
+        return port
+
+    def test_returns_midaz_balance(self):
+        port = self._make_port(Decimal("100000.00"))
+        assert port.get_client_funds_gbp(D) == Decimal("100000.00")
+
+    def test_returns_decimal_not_float(self):
+        port = self._make_port(Decimal("99999.99"))
+        result = port.get_client_funds_gbp(D)
+        assert isinstance(result, Decimal)
+
+    def test_calls_get_balance_with_org_ledger_account(self):
+        port = self._make_port(Decimal("50000.00"))
+        port.get_client_funds_gbp(D)
+        port._midaz.get_balance.assert_called_once_with("org-1", "led-1", "acct-1")
+
+    def test_env_override_org_id(self, monkeypatch):
+        monkeypatch.setenv("MIDAZ_ORG_ID", "custom-org")
+        # Lazy import in __init__ — patch at the source module, not the adapter
+        with patch("services.ledger.midaz_adapter.MidazLedgerAdapter") as mock_cls:
+            mock_cls.return_value.get_balance.return_value = Decimal("1.00")
+            port = MidazClientFundsPort()
+            assert port._org_id == "custom-org"
+
+
+# ── StatementBankPort ─────────────────────────────────────────────────────────
+
+
+class TestStatementBankPort:
+    def _make_port(self, balances: list) -> StatementBankPort:
+        from services.recon.statement_fetcher import StatementBalance
+
+        mock_fetcher = MagicMock()
+        mock_fetcher.fetch.return_value = [
+            StatementBalance(
+                account_id=f"acct-{i}",
+                currency=b["currency"],
+                balance=b["balance"],
+                statement_date=D,
+                source_file="test.csv",
+            )
+            for i, b in enumerate(balances)
+        ]
+        port = StatementBankPort.__new__(StatementBankPort)
+        port._fetcher = mock_fetcher
+        return port
+
+    def test_single_gbp_account_returns_balance(self):
+        port = self._make_port([{"currency": "GBP", "balance": Decimal("50000.00")}])
+        assert port.get_closing_balance_gbp(D) == Decimal("50000.00")
+
+    def test_multiple_gbp_accounts_summed(self):
+        port = self._make_port(
+            [
+                {"currency": "GBP", "balance": Decimal("30000.00")},
+                {"currency": "GBP", "balance": Decimal("20000.00")},
+            ]
+        )
+        assert port.get_closing_balance_gbp(D) == Decimal("50000.00")
+
+    def test_non_gbp_accounts_excluded(self):
+        port = self._make_port(
+            [
+                {"currency": "GBP", "balance": Decimal("50000.00")},
+                {"currency": "EUR", "balance": Decimal("10000.00")},
+            ]
+        )
+        assert port.get_closing_balance_gbp(D) == Decimal("50000.00")
+
+    def test_no_gbp_accounts_returns_pending(self):
+        port = self._make_port([{"currency": "EUR", "balance": Decimal("10000.00")}])
+        assert port.get_closing_balance_gbp(D) is None
+
+    def test_empty_statement_returns_pending(self):
+        port = self._make_port([])
+        assert port.get_closing_balance_gbp(D) is None
+
+    def test_result_is_decimal(self):
+        port = self._make_port([{"currency": "GBP", "balance": Decimal("12345.67")}])
+        result = port.get_closing_balance_gbp(D)
+        assert isinstance(result, Decimal)
+
+
+# ── _run_safeguarding_agent ───────────────────────────────────────────────────
+
+
+class TestRunSafeguardingAgent:
+    # _run_safeguarding_agent uses lazy imports (PLC0415), so we patch at
+    # source modules, not at the cron_daily_recon namespace.
+    _SA_AGENT = "src.safeguarding.agent.SafeguardingAgent"
+    _SA_PORTS = "src.safeguarding.agent.SafeguardingAgentPorts"
+    _SA_AUDIT = "src.safeguarding.audit_trail.AuditTrail"
+    _SA_RAIL = "src.safeguarding.three_leg.InMemoryRailBalancePort"
+    _MIDAZ_PORT = "services.recon.safeguarding_adapters.MidazClientFundsPort"
+    _STMT_PORT = "services.recon.safeguarding_adapters.StatementBankPort"
+    _STREAK = "services.recon.safeguarding_adapters.ZeroStreakCounter"
+
+    def test_matched_returns_exit_matched(self):
+        from services.recon.cron_daily_recon import EXIT_MATCHED, _run_safeguarding_agent
+
+        with (
+            patch(self._MIDAZ_PORT),
+            patch(self._STMT_PORT),
+            patch(self._STREAK),
+            patch(self._SA_AUDIT),
+            patch(self._SA_RAIL),
+            patch(self._SA_PORTS),
+            patch(self._SA_AGENT) as mock_agent_cls,
+        ):
+            mock_result = MagicMock()
+            mock_result.exit_code = 0
+            mock_result.status_label = "MATCHED"
+            mock_result.three_leg_result = None
+            mock_agent_cls.return_value.run.return_value = mock_result
+            exit_code = _run_safeguarding_agent(D, dry_run=True)
+        assert exit_code == EXIT_MATCHED
+
+    def test_breach_maps_to_discrepancy(self):
+        from services.recon.cron_daily_recon import (
+            EXIT_DISCREPANCY,
+            _run_safeguarding_agent,
+        )
+
+        with (
+            patch(self._MIDAZ_PORT),
+            patch(self._STMT_PORT),
+            patch(self._STREAK),
+            patch(self._SA_AUDIT),
+            patch(self._SA_RAIL),
+            patch(self._SA_PORTS),
+            patch(self._SA_AGENT) as mock_agent_cls,
+        ):
+            mock_result = MagicMock()
+            mock_result.exit_code = 1  # EXIT_BREACH in agent constants → DISCREPANCY in cron
+            mock_result.status_label = "BREACH"
+            mock_result.three_leg_result = None
+            mock_agent_cls.return_value.run.return_value = mock_result
+            exit_code = _run_safeguarding_agent(D, dry_run=True)
+        assert exit_code == EXIT_DISCREPANCY
+
+    def test_exception_returns_fatal(self):
+        from services.recon.cron_daily_recon import EXIT_FATAL, _run_safeguarding_agent
+
+        # Raise during adapter construction (first lazy import target)
+        with patch(self._MIDAZ_PORT, side_effect=RuntimeError("Midaz timeout")):
+            exit_code = _run_safeguarding_agent(D, dry_run=True)
+        assert exit_code == EXIT_FATAL

--- a/tests/test_src_safeguarding_agent.py
+++ b/tests/test_src_safeguarding_agent.py
@@ -23,6 +23,7 @@ from src.safeguarding.agent import (
 from src.safeguarding.audit_trail import AuditTrail
 from src.safeguarding.breach_detector import BreachAlert, BreachDetector, BreachSeverity
 from src.safeguarding.daily_reconciliation import ReconStatus
+from src.safeguarding.three_leg import InMemoryRailBalancePort, ThreeLegStatus
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -274,3 +275,132 @@ class TestFCANotification:
         agent = SafeguardingAgent(ports, fca_notify=True, detector=mock_detector)
         agent.run(date(2026, 4, 13))
         mock_detector.notify_fca.assert_called_once_with(mock_alert, dry_run=False)
+
+
+# ── Three-leg wiring in SafeguardingAgent ─────────────────────────────────────
+
+
+RUN_DATE = date(2026, 6, 26)
+
+
+def _make_ports_with_rail(
+    ledger_bal: Decimal = Decimal("100000"),
+    bank_bal: Decimal | None = Decimal("100000"),
+    rail_bal: Decimal | None = Decimal("100000"),
+    streak: int = 0,
+) -> SafeguardingAgentPorts:
+    rail_port = InMemoryRailBalancePort()
+    if rail_bal is not None:
+        rail_port.set_balance(RUN_DATE, rail_bal)
+    return SafeguardingAgentPorts(
+        ledger=StubLedgerPort(ledger_bal),
+        bank=StubBankStatementPort(bank_bal),
+        audit=AuditTrail(clickhouse_url="", dry_run=True),
+        streak_counter=InMemoryStreakCounter(streak),
+        rail=rail_port,
+    )
+
+
+class TestThreeLegWiring:
+    def test_no_rail_port_skips_three_leg(self):
+        """rail=None → three_leg_result is None (backward-compatible)."""
+        ports = _make_ports()
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is None
+
+    def test_three_legs_all_match(self):
+        """A == B == C → three_leg_result.status MATCHED, exit MATCHED."""
+        ports = _make_ports_with_rail(Decimal("100000"), Decimal("100000"), Decimal("100000"))
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is not None
+        assert result.three_leg_result.status == ThreeLegStatus.MATCHED
+        assert result.exit_code == EXIT_MATCHED
+
+    def test_three_leg_break_escalates_to_breach(self):
+        """2-leg MATCHED but Leg C diverges → 3-leg BREAK → exit BREACH."""
+        ports = _make_ports_with_rail(
+            Decimal("100000"), Decimal("100000"), Decimal("80000")  # C differs by £20k
+        )
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is not None
+        assert result.three_leg_result.status == ThreeLegStatus.BREAK
+        assert result.exit_code == EXIT_BREACH
+
+    def test_three_leg_shortfall_flagged(self):
+        """A (ledger) > B (safeguarding) → shortfall=True in three_leg_result."""
+        ports = _make_ports_with_rail(
+            Decimal("120000"), Decimal("100000"), Decimal("120000")
+        )
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is not None
+        assert result.three_leg_result.shortfall is True
+        assert result.exit_code == EXIT_BREACH
+
+    def test_three_leg_pending_when_rail_missing(self):
+        """Leg C balance unavailable → three_leg_result.status PENDING."""
+        ports = _make_ports_with_rail(Decimal("100000"), Decimal("100000"), rail_bal=None)
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.three_leg_result is not None
+        assert result.three_leg_result.status == ThreeLegStatus.PENDING
+
+    def test_summary_includes_three_leg_status(self):
+        """summary() shows 3-leg status line when rail port is wired."""
+        ports = _make_ports_with_rail(Decimal("100000"), Decimal("100000"), Decimal("100000"))
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert "3-leg" in result.summary()
+        assert "MATCHED" in result.summary()
+
+    def test_summary_shows_shortfall_label(self):
+        """summary() includes SHORTFALL when three_leg_result.shortfall=True."""
+        ports = _make_ports_with_rail(Decimal("120000"), Decimal("100000"), Decimal("120000"))
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert "SHORTFALL" in result.summary()
+
+    def test_audit_payload_includes_three_leg_status(self):
+        """AuditEvent payload carries three_leg_status when rail is wired."""
+        captured: list[object] = []
+
+        class CapturingAuditTrail(AuditTrail):
+            def log(self, event):  # type: ignore[override]
+                captured.append(event)
+
+        rail_port = InMemoryRailBalancePort()
+        rail_port.set_balance(RUN_DATE, Decimal("100000"))
+        ports = SafeguardingAgentPorts(
+            ledger=StubLedgerPort(Decimal("100000")),
+            bank=StubBankStatementPort(Decimal("100000")),
+            audit=CapturingAuditTrail(clickhouse_url="", dry_run=True),
+            streak_counter=InMemoryStreakCounter(),
+            rail=rail_port,
+        )
+        agent = _make_agent(ports)
+        agent.run(RUN_DATE)
+        assert captured
+        event = captured[0]
+        assert event.payload["three_leg_status"] == "MATCHED"
+        assert event.payload["three_leg_shortfall"] is False
+
+    def test_fatal_does_not_propagate_three_leg_error(self):
+        """If rail port raises, agent catches and returns EXIT_FATAL (never raises)."""
+
+        class BrokenRailPort:
+            def get_rail_balance_gbp(self, as_of):
+                raise RuntimeError("rail timeout")
+
+        ports = SafeguardingAgentPorts(
+            ledger=StubLedgerPort(Decimal("100000")),
+            bank=StubBankStatementPort(Decimal("100000")),
+            audit=AuditTrail(clickhouse_url="", dry_run=True),
+            streak_counter=InMemoryStreakCounter(),
+            rail=BrokenRailPort(),
+        )
+        agent = _make_agent(ports)
+        result = agent.run(RUN_DATE)
+        assert result.exit_code == EXIT_FATAL

--- a/tests/test_src_safeguarding_agent.py
+++ b/tests/test_src_safeguarding_agent.py
@@ -321,7 +321,9 @@ class TestThreeLegWiring:
     def test_three_leg_break_escalates_to_breach(self):
         """2-leg MATCHED but Leg C diverges → 3-leg BREAK → exit BREACH."""
         ports = _make_ports_with_rail(
-            Decimal("100000"), Decimal("100000"), Decimal("80000")  # C differs by £20k
+            Decimal("100000"),
+            Decimal("100000"),
+            Decimal("80000"),  # C differs by £20k
         )
         agent = _make_agent(ports)
         result = agent.run(RUN_DATE)
@@ -331,9 +333,7 @@ class TestThreeLegWiring:
 
     def test_three_leg_shortfall_flagged(self):
         """A (ledger) > B (safeguarding) → shortfall=True in three_leg_result."""
-        ports = _make_ports_with_rail(
-            Decimal("120000"), Decimal("100000"), Decimal("120000")
-        )
+        ports = _make_ports_with_rail(Decimal("120000"), Decimal("100000"), Decimal("120000"))
         agent = _make_agent(ports)
         result = agent.run(RUN_DATE)
         assert result.three_leg_result is not None


### PR DESCRIPTION
## Summary

- **`services/recon/safeguarding_adapters.py`** (new): three production port adapters bridging existing infrastructure to `SafeguardingAgent` ports:
  - `MidazClientFundsPort` — LedgerBalancePort via MidazLedgerAdapter, client-funds account (env-overridable IDs)
  - `StatementBankPort` — BankStatementPort via StatementFetcher, sums GBP balances, returns `None` (PENDING) when no GBP statement
  - `ZeroStreakCounter` — StreakCounterPort stub (streak=0 always; ClickHouse-backed counter is P1)
- **`services/recon/cron_daily_recon.py`** (modified): added `_run_safeguarding_agent(recon_date, dry_run)` + wired into `main()` as step 6; worst-case exit code via severity ordering `FATAL(3) > DISCREPANCY(2) > PENDING(1) > MATCHED(0)`
- **`tests/test_recon/test_safeguarding_adapters.py`** (new): 15 offline unit tests covering all adapters and `_run_safeguarding_agent` matched/breach/fatal paths

## Compliance

- I-01: All amounts `Decimal`, never `float`
- I-24: Audit trail via `AuditTrail` (append-only ClickHouse, dry_run=True in tests)
- I-27: HITL preserved — agent proposes, no autonomous breach suppression
- CASS 7.15: cron escalates to exit=1 (DISCREPANCY) on any breach detected by either legacy pipeline or SafeguardingAgent

## Test plan

- [ ] 15 tests green (`pytest tests/test_recon/test_safeguarding_adapters.py -v`)
- [ ] Ruff clean (`ruff check` + `ruff format --check`)
- [ ] No new semgrep findings
- [ ] CI pipeline passes (quality-gate.yml all 5 jobs)

## Leg C status

`rail=InMemoryRailBalancePort()` (no data → PENDING path). Three-leg status will be PENDING until a real payment-rail adapter is wired — this is correct initial state per spec; breach escalation on Leg C mismatch is already implemented in `SafeguardingAgent.run()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)