### PR TITLE
feat(gabriel): ReturnsGovernor — K-gabriel deadline/idempotency/breach-draft [IL-CBS-GABRIEL-GOVERNOR-2026-06-26]

### DIFF
--- a/services/gabriel/__init__.py
+++ b/services/gabriel/__init__.py
@@ -1,0 +1,32 @@
+"""K-gabriel — FCA Gabriel/RegData regulatory-returns governance layer.
+
+Orchestrates: schedule → deadline-track → validate → HITL sign-off → submit.
+
+FCA refs:
+  SUP 16.12R  — Gabriel return filing obligations
+  CASS 7.15R  — Monthly FIN060 safeguarding return
+  PS23/3 §5   — Safeguarding breach notification within 48h
+
+I-27: ReturnsGovernor PROPOSES drafts; human APPROVES before GabrielSubmissionPort fires.
+I-24: Append-only submission audit, TTL ≥ 5 years (I-08).
+"""
+
+from services.gabriel.gabriel_models import (
+    DeadlineStatus,
+    GabrielAuditEntry,
+    GabrielReturnStatus,
+    GabrielReturnType,
+    ReturnSchedule,
+    SubmissionRecord,
+)
+from services.gabriel.returns_governor import ReturnsGovernor
+
+__all__ = [
+    "GabrielReturnType",
+    "GabrielReturnStatus",
+    "SubmissionRecord",
+    "ReturnSchedule",
+    "DeadlineStatus",
+    "GabrielAuditEntry",
+    "ReturnsGovernor",
+]

--- a/services/gabriel/gabriel_models.py
+++ b/services/gabriel/gabriel_models.py
@@ -1,0 +1,144 @@
+"""
+services/gabriel/gabriel_models.py
+K-gabriel domain models and Protocol ports.
+
+K-gabriel spec §2: SubmissionRecord is the core entity — append-only (I-24),
+TTL 5 years (I-08), idempotency keyed by (return_type, return_period).
+
+I-01: No monetary fields at this layer — amounts flow via FinRepSourcePort.
+I-24: Submission audit entries are NEVER updated or deleted.
+I-27: GabrielSubmissionPort.submit() is ONLY called after HITL sign-off.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+from uuid import uuid4
+
+# ── Enums ──────────────────────────────────────────────────────────────────────
+
+
+class GabrielReturnType(str, Enum):
+    FIN060 = "FIN060"  # FCA CASS 15 monthly safeguarding return — SUP 16
+    BREACH_REPORT = "BREACH_REPORT"  # ad-hoc breach notification — PS23/3 §5
+
+
+class GabrielReturnStatus(str, Enum):
+    DRAFT = "DRAFT"  # created, awaiting validation
+    PREPARED = "PREPARED"  # validated, awaiting HITL sign-off
+    HITL_PENDING = "HITL_PENDING"  # submitted for human approval
+    APPROVED = "APPROVED"  # human approved, ready to submit to FCA
+    SUBMITTED = "SUBMITTED"  # sent to Gabriel
+    ACCEPTED = "ACCEPTED"  # FCA accepted
+    REJECTED = "REJECTED"  # FCA rejected — re-prepare required
+
+
+# ── Data classes ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SubmissionRecord:
+    """Append-only record of a Gabriel return submission (I-24, TTL 5Y I-08).
+
+    Fields mirror K-gabriel spec §3.1 submission record schema.
+    """
+
+    submission_id: str
+    return_type: GabrielReturnType
+    return_period: str  # ISO period "YYYY-MM" for monthly, "YYYY-MM-DD" for breach
+    fca_item_code: str  # Gabriel FCA item code e.g. "FIN060-MONTHLY"
+    prepared_at: str  # ISO-8601 datetime UTC
+    validated_by: str  # user/system id that validated
+    status: GabrielReturnStatus
+    idempotency_key: str  # "{return_type}:{return_period}" — unique per period
+    submitted_at: str | None = None  # ISO-8601 datetime UTC, set on submission
+    submission_ref: str | None = None  # FCA reference number, set on acceptance
+    source_recon_id: str | None = None  # recon_id if triggered by D-recon breach
+
+
+@dataclass(frozen=True)
+class ReturnSchedule:
+    """Config-driven return schedule entry."""
+
+    return_type: GabrielReturnType
+    frequency: str  # "MONTHLY" | "AD_HOC"
+    deadline_day: int  # day-of-month deadline (e.g. 15 for FIN060)
+    fca_item_code: str
+
+
+@dataclass(frozen=True)
+class DeadlineStatus:
+    """Deadline status for a pending return."""
+
+    return_type: GabrielReturnType
+    return_period: str
+    deadline_date: str  # ISO date
+    days_remaining: int  # negative = overdue
+    is_overdue: bool
+
+
+@dataclass(frozen=True)
+class GabrielAuditEntry:
+    """Immutable audit entry for a Gabriel submission event (I-24)."""
+
+    entry_id: str = field(default_factory=lambda: str(uuid4()))
+    submission_id: str = ""
+    action: str = ""  # "DRAFT_CREATED" | "PREPARED" | "HITL_SUBMITTED" | "SUBMITTED" | "ACCEPTED"
+    actor: str = ""  # user/system
+    occurred_at: str = ""  # ISO-8601 datetime UTC
+    details: str = ""
+
+
+# ── Ports (Protocol DI) ────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class GabrielSubmissionPort(Protocol):
+    """Port for submitting approved returns to FCA Gabriel / RegData.
+
+    ONLY called after HITL sign-off (I-27). Never call autonomously.
+    """
+
+    def submit(self, record: SubmissionRecord) -> SubmissionRecord: ...
+
+
+@runtime_checkable
+class GabrielAuditPort(Protocol):
+    """Port for appending Gabriel submission audit entries (I-24).
+
+    Implementations MUST be append-only — no UPDATE or DELETE permitted.
+    """
+
+    def record(self, entry: GabrielAuditEntry) -> None: ...
+
+
+class InMemoryGabrielSubmissionPort:
+    """Test stub — records submissions, returns a SUBMITTED copy."""
+
+    def __init__(self) -> None:
+        self.submitted: list[SubmissionRecord] = []
+
+    def submit(self, record: SubmissionRecord) -> SubmissionRecord:
+        from dataclasses import replace
+        from datetime import UTC, datetime
+
+        submitted = replace(
+            record,
+            status=GabrielReturnStatus.SUBMITTED,
+            submitted_at=datetime.now(UTC).isoformat(),
+            submission_ref=f"FCA-REF-{record.submission_id[:8].upper()}",
+        )
+        self.submitted.append(submitted)
+        return submitted
+
+
+class InMemoryGabrielAuditPort:
+    """Test stub — accumulates audit entries in order for assertion."""
+
+    def __init__(self) -> None:
+        self.entries: list[GabrielAuditEntry] = []
+
+    def record(self, entry: GabrielAuditEntry) -> None:
+        self.entries.append(entry)

--- a/services/gabriel/returns_governor.py
+++ b/services/gabriel/returns_governor.py
@@ -1,0 +1,194 @@
+"""
+services/gabriel/returns_governor.py
+ReturnsGovernor — K-gabriel orchestrator for FCA return submissions.
+
+Responsibilities (K-gabriel spec §3):
+  - Config-driven return schedule (FIN060 monthly, breach ad-hoc)
+  - Deadline tracking: days remaining before FCA Gabriel cutoff
+  - Idempotency: same (return_type, return_period) → same SubmissionRecord
+  - Breach→draft: safeguarding.breach.detected → DRAFT SubmissionRecord (I-27)
+  - Pre-submission validation gate: blocks invalid drafts from reaching HITL
+  - Append-only audit trail for every state transition (I-24, I-08)
+
+I-27: ReturnsGovernor NEVER calls GabrielSubmissionPort autonomously.
+      Submission is reserved for an explicit human-approved action.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+import logging
+from uuid import uuid4
+
+from services.gabriel.gabriel_models import (
+    DeadlineStatus,
+    GabrielAuditEntry,
+    GabrielAuditPort,
+    GabrielReturnStatus,
+    GabrielReturnType,
+    InMemoryGabrielAuditPort,
+    ReturnSchedule,
+    SubmissionRecord,
+)
+from services.recon.breach_notify_port import BreachEvent
+
+logger = logging.getLogger(__name__)
+
+# ── Default config ────────────────────────────────────────────────────────────
+
+_DEFAULT_SCHEDULE: dict[GabrielReturnType, ReturnSchedule] = {
+    GabrielReturnType.FIN060: ReturnSchedule(
+        return_type=GabrielReturnType.FIN060,
+        frequency="MONTHLY",
+        deadline_day=15,
+        fca_item_code="FIN060-MONTHLY",
+    ),
+    GabrielReturnType.BREACH_REPORT: ReturnSchedule(
+        return_type=GabrielReturnType.BREACH_REPORT,
+        frequency="AD_HOC",
+        deadline_day=2,  # 48h per PS23/3 §5
+        fca_item_code="BREACH-SAFEGUARD",
+    ),
+}
+
+
+# ── ReturnsGovernor ───────────────────────────────────────────────────────────
+
+
+class ReturnsGovernor:
+    """Orchestrates FCA Gabriel return lifecycle from draft to HITL.
+
+    Args:
+        audit: Append-only audit port (I-24). Defaults to InMemory.
+        schedule_config: Override return schedule (useful for tests).
+    """
+
+    def __init__(
+        self,
+        audit: GabrielAuditPort | None = None,
+        schedule_config: dict[GabrielReturnType, ReturnSchedule] | None = None,
+    ) -> None:
+        self._audit: GabrielAuditPort = audit or InMemoryGabrielAuditPort()
+        self._schedule = schedule_config if schedule_config is not None else _DEFAULT_SCHEDULE
+        self._records: dict[str, SubmissionRecord] = {}  # idempotency_key → record
+
+    # ── Public: schedule access ───────────────────────────────────────────────
+
+    def get_schedule(self, return_type: GabrielReturnType) -> ReturnSchedule:
+        """Return the configured schedule for a return type."""
+        if return_type not in self._schedule:
+            raise KeyError(f"No schedule configured for {return_type}")
+        return self._schedule[return_type]
+
+    # ── Public: deadline tracking ──────────────────────────────────────────────
+
+    def get_deadline_status(
+        self, return_type: GabrielReturnType, return_period: str
+    ) -> DeadlineStatus:
+        """Compute days remaining before FCA Gabriel cutoff.
+
+        For FIN060 "YYYY-MM": deadline = 15th of the following month.
+        For BREACH_REPORT "YYYY-MM-DD": deadline = detected_date + 2 days.
+        """
+        schedule = self.get_schedule(return_type)
+        today = date.today()
+
+        if return_type == GabrielReturnType.FIN060:
+            year, month = int(return_period[:4]), int(return_period[5:7])
+            # Advance to next month
+            if month == 12:
+                deadline = date(year + 1, 1, schedule.deadline_day)
+            else:
+                deadline = date(year, month + 1, schedule.deadline_day)
+        else:
+            # Ad-hoc breach: deadline is period_date + deadline_day days
+            period_date = date.fromisoformat(return_period)
+            from datetime import timedelta
+
+            deadline = period_date + timedelta(days=schedule.deadline_day)
+
+        days_remaining = (deadline - today).days
+        return DeadlineStatus(
+            return_type=return_type,
+            return_period=return_period,
+            deadline_date=deadline.isoformat(),
+            days_remaining=days_remaining,
+            is_overdue=days_remaining < 0,
+        )
+
+    # ── Public: idempotent create ──────────────────────────────────────────────
+
+    def get_or_create(
+        self,
+        return_type: GabrielReturnType,
+        return_period: str,
+        validated_by: str = "SYSTEM",
+        source_recon_id: str | None = None,
+    ) -> SubmissionRecord:
+        """Return existing draft for (type, period) or create a new one.
+
+        Idempotency: repeated calls with the same key return the same record
+        without creating duplicates (K-gabriel spec §3.2).
+        """
+        ikey = f"{return_type.value}:{return_period}"
+        if ikey in self._records:
+            return self._records[ikey]
+
+        schedule = self.get_schedule(return_type)
+        record = SubmissionRecord(
+            submission_id=str(uuid4()),
+            return_type=return_type,
+            return_period=return_period,
+            fca_item_code=schedule.fca_item_code,
+            prepared_at=datetime.now(UTC).isoformat(),
+            validated_by=validated_by,
+            status=GabrielReturnStatus.DRAFT,
+            idempotency_key=ikey,
+            source_recon_id=source_recon_id,
+        )
+        self._records[ikey] = record
+        self._audit.record(
+            GabrielAuditEntry(
+                submission_id=record.submission_id,
+                action="DRAFT_CREATED",
+                actor=validated_by,
+                occurred_at=datetime.now(UTC).isoformat(),
+                details=f"return_type={return_type.value} period={return_period}",
+            )
+        )
+        return record
+
+    # ── Public: breach→draft path ──────────────────────────────────────────────
+
+    def create_breach_draft(self, breach_event: BreachEvent) -> SubmissionRecord:
+        """Create a DRAFT breach report from a safeguarding.breach.detected event.
+
+        D-recon spec §4 → K-gabriel: breach event triggers a DRAFT submission.
+        HITL sign-off is required before the draft reaches GabrielSubmissionPort.
+
+        I-27: This method PROPOSES only — no autonomous FCA submission.
+        """
+        return self.get_or_create(
+            return_type=GabrielReturnType.BREACH_REPORT,
+            return_period=breach_event.recon_date,
+            validated_by=breach_event.requires_approval_from,
+            source_recon_id=breach_event.recon_id,
+        )
+
+    # ── Public: pre-submission validation ────────────────────────────────────
+
+    def validate_for_submission(self, record: SubmissionRecord) -> list[str]:
+        """Run pre-submission validation; return list of errors (empty = valid).
+
+        Blocks submission if status is SUBMITTED or ACCEPTED (duplicate guard).
+        """
+        errors: list[str] = []
+        if record.status in (GabrielReturnStatus.SUBMITTED, GabrielReturnStatus.ACCEPTED):
+            errors.append(
+                f"Submission {record.submission_id} already in terminal state {record.status}"
+            )
+        if not record.return_period:
+            errors.append("return_period is required")
+        if not record.fca_item_code:
+            errors.append("fca_item_code is required")
+        return errors

--- a/services/recon/breach_notify_port.py
+++ b/services/recon/breach_notify_port.py
@@ -1,0 +1,129 @@
+"""
+services/recon/breach_notify_port.py
+BreachNotifyPort — Protocol DI for safeguarding.breach.detected event.
+
+D-recon spec §4: when ReconciliationEngine detects a shortfall it emits
+`safeguarding.breach.detected` via this port to the K-gabriel workflow,
+where a HITL sign-off gate blocks any autonomous FCA submission (I-27).
+
+I-01: All monetary fields are Decimal — never float.
+I-24: N8nBreachNotifyAdapter logs every emission; audit trail in engine.
+I-27: Downstream K-gabriel is HITL-gated; this port only fires the event.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+import logging
+import os
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_N8N_TIMEOUT = 5.0
+
+
+@dataclass(frozen=True)
+class BreachEvent:
+    """Payload for `safeguarding.breach.detected` (D-recon spec §4).
+
+    I-01: client_funds_total, safeguarding_total, shortfall are Decimal.
+    """
+
+    event_type: str  # always "safeguarding.breach.detected"
+    recon_id: str
+    recon_date: str  # ISO-8601 date string
+    currency: str
+    client_funds_total: Decimal
+    safeguarding_total: Decimal
+    shortfall: Decimal  # abs(client_funds - safeguarding); always positive
+    detected_at: str  # ISO-8601 datetime UTC
+    requires_approval_from: str  # "MLRO"
+
+
+@runtime_checkable
+class BreachNotifyPort(Protocol):
+    """Port for emitting `safeguarding.breach.detected` to K-gabriel / n8n.
+
+    Implementations MUST be fail-open: log on error, never raise, so a
+    failed notification never breaks the reconciliation audit trail.
+    """
+
+    def notify(self, event: BreachEvent) -> None: ...
+
+
+class InMemoryBreachNotifyPort:
+    """Test stub — records all events in order for assertion."""
+
+    def __init__(self) -> None:
+        self.events: list[BreachEvent] = []
+
+    def notify(self, event: BreachEvent) -> None:
+        self.events.append(event)
+
+
+class N8nBreachNotifyAdapter:
+    """Sends `safeguarding.breach.detected` to n8n :5678 via HTTP POST.
+
+    URL resolution order:
+      1. ``webhook_url`` constructor arg (for tests / explicit wiring)
+      2. ``N8N_BREACH_NOTIFY_URL`` environment variable
+      3. ``N8N_WEBHOOK_URL`` environment variable (legacy fallback)
+
+    If no URL is available, the call is a no-op (logged as WARNING).
+    All failures are fail-open: logged as ERROR, never raised.
+
+    Args:
+        webhook_url: Optional override URL. Skips env-var lookup when set.
+    """
+
+    def __init__(self, webhook_url: str | None = None) -> None:
+        self._webhook_url = webhook_url
+
+    def _resolved_url(self) -> str | None:
+        if self._webhook_url:
+            return self._webhook_url
+        return os.getenv("N8N_BREACH_NOTIFY_URL") or os.getenv("N8N_WEBHOOK_URL")
+
+    def notify(self, event: BreachEvent) -> None:
+        url = self._resolved_url()
+        if not url:
+            logger.warning(
+                "N8nBreachNotifyAdapter: N8N_BREACH_NOTIFY_URL not configured — "
+                "breach event not forwarded (recon_id=%s, shortfall=%s)",
+                event.recon_id,
+                event.shortfall,
+            )
+            return
+
+        payload = {
+            "event_type": event.event_type,
+            "recon_id": event.recon_id,
+            "recon_date": event.recon_date,
+            "currency": event.currency,
+            "client_funds_total": str(event.client_funds_total),
+            "safeguarding_total": str(event.safeguarding_total),
+            "shortfall": str(event.shortfall),
+            "detected_at": event.detected_at,
+            "requires_approval_from": event.requires_approval_from,
+        }
+        try:
+            resp = httpx.post(url, json=payload, timeout=_N8N_TIMEOUT)
+            resp.raise_for_status()
+            logger.info(
+                "BreachNotifyPort: safeguarding.breach.detected forwarded to n8n "
+                "(recon_id=%s, shortfall=%s %s)",
+                event.recon_id,
+                event.shortfall,
+                event.currency,
+            )
+        except Exception as exc:
+            logger.error(
+                "N8nBreachNotifyAdapter.notify failed (recon_id=%s): %s. "
+                "Breach event NOT forwarded — FCA audit trail in engine intact.",
+                event.recon_id,
+                exc,
+            )

--- a/services/recon/recon_engine.py
+++ b/services/recon/recon_engine.py
@@ -15,10 +15,12 @@ I-27: HITL escalation for shortfalls.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Protocol
 from uuid import uuid4
 
+from services.recon.breach_notify_port import BreachEvent, BreachNotifyPort
 from services.recon.recon_models import (
     BLOCKED_JURISDICTIONS,
     LARGE_VALUE_THRESHOLD,
@@ -92,10 +94,12 @@ class ReconciliationEngine:
         ledger: LedgerPort,
         audit: ReconAuditPort | None = None,
         tolerance: Decimal | None = None,
+        breach_notifier: BreachNotifyPort | None = None,
     ) -> None:
         self._ledger = ledger
         self._audit: ReconAuditPort = audit or InMemoryReconAuditPort()
         self._tolerance = tolerance if tolerance is not None else RECON_TOLERANCE
+        self._breach_notifier = breach_notifier
         self._escalations: list[HITLEscalation] = []
 
     @property
@@ -177,6 +181,21 @@ class ReconciliationEngine:
                         requires_approval_from="MLRO",
                     )
                 )
+                # D-recon spec §4: emit safeguarding.breach.detected to K-gabriel.
+                if self._breach_notifier is not None:
+                    self._breach_notifier.notify(
+                        BreachEvent(
+                            event_type="safeguarding.breach.detected",
+                            recon_id=recon_id,
+                            recon_date=recon_date,
+                            currency="GBP",
+                            client_funds_total=client_total,
+                            safeguarding_total=safeguarding_total,
+                            shortfall=abs(difference),
+                            detected_at=datetime.now(UTC).isoformat(),
+                            requires_approval_from="MLRO",
+                        )
+                    )
 
         status = ReconStatus.BALANCED if not discrepancies else ReconStatus.DISCREPANCY
 

--- a/src/safeguarding/__init__.py
+++ b/src/safeguarding/__init__.py
@@ -15,6 +15,7 @@ FCA references:
 
 from .audit_trail import AuditEvent, AuditTrail
 from .breach_detector import BreachAlert, BreachDetector, BreachSeverity
+from .clickhouse_streak_counter import ClickHouseStreakCounter
 from .daily_reconciliation import DailyReconciliation, ReconciliationResult, ReconStatus
 from .fin060_generator import FIN060Generator, FIN060Return
 
@@ -29,4 +30,5 @@ __all__ = [
     "FIN060Return",
     "AuditTrail",
     "AuditEvent",
+    "ClickHouseStreakCounter",
 ]

--- a/src/safeguarding/clickhouse_streak_counter.py
+++ b/src/safeguarding/clickhouse_streak_counter.py
@@ -1,0 +1,159 @@
+"""clickhouse_streak_counter.py — ClickHouse-backed StreakCounterPort.
+
+Queries the safeguarding_audit table for consecutive RECON_BREAK events
+going backward from (as_of - 1 day) to compute the break streak passed
+to BreachDetector on each daily run.
+
+Called by SafeguardingAgent._run_internal() before today's audit event
+is written, so the query boundary is strictly < as_of (yesterday and earlier).
+
+Fail-open: returns 0 on ClickHouse failure.  The audit trail still captures
+every RECON_BREAK event — streak is always recoverable from history.
+
+FCA reference: CASS 7.15.29G / PS23/3 §3.49 (streak-based breach notification).
+
+Usage:
+    from src.safeguarding.clickhouse_streak_counter import ClickHouseStreakCounter
+
+    counter = ClickHouseStreakCounter(
+        clickhouse_url="http://localhost:8123",
+        database="banxe",
+    )
+    streak = counter.get_streak(date.today())
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+import logging
+
+logger = logging.getLogger(__name__)
+
+_LOOKBACK_DAYS_DEFAULT = 30
+_CH_TIMEOUT = 5.0
+
+
+class ClickHouseStreakCounter:
+    """ClickHouse-backed streak counter for CASS 15 consecutive reconciliation breaks.
+
+    Queries ``{database}.safeguarding_audit`` for consecutive ``RECON_BREAK``
+    days immediately before ``as_of``.  Today's audit event has not yet been
+    written when ``get_streak`` is called from SafeguardingAgent, so the query
+    uses a strict ``< as_of`` boundary.
+
+    ``reset_streak`` is a no-op: the RECON_MATCHED audit event written by
+    AuditTrail already acts as the natural streak-reset sentinel on the next
+    call to ``get_streak``.
+
+    Args:
+        clickhouse_url: Base URL of ClickHouse HTTP interface, e.g.
+                        ``"http://localhost:8123"``.
+        database:       ClickHouse database (default: ``"banxe"``).
+        clickhouse_user:     ClickHouse username (default: ``"default"``).
+        clickhouse_password: ClickHouse password (default: ``""``).
+        lookback_days:  Max calendar days to scan for consecutive breaks
+                        (default: 30).  Caps the query window; a break
+                        streak longer than this returns ``lookback_days``.
+    """
+
+    def __init__(
+        self,
+        clickhouse_url: str = "http://localhost:8123",
+        database: str = "banxe",
+        clickhouse_user: str = "default",
+        clickhouse_password: str = "",
+        lookback_days: int = _LOOKBACK_DAYS_DEFAULT,
+    ) -> None:
+        self._url = clickhouse_url.rstrip("/")
+        self._db = database
+        self._user = clickhouse_user
+        self._password = clickhouse_password
+        self._lookback = max(1, lookback_days)
+
+    # ── Public interface (StreakCounterPort) ───────────────────────────────────
+
+    def get_streak(self, as_of: date) -> int:
+        """Count consecutive RECON_BREAK days immediately before *as_of*.
+
+        Returns 0 on any ClickHouse error (fail-open, conservative for breach
+        detection — individual RECON_BREAK events are preserved in audit trail).
+        """
+        try:
+            return self._query_streak(as_of)
+        except Exception as exc:
+            logger.error(
+                "ClickHouseStreakCounter.get_streak(%s) failed — %s. Returning 0 (fail-open).",
+                as_of.isoformat(),
+                exc,
+            )
+            return 0
+
+    def reset_streak(self, as_of: date) -> None:
+        """No-op.
+
+        The RECON_MATCHED audit event written by AuditTrail on the same day
+        breaks the streak naturally: the next ``get_streak`` call will encounter
+        that MATCHED event and stop counting.
+        """
+        logger.debug("ClickHouseStreakCounter.reset_streak no-op for %s", as_of.isoformat())
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _query_streak(self, as_of: date) -> int:
+        """Query ClickHouse and walk backward through days counting breaks."""
+        import httpx
+
+        cutoff = as_of - timedelta(days=self._lookback)
+        # db name from config; dates from .isoformat() (no injection risk)
+        sql = (
+            f"SELECT toDate(occurred_at) AS recon_day, "  # noqa: S608
+            f"countIf(event_type = 'RECON_BREAK') AS breaks, "
+            f"countIf(event_type = 'RECON_MATCHED') AS matched "
+            f"FROM {self._db}.safeguarding_audit "
+            f"WHERE toDate(occurred_at) < '{as_of.isoformat()}' "
+            f"AND toDate(occurred_at) >= '{cutoff.isoformat()}' "
+            f"AND actor = 'SafeguardingAgent' "
+            f"GROUP BY recon_day "
+            f"ORDER BY recon_day DESC "
+            f"FORMAT TabSeparated"
+        )
+        resp = httpx.post(
+            self._url,
+            params={"query": sql},
+            auth=(self._user, self._password) if self._password else None,
+            timeout=_CH_TIMEOUT,
+        )
+        resp.raise_for_status()
+        return self._parse_streak(resp.text, as_of)
+
+    @staticmethod
+    def _parse_streak(tsv: str, as_of: date) -> int:
+        """Walk rows (newest first) counting consecutive RECON_BREAK-only days."""
+        streak = 0
+        prev_day: date | None = None
+
+        for line in tsv.strip().splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\t")
+            if len(parts) < 3:  # noqa: PLR2004
+                continue
+            try:
+                day = date.fromisoformat(parts[0])
+                breaks = int(parts[1])
+                matched = int(parts[2])
+            except (ValueError, IndexError):
+                continue
+
+            # A gap in calendar days (missed day = no RECON_BREAK) breaks the streak
+            if prev_day is not None and (prev_day - day).days > 1:
+                break
+            prev_day = day
+
+            if breaks > 0 and matched == 0:
+                streak += 1
+            else:
+                # Day had a MATCHED event (or no BREAK) — streak ends
+                break
+
+        return streak

--- a/tests/test_gabriel_returns_governor.py
+++ b/tests/test_gabriel_returns_governor.py
@@ -1,0 +1,295 @@
+"""
+tests/test_gabriel_returns_governor.py
+K-gabriel ReturnsGovernor tests (IL-CBS-GABRIEL-GOVERNOR-2026-06-26).
+
+DoD coverage (K-gabriel spec §4):
+  - test_return_schedule_config_driven
+  - test_pre_submission_validation_blocks_invalid
+  - test_deadline_tracking_before_fca_cutoff
+  - test_breach_event_to_report_path
+  - test_submission_audit_immutable_5y
+  - test_submission_idempotent_per_period
+
+Additional:
+  - Protocol compliance for ports
+  - deadline overdue detection
+  - breach draft links recon_id
+  - multiple return types independent
+  - validation passes valid record
+  - InMemory submission port returns SUBMITTED copy
+  - audit entry count per operation
+  - status remains DRAFT (no autonomous submission)
+  - BREACH_REPORT deadline is 2-day window
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from services.gabriel.gabriel_models import (
+    GabrielAuditPort,
+    GabrielReturnStatus,
+    GabrielReturnType,
+    GabrielSubmissionPort,
+    InMemoryGabrielAuditPort,
+    InMemoryGabrielSubmissionPort,
+    ReturnSchedule,
+    SubmissionRecord,
+)
+from services.gabriel.returns_governor import ReturnsGovernor
+from services.recon.breach_notify_port import BreachEvent
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+PERIOD_MAY = "2026-05"
+PERIOD_JUN = "2026-06"
+PERIOD_DATE = "2026-06-20"
+
+
+def _make_breach_event(recon_id: str = "recon-abc", recon_date: str = PERIOD_DATE) -> BreachEvent:
+    return BreachEvent(
+        event_type="safeguarding.breach.detected",
+        recon_id=recon_id,
+        recon_date=recon_date,
+        currency="GBP",
+        client_funds_total=Decimal("10500.00"),
+        safeguarding_total=Decimal("10000.00"),
+        shortfall=Decimal("500.00"),
+        detected_at=datetime.now(UTC).isoformat(),
+        requires_approval_from="MLRO",
+    )
+
+
+def _governor(audit: InMemoryGabrielAuditPort | None = None) -> ReturnsGovernor:
+    return ReturnsGovernor(audit=audit or InMemoryGabrielAuditPort())
+
+
+# ── DoD: test_return_schedule_config_driven ───────────────────────────────────
+
+
+class TestReturnScheduleConfigDriven:
+    def test_fin060_schedule_is_monthly(self) -> None:
+        gov = _governor()
+        sched = gov.get_schedule(GabrielReturnType.FIN060)
+        assert sched.frequency == "MONTHLY"
+
+    def test_fin060_deadline_day_is_15(self) -> None:
+        gov = _governor()
+        sched = gov.get_schedule(GabrielReturnType.FIN060)
+        assert sched.deadline_day == 15
+
+    def test_breach_report_schedule_is_adhoc(self) -> None:
+        gov = _governor()
+        sched = gov.get_schedule(GabrielReturnType.BREACH_REPORT)
+        assert sched.frequency == "AD_HOC"
+
+    def test_custom_schedule_overrides_default(self) -> None:
+        custom = {
+            GabrielReturnType.FIN060: ReturnSchedule(
+                return_type=GabrielReturnType.FIN060,
+                frequency="QUARTERLY",
+                deadline_day=30,
+                fca_item_code="FIN060-QUARTERLY-TEST",
+            )
+        }
+        gov = ReturnsGovernor(schedule_config=custom)
+        sched = gov.get_schedule(GabrielReturnType.FIN060)
+        assert sched.frequency == "QUARTERLY"
+        assert sched.deadline_day == 30
+
+    def test_unknown_return_type_raises(self) -> None:
+        custom_sched: dict[GabrielReturnType, ReturnSchedule] = {}
+        gov = ReturnsGovernor(schedule_config=custom_sched)
+        with pytest.raises(KeyError):
+            gov.get_schedule(GabrielReturnType.FIN060)
+
+
+# ── DoD: test_deadline_tracking_before_fca_cutoff ────────────────────────────
+
+
+class TestDeadlineTracking:
+    def test_fin060_deadline_is_15th_of_next_month(self) -> None:
+        gov = _governor()
+        status = gov.get_deadline_status(GabrielReturnType.FIN060, "2026-05")
+        assert status.deadline_date == "2026-06-15"
+
+    def test_fin060_december_wraps_to_january(self) -> None:
+        gov = _governor()
+        status = gov.get_deadline_status(GabrielReturnType.FIN060, "2026-12")
+        assert status.deadline_date == "2027-01-15"
+
+    def test_breach_report_deadline_is_two_days(self) -> None:
+        gov = _governor()
+        status = gov.get_deadline_status(GabrielReturnType.BREACH_REPORT, "2026-06-20")
+        assert status.deadline_date == "2026-06-22"
+
+    def test_days_remaining_positive_for_future_deadline(self) -> None:
+        gov = _governor()
+        future_period = (date.today() - timedelta(days=5)).strftime("%Y-%m")
+        status = gov.get_deadline_status(GabrielReturnType.FIN060, future_period)
+        assert status.days_remaining > 0 or status.is_overdue  # one or the other
+
+    def test_overdue_flag_set_when_past_deadline(self) -> None:
+        gov = _governor()
+        # Period 3 months ago — deadline long past
+        old_date = date.today() - timedelta(days=90)
+        period = old_date.strftime("%Y-%m")
+        status = gov.get_deadline_status(GabrielReturnType.FIN060, period)
+        assert status.is_overdue is True
+        assert status.days_remaining < 0
+
+
+# ── DoD: test_breach_event_to_report_path ────────────────────────────────────
+
+
+class TestBreachEventToReportPath:
+    def test_creates_submission_record(self) -> None:
+        gov = _governor()
+        record = gov.create_breach_draft(_make_breach_event())
+        assert record is not None
+        assert isinstance(record, SubmissionRecord)
+
+    def test_record_type_is_breach_report(self) -> None:
+        gov = _governor()
+        record = gov.create_breach_draft(_make_breach_event())
+        assert record.return_type == GabrielReturnType.BREACH_REPORT
+
+    def test_record_links_source_recon_id(self) -> None:
+        gov = _governor()
+        event = _make_breach_event(recon_id="recon-xyz999")
+        record = gov.create_breach_draft(event)
+        assert record.source_recon_id == "recon-xyz999"
+
+    def test_record_status_is_draft_not_submitted(self) -> None:
+        # I-27: no autonomous submission
+        gov = _governor()
+        record = gov.create_breach_draft(_make_breach_event())
+        assert record.status == GabrielReturnStatus.DRAFT
+
+    def test_record_period_matches_recon_date(self) -> None:
+        gov = _governor()
+        event = _make_breach_event(recon_date="2026-06-25")
+        record = gov.create_breach_draft(event)
+        assert record.return_period == "2026-06-25"
+
+    def test_record_fca_item_code_from_schedule(self) -> None:
+        gov = _governor()
+        record = gov.create_breach_draft(_make_breach_event())
+        assert record.fca_item_code == "BREACH-SAFEGUARD"
+
+
+# ── DoD: test_submission_audit_immutable_5y ───────────────────────────────────
+
+
+class TestSubmissionAuditImmutable:
+    def test_audit_recorded_on_draft_creation(self) -> None:
+        audit = InMemoryGabrielAuditPort()
+        gov = ReturnsGovernor(audit=audit)
+        gov.create_breach_draft(_make_breach_event())
+        assert len(audit.entries) == 1
+
+    def test_audit_entry_action_is_draft_created(self) -> None:
+        audit = InMemoryGabrielAuditPort()
+        gov = ReturnsGovernor(audit=audit)
+        gov.create_breach_draft(_make_breach_event())
+        assert audit.entries[0].action == "DRAFT_CREATED"
+
+    def test_audit_entry_has_submission_id(self) -> None:
+        audit = InMemoryGabrielAuditPort()
+        gov = ReturnsGovernor(audit=audit)
+        record = gov.create_breach_draft(_make_breach_event())
+        assert audit.entries[0].submission_id == record.submission_id
+
+    def test_audit_port_satisfies_protocol(self) -> None:
+        assert isinstance(InMemoryGabrielAuditPort(), GabrielAuditPort)
+
+    def test_audit_entries_accumulate_not_overwrite(self) -> None:
+        audit = InMemoryGabrielAuditPort()
+        gov = ReturnsGovernor(audit=audit)
+        gov.create_breach_draft(_make_breach_event(recon_date="2026-06-20"))
+        gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        assert len(audit.entries) == 2
+
+
+# ── DoD: test_submission_idempotent_per_period ────────────────────────────────
+
+
+class TestSubmissionIdempotency:
+    def test_same_type_and_period_returns_same_record(self) -> None:
+        gov = _governor()
+        r1 = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        r2 = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        assert r1.submission_id == r2.submission_id
+
+    def test_idempotency_key_format(self) -> None:
+        gov = _governor()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        assert record.idempotency_key == "FIN060:2026-05"
+
+    def test_different_periods_get_different_records(self) -> None:
+        gov = _governor()
+        r1 = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        r2 = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_JUN)
+        assert r1.submission_id != r2.submission_id
+
+    def test_breach_draft_idempotent_on_same_date(self) -> None:
+        gov = _governor()
+        e1 = _make_breach_event(recon_id="recon-001", recon_date="2026-06-20")
+        e2 = _make_breach_event(recon_id="recon-002", recon_date="2026-06-20")  # same date
+        r1 = gov.create_breach_draft(e1)
+        r2 = gov.create_breach_draft(e2)
+        assert r1.submission_id == r2.submission_id
+
+
+# ── DoD: test_pre_submission_validation_blocks_invalid ───────────────────────
+
+
+class TestPreSubmissionValidation:
+    def test_valid_draft_returns_no_errors(self) -> None:
+        gov = _governor()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        errors = gov.validate_for_submission(record)
+        assert errors == []
+
+    def test_submitted_record_blocked(self) -> None:
+        gov = _governor()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        submitted = replace(record, status=GabrielReturnStatus.SUBMITTED)
+        errors = gov.validate_for_submission(submitted)
+        assert len(errors) == 1
+        assert "terminal state" in errors[0]
+
+    def test_accepted_record_blocked(self) -> None:
+        gov = _governor()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        accepted = replace(record, status=GabrielReturnStatus.ACCEPTED)
+        errors = gov.validate_for_submission(accepted)
+        assert errors  # blocked
+
+    def test_missing_fca_item_code_blocked(self) -> None:
+        gov = _governor()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        bad = replace(record, fca_item_code="")
+        errors = gov.validate_for_submission(bad)
+        assert any("fca_item_code" in e for e in errors)
+
+
+# ── Protocol compliance ───────────────────────────────────────────────────────
+
+
+class TestProtocolCompliance:
+    def test_gabriel_submission_port_satisfied(self) -> None:
+        assert isinstance(InMemoryGabrielSubmissionPort(), GabrielSubmissionPort)
+
+    def test_in_memory_submit_returns_submitted_status(self) -> None:
+        port = InMemoryGabrielSubmissionPort()
+        gov = _governor()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        submitted = port.submit(record)
+        assert submitted.status == GabrielReturnStatus.SUBMITTED
+        assert submitted.submitted_at is not None
+        assert submitted.submission_ref is not None

--- a/tests/test_recon_breach_notify.py
+++ b/tests/test_recon_breach_notify.py
@@ -1,0 +1,336 @@
+"""
+tests/test_recon_breach_notify.py
+Tests for BreachNotifyPort — D-recon spec §4 (IL-CBS-DRECON-BREACHNOTIFY-2026-06-26).
+
+Coverage:
+  - BreachEvent frozen dataclass: immutability, I-01 Decimal fields
+  - InMemoryBreachNotifyPort: Protocol compliance, accumulates events, ordered
+  - N8nBreachNotifyAdapter: Protocol compliance, sends POST, payload shape
+  - N8nBreachNotifyAdapter: fail-open on HTTP error, connection error, timeout
+  - N8nBreachNotifyAdapter: no-op + warning when URL not set
+  - ReconciliationEngine: calls breach_notifier on SHORTFALL only
+  - ReconciliationEngine: breach_notifier=None → no error (backward-compat)
+  - ReconciliationEngine: BreachEvent fields match recon output
+  - ReconciliationEngine: multiple runs, each shortfall emits one event
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.recon.breach_notify_port import (
+    BreachEvent,
+    BreachNotifyPort,
+    InMemoryBreachNotifyPort,
+    N8nBreachNotifyAdapter,
+)
+from services.recon.recon_engine import ReconciliationEngine
+from services.recon.recon_port import InMemoryLedgerPort
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+RECON_DATE = "2026-06-26"
+
+
+def _make_event(
+    recon_id: str = "recon-abc123",
+    shortfall: Decimal = Decimal("500.00"),
+) -> BreachEvent:
+    return BreachEvent(
+        event_type="safeguarding.breach.detected",
+        recon_id=recon_id,
+        recon_date=RECON_DATE,
+        currency="GBP",
+        client_funds_total=Decimal("10500.00"),
+        safeguarding_total=Decimal("10000.00"),
+        shortfall=shortfall,
+        detected_at="2026-06-26T00:00:00+00:00",
+        requires_approval_from="MLRO",
+    )
+
+
+def _mock_ok_response() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _mock_error_response(status: int = 500) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.raise_for_status = MagicMock(side_effect=Exception(f"HTTP {status}"))
+    return resp
+
+
+# ── BreachEvent ───────────────────────────────────────────────────────────────
+
+
+class TestBreachEvent:
+    def test_is_frozen(self) -> None:
+        event = _make_event()
+        with pytest.raises((AttributeError, TypeError)):
+            event.recon_id = "other"  # type: ignore[misc]
+
+    def test_shortfall_is_decimal(self) -> None:
+        event = _make_event(shortfall=Decimal("1234.56"))
+        assert isinstance(event.shortfall, Decimal)
+
+    def test_client_funds_total_is_decimal(self) -> None:
+        assert isinstance(_make_event().client_funds_total, Decimal)
+
+    def test_safeguarding_total_is_decimal(self) -> None:
+        assert isinstance(_make_event().safeguarding_total, Decimal)
+
+    def test_event_type_constant(self) -> None:
+        assert _make_event().event_type == "safeguarding.breach.detected"
+
+    def test_requires_approval_from_default(self) -> None:
+        assert _make_event().requires_approval_from == "MLRO"
+
+
+# ── InMemoryBreachNotifyPort ──────────────────────────────────────────────────
+
+
+class TestInMemoryBreachNotifyPort:
+    def test_satisfies_protocol(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        assert isinstance(port, BreachNotifyPort)
+
+    def test_starts_empty(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        assert port.events == []
+
+    def test_records_single_event(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        event = _make_event()
+        port.notify(event)
+        assert len(port.events) == 1
+        assert port.events[0] is event
+
+    def test_records_multiple_events_in_order(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        e1 = _make_event(recon_id="recon-001", shortfall=Decimal("100"))
+        e2 = _make_event(recon_id="recon-002", shortfall=Decimal("200"))
+        port.notify(e1)
+        port.notify(e2)
+        assert port.events[0].recon_id == "recon-001"
+        assert port.events[1].recon_id == "recon-002"
+
+    def test_independent_instances_do_not_share_state(self) -> None:
+        p1 = InMemoryBreachNotifyPort()
+        p2 = InMemoryBreachNotifyPort()
+        p1.notify(_make_event())
+        assert p2.events == []
+
+
+# ── N8nBreachNotifyAdapter: Protocol ─────────────────────────────────────────
+
+
+class TestN8nAdapterProtocol:
+    def test_satisfies_breach_notify_port(self) -> None:
+        adapter = N8nBreachNotifyAdapter(webhook_url="http://n8n:5678/webhook/test")
+        assert isinstance(adapter, BreachNotifyPort)
+
+
+# ── N8nBreachNotifyAdapter: happy path ───────────────────────────────────────
+
+
+class TestN8nAdapterHappyPath:
+    def test_sends_post_to_configured_url(self) -> None:
+        with patch("httpx.post", return_value=_mock_ok_response()) as mock_post:
+            adapter = N8nBreachNotifyAdapter(webhook_url="http://n8n:5678/test")
+            adapter.notify(_make_event())
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            assert call_args[0][0] == "http://n8n:5678/test"
+
+    def test_payload_contains_event_type(self) -> None:
+        with patch("httpx.post", return_value=_mock_ok_response()) as mock_post:
+            adapter = N8nBreachNotifyAdapter(webhook_url="http://n8n:5678/test")
+            adapter.notify(_make_event())
+            payload = mock_post.call_args[1]["json"]
+            assert payload["event_type"] == "safeguarding.breach.detected"
+
+    def test_payload_amounts_are_strings_not_floats(self) -> None:
+        with patch("httpx.post", return_value=_mock_ok_response()) as mock_post:
+            adapter = N8nBreachNotifyAdapter(webhook_url="http://n8n:5678/test")
+            adapter.notify(_make_event(shortfall=Decimal("500.00")))
+            payload = mock_post.call_args[1]["json"]
+            assert isinstance(payload["shortfall"], str)
+            assert isinstance(payload["client_funds_total"], str)
+            assert isinstance(payload["safeguarding_total"], str)
+
+    def test_payload_shortfall_value_correct(self) -> None:
+        with patch("httpx.post", return_value=_mock_ok_response()) as mock_post:
+            adapter = N8nBreachNotifyAdapter(webhook_url="http://n8n:5678/test")
+            adapter.notify(_make_event(shortfall=Decimal("1234.56")))
+            payload = mock_post.call_args[1]["json"]
+            assert payload["shortfall"] == "1234.56"
+
+    def test_payload_contains_recon_id(self) -> None:
+        with patch("httpx.post", return_value=_mock_ok_response()) as mock_post:
+            adapter = N8nBreachNotifyAdapter(webhook_url="http://n8n:5678/test")
+            adapter.notify(_make_event(recon_id="recon-xyz789"))
+            payload = mock_post.call_args[1]["json"]
+            assert payload["recon_id"] == "recon-xyz789"
+
+
+# ── N8nBreachNotifyAdapter: fail-open ────────────────────────────────────────
+
+
+class TestN8nAdapterFailOpen:
+    def test_http_error_does_not_raise(self) -> None:
+        with patch("httpx.post", return_value=_mock_error_response(500)):
+            adapter = N8nBreachNotifyAdapter(webhook_url="http://n8n:5678/test")
+            adapter.notify(_make_event())  # must not raise
+
+    def test_connection_error_does_not_raise(self) -> None:
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.ConnectError("refused")):
+            adapter = N8nBreachNotifyAdapter(webhook_url="http://n8n:5678/test")
+            adapter.notify(_make_event())  # must not raise
+
+    def test_timeout_does_not_raise(self) -> None:
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.TimeoutException("timeout")):
+            adapter = N8nBreachNotifyAdapter(webhook_url="http://n8n:5678/test")
+            adapter.notify(_make_event())  # must not raise
+
+    def test_no_url_makes_no_http_call(self) -> None:
+        with patch.dict("os.environ", {}, clear=False):
+            # Ensure neither env var is set
+            import os
+
+            os.environ.pop("N8N_BREACH_NOTIFY_URL", None)
+            os.environ.pop("N8N_WEBHOOK_URL", None)
+            with patch("httpx.post") as mock_post:
+                adapter = N8nBreachNotifyAdapter()
+                adapter.notify(_make_event())
+                mock_post.assert_not_called()
+
+    def test_env_var_used_when_no_constructor_url(self) -> None:
+        with patch.dict("os.environ", {"N8N_BREACH_NOTIFY_URL": "http://env-n8n:5678/breach"}):
+            with patch("httpx.post", return_value=_mock_ok_response()) as mock_post:
+                adapter = N8nBreachNotifyAdapter()
+                adapter.notify(_make_event())
+                call_url = mock_post.call_args[0][0]
+                assert call_url == "http://env-n8n:5678/breach"
+
+
+# ── ReconciliationEngine integration ─────────────────────────────────────────
+
+
+class TestReconEngineBreachNotify:
+    def _shortfall_ledger(self) -> InMemoryLedgerPort:
+        ledger = InMemoryLedgerPort()
+        ledger.add_client_fund("CLIENT-001", Decimal("10500.00"))
+        ledger.add_safeguarding("SAFEG-001", Decimal("10000.00"))
+        return ledger
+
+    def _balanced_ledger(self) -> InMemoryLedgerPort:
+        ledger = InMemoryLedgerPort()
+        ledger.add_client_fund("CLIENT-001", Decimal("10000.00"))
+        ledger.add_safeguarding("SAFEG-001", Decimal("10000.00"))
+        return ledger
+
+    def _surplus_ledger(self) -> InMemoryLedgerPort:
+        ledger = InMemoryLedgerPort()
+        ledger.add_client_fund("CLIENT-001", Decimal("9500.00"))
+        ledger.add_safeguarding("SAFEG-001", Decimal("10000.00"))
+        return ledger
+
+    def test_calls_notify_on_shortfall(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        engine = ReconciliationEngine(
+            ledger=self._shortfall_ledger(),
+            breach_notifier=port,
+        )
+        engine.run_daily_recon(RECON_DATE)
+        assert len(port.events) == 1
+
+    def test_no_notify_on_balanced(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        engine = ReconciliationEngine(
+            ledger=self._balanced_ledger(),
+            breach_notifier=port,
+        )
+        engine.run_daily_recon(RECON_DATE)
+        assert port.events == []
+
+    def test_no_notify_on_surplus(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        engine = ReconciliationEngine(
+            ledger=self._surplus_ledger(),
+            breach_notifier=port,
+        )
+        engine.run_daily_recon(RECON_DATE)
+        assert port.events == []
+
+    def test_breach_event_shortfall_amount_correct(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        engine = ReconciliationEngine(
+            ledger=self._shortfall_ledger(),
+            breach_notifier=port,
+        )
+        engine.run_daily_recon(RECON_DATE)
+        assert port.events[0].shortfall == Decimal("500.00")
+
+    def test_breach_event_recon_id_matches_result(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        engine = ReconciliationEngine(
+            ledger=self._shortfall_ledger(),
+            breach_notifier=port,
+        )
+        result = engine.run_daily_recon(RECON_DATE)
+        assert port.events[0].recon_id == result.recon_id
+
+    def test_breach_event_recon_date_matches_input(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        engine = ReconciliationEngine(
+            ledger=self._shortfall_ledger(),
+            breach_notifier=port,
+        )
+        engine.run_daily_recon(RECON_DATE)
+        assert port.events[0].recon_date == RECON_DATE
+
+    def test_breach_event_type_is_canonical(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        engine = ReconciliationEngine(
+            ledger=self._shortfall_ledger(),
+            breach_notifier=port,
+        )
+        engine.run_daily_recon(RECON_DATE)
+        assert port.events[0].event_type == "safeguarding.breach.detected"
+
+    def test_no_notify_port_does_not_raise(self) -> None:
+        engine = ReconciliationEngine(
+            ledger=self._shortfall_ledger(),
+            breach_notifier=None,
+        )
+        result = engine.run_daily_recon(RECON_DATE)  # must not raise
+        assert result is not None
+
+    def test_multiple_runs_each_shortfall_emits_event(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        engine = ReconciliationEngine(
+            ledger=self._shortfall_ledger(),
+            breach_notifier=port,
+        )
+        engine.run_daily_recon("2026-06-25")
+        engine.run_daily_recon("2026-06-26")
+        assert len(port.events) == 2
+
+    def test_breach_event_requires_approval_from_mlro(self) -> None:
+        port = InMemoryBreachNotifyPort()
+        engine = ReconciliationEngine(
+            ledger=self._shortfall_ledger(),
+            breach_notifier=port,
+        )
+        engine.run_daily_recon(RECON_DATE)
+        assert port.events[0].requires_approval_from == "MLRO"

--- a/tests/test_src_safeguarding/test_clickhouse_streak_counter.py
+++ b/tests/test_src_safeguarding/test_clickhouse_streak_counter.py
@@ -1,0 +1,241 @@
+"""Tests for ClickHouseStreakCounter.
+
+Coverage:
+  - Satisfies StreakCounterPort Protocol (duck-typing / runtime_checkable)
+  - get_streak: empty result → 0
+  - get_streak: consecutive RECON_BREAK days → correct count
+  - get_streak: stops at RECON_MATCHED day
+  - get_streak: stops at calendar-day gap
+  - get_streak: ClickHouse HTTP error → fail-open 0
+  - get_streak: ClickHouse connection error → fail-open 0
+  - get_streak: boundary — as_of itself not included in query
+  - get_streak: respects lookback_days cutoff
+  - get_streak: day with both BREAK and MATCHED events treated as non-break
+  - get_streak: malformed TSV lines skipped
+  - get_streak: single trailing break day = streak 1
+  - get_streak: long streak capped at lookback_days
+  - reset_streak: no-op — does not raise
+  - Protocol DI: works as SafeguardingAgentPorts.streak_counter
+  - _parse_streak: static method unit-testable directly
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from src.safeguarding.agent import StreakCounterPort
+from src.safeguarding.clickhouse_streak_counter import ClickHouseStreakCounter
+
+TODAY = date(2026, 6, 26)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_tsv(*rows: tuple[str, int, int]) -> str:
+    """Build a TabSeparated ClickHouse response (day, breaks, matched)."""
+    return "\n".join(f"{d}\t{b}\t{m}" for d, b, m in rows)
+
+
+def _mock_ch_response(text: str, status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    resp.raise_for_status = MagicMock(
+        side_effect=None if status == 200 else Exception(f"HTTP {status}")
+    )
+    return resp
+
+
+# ── StreakCounterPort Protocol compliance ──────────────────────────────────────
+
+
+class TestProtocolCompliance:
+    def test_satisfies_streak_counter_port(self):
+        counter = ClickHouseStreakCounter()
+        assert isinstance(counter, StreakCounterPort)
+
+    def test_get_streak_method_exists(self):
+        assert callable(ClickHouseStreakCounter().get_streak)
+
+    def test_reset_streak_method_exists(self):
+        assert callable(ClickHouseStreakCounter().reset_streak)
+
+
+# ── get_streak: happy path ─────────────────────────────────────────────────────
+
+
+class TestGetStreakHappyPath:
+    def test_empty_result_returns_zero(self):
+        with patch("httpx.post", return_value=_mock_ch_response("")):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 0
+
+    def test_single_break_day_returns_one(self):
+        tsv = _make_tsv(("2026-06-25", 1, 0))
+        with patch("httpx.post", return_value=_mock_ch_response(tsv)):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 1
+
+    def test_two_consecutive_break_days_returns_two(self):
+        tsv = _make_tsv(("2026-06-25", 1, 0), ("2026-06-24", 1, 0))
+        with patch("httpx.post", return_value=_mock_ch_response(tsv)):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 2
+
+    def test_five_consecutive_breaks_returns_five(self):
+        rows = tuple((f"2026-06-{25 - i:02d}", 1, 0) for i in range(5))
+        tsv = _make_tsv(*rows)
+        with patch("httpx.post", return_value=_mock_ch_response(tsv)):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 5
+
+    def test_breaks_stop_at_matched_day(self):
+        # 2 breaks, then a MATCHED day, then more breaks
+        tsv = _make_tsv(
+            ("2026-06-25", 1, 0),
+            ("2026-06-24", 1, 0),
+            ("2026-06-23", 0, 1),  # MATCHED — streak stops here
+            ("2026-06-22", 1, 0),
+        )
+        with patch("httpx.post", return_value=_mock_ch_response(tsv)):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 2
+
+    def test_streak_stops_at_calendar_gap(self):
+        # Gap between Jun 24 and Jun 22 (Jun 23 missing → no RECON_BREAK that day)
+        tsv = _make_tsv(
+            ("2026-06-25", 1, 0),
+            ("2026-06-24", 1, 0),
+            ("2026-06-22", 1, 0),  # gap: Jun 23 missing
+        )
+        with patch("httpx.post", return_value=_mock_ch_response(tsv)):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 2
+
+    def test_day_with_both_break_and_matched_is_not_counted(self):
+        # Edge case: two events on same day → not a clean break day
+        tsv = _make_tsv(("2026-06-25", 1, 1))
+        with patch("httpx.post", return_value=_mock_ch_response(tsv)):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 0
+
+    def test_matched_only_day_returns_zero(self):
+        tsv = _make_tsv(("2026-06-25", 0, 1))
+        with patch("httpx.post", return_value=_mock_ch_response(tsv)):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 0
+
+
+# ── get_streak: fail-open behaviour ───────────────────────────────────────────
+
+
+class TestGetStreakFailOpen:
+    def test_http_error_returns_zero(self):
+        bad_resp = _mock_ch_response("", status=503)
+        bad_resp.raise_for_status.side_effect = Exception("HTTP 503")
+        with patch("httpx.post", return_value=bad_resp):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 0
+
+    def test_connection_error_returns_zero(self):
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.ConnectError("refused")):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 0
+
+    def test_timeout_returns_zero(self):
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.TimeoutException("timeout")):
+            assert ClickHouseStreakCounter().get_streak(TODAY) == 0
+
+
+# ── get_streak: query boundary ────────────────────────────────────────────────
+
+
+class TestGetStreakQueryBoundary:
+    def test_query_excludes_as_of_itself(self):
+        """SQL must use < as_of, not <=, so today's event is excluded."""
+        captured: list[str] = []
+
+        def capture(url: str, **kwargs: object) -> MagicMock:  # type: ignore[misc]
+            q = kwargs.get("params", {}).get("query", "")
+            captured.append(q)
+            return _mock_ch_response("")
+
+        with patch("httpx.post", side_effect=capture):
+            ClickHouseStreakCounter().get_streak(TODAY)
+
+        assert captured, "httpx.post was not called"
+        assert f"< '{TODAY.isoformat()}'" in captured[0]
+        assert f"<= '{TODAY.isoformat()}'" not in captured[0]
+
+    def test_lookback_days_limits_query_window(self):
+        """Custom lookback_days adjusts the lower bound in the SQL."""
+        captured: list[str] = []
+
+        def capture(url: str, **kwargs: object) -> MagicMock:  # type: ignore[misc]
+            q = kwargs.get("params", {}).get("query", "")
+            captured.append(q)
+            return _mock_ch_response("")
+
+        counter = ClickHouseStreakCounter(lookback_days=7)
+        with patch("httpx.post", side_effect=capture):
+            counter.get_streak(TODAY)
+
+        from datetime import timedelta
+
+        expected_cutoff = TODAY - timedelta(days=7)
+        assert f">= '{expected_cutoff.isoformat()}'" in captured[0]
+
+
+# ── reset_streak ──────────────────────────────────────────────────────────────
+
+
+class TestResetStreak:
+    def test_reset_streak_does_not_raise(self):
+        ClickHouseStreakCounter().reset_streak(TODAY)
+
+    def test_reset_streak_makes_no_http_call(self):
+        with patch("httpx.post") as mock_post:
+            ClickHouseStreakCounter().reset_streak(TODAY)
+            mock_post.assert_not_called()
+
+
+# ── _parse_streak static method ───────────────────────────────────────────────
+
+
+class TestParseStreak:
+    def test_empty_string_returns_zero(self):
+        assert ClickHouseStreakCounter._parse_streak("", TODAY) == 0
+
+    def test_malformed_line_skipped(self):
+        tsv = "bad_line\n2026-06-25\t1\t0"
+        assert ClickHouseStreakCounter._parse_streak(tsv, TODAY) == 1
+
+    def test_blank_lines_skipped(self):
+        tsv = "\n\n2026-06-25\t1\t0\n\n"
+        assert ClickHouseStreakCounter._parse_streak(tsv, TODAY) == 1
+
+
+# ── Protocol DI integration ───────────────────────────────────────────────────
+
+
+class TestProtocolDI:
+    def test_usable_as_safeguarding_agent_ports_streak_counter(self):
+        """ClickHouseStreakCounter fits SafeguardingAgentPorts.streak_counter."""
+        from decimal import Decimal
+
+        from src.safeguarding.agent import (
+            SafeguardingAgentPorts,
+            StubBankStatementPort,
+            StubLedgerPort,
+        )
+        from src.safeguarding.audit_trail import AuditTrail
+
+        ports = SafeguardingAgentPorts(
+            ledger=StubLedgerPort(balance_gbp=Decimal("100000.00")),
+            bank=StubBankStatementPort(balance_gbp=Decimal("100000.00")),
+            audit=AuditTrail(dry_run=True),
+            streak_counter=ClickHouseStreakCounter(),
+        )
+        # Duck-typing: no runtime error when assigning
+        assert ports.streak_counter is not None
+
+    def test_in_memory_also_satisfies_protocol(self):
+        from src.safeguarding.agent import InMemoryStreakCounter  # noqa: PLC0415
+
+        assert isinstance(InMemoryStreakCounter(), StreakCounterPort)


### PR DESCRIPTION
## Summary

- **K-gabriel spec §3** `ReturnsGovernor` orchestrator: config-driven FIN060/BREACH_REPORT return schedule, FCA Gabriel deadline tracking (15th of following month for FIN060; +48h PS23/3 §5 for breach), idempotent `get_or_create` per `(return_type, return_period)`, breach→DRAFT path from `BreachNotifyPort` event, pre-submission validation gate, append-only audit trail.
- **I-27**: `ReturnsGovernor` PROPOSES only — `GabrielSubmissionPort.submit()` never called autonomously; human HITL approval required.
- **I-24 / I-08**: `GabrielAuditPort` is append-only, `InMemoryGabrielAuditPort` accumulates entries in order; TTL ≥ 5 years on real persistence.
- Connects **D-recon `BreachNotifyPort`** (PR #223) → K-gabriel: `create_breach_draft(breach_event)` creates a linked DRAFT with `source_recon_id`.

## Files

| File | Role |
|------|------|
| `services/gabriel/__init__.py` | Package, public exports |
| `services/gabriel/gabriel_models.py` | Domain models + Protocol ports (GabrielSubmissionPort, GabrielAuditPort, InMemory stubs) |
| `services/gabriel/returns_governor.py` | ReturnsGovernor orchestrator |
| `tests/test_gabriel_returns_governor.py` | 31 tests covering all 6 DoD scenarios |

## Test plan

- [x] `TestReturnScheduleConfigDriven` — FIN060 monthly, BREACH_REPORT ad-hoc, custom override, unknown type raises
- [x] `TestDeadlineTracking` — 15th next month, December→January wrap, 2-day breach window, overdue flag
- [x] `TestBreachEventToReportPath` — DRAFT created, type=BREACH_REPORT, links recon_id, status=DRAFT (I-27), fca_item_code from schedule
- [x] `TestSubmissionAuditImmutable` — DRAFT_CREATED action, submission_id in entry, entries accumulate
- [x] `TestSubmissionIdempotency` — same key → same record, `FIN060:2026-05` key format, different periods → different records
- [x] `TestPreSubmissionValidation` — valid passes, SUBMITTED/ACCEPTED blocked, empty fca_item_code blocked
- [x] `TestProtocolCompliance` — InMemory satisfies Protocol, submit returns SUBMITTED status
- [x] Ruff clean · Semgrep 0 findings · 31/31 green

## Invariant compliance

| Invariant | Status |
|-----------|--------|
| I-01 No float for money | ✅ No monetary fields at this layer |
| I-24 Append-only audit | ✅ GabrielAuditPort append-only; no delete |
| I-27 HITL — propose only | ✅ ReturnsGovernor never calls submit() |
| I-08 TTL ≥ 5yr | ✅ Enforced at persistence layer; InMemory stub for tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)