### PR TITLE
feat(gabriel): K-gabriel API layer — HITL approve/reject endpoints [IL-CBS-GABRIEL-API-2026-06-26]

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -73,6 +73,7 @@ from api.routers import (
     fx_engine,
     fx_exchange,
     fx_rates,
+    gabriel,
     health,
     hitl,
     hmrc_reporting,
@@ -199,6 +200,7 @@ app.include_router(experiments.router, prefix="/v1")  # GET/POST /v1/experiments
 app.include_router(transaction_monitor.router, prefix="/v1")  # GET/POST /v1/monitor/* (IL-RTM-01)
 app.include_router(safeguarding.router, prefix="/v1")  # CASS 15 safeguarding (6 endpoints)
 app.include_router(recon.router, prefix="/v1")  # Reconciliation (3 endpoints)
+app.include_router(gabriel.router, prefix="/v1")  # K-gabriel FCA returns (IL-CBS-GABRIEL-API-2026-06-26)
 app.include_router(support.router, prefix="/v1")  # Customer Support Block (IL-CSB-01)
 app.include_router(regulatory.router, prefix="/v1")  # Regulatory Reporting (IL-RRA-01)
 app.include_router(open_banking.router, prefix="/v1")  # Open Banking PSD2 Gateway (IL-OBK-01)

--- a/api/models/gabriel.py
+++ b/api/models/gabriel.py
@@ -1,0 +1,48 @@
+"""
+api/models/gabriel.py
+K-gabriel API request/response models.
+
+All amounts are string (DecimalString) per I-01.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SubmissionRecordResponse(BaseModel):
+    submission_id: str
+    return_type: str
+    return_period: str
+    fca_item_code: str
+    prepared_at: str
+    validated_by: str
+    status: str
+    idempotency_key: str
+    submitted_at: str | None = None
+    submission_ref: str | None = None
+    source_recon_id: str | None = None
+
+
+class DeadlineStatusResponse(BaseModel):
+    return_type: str
+    return_period: str
+    deadline_date: str
+    days_remaining: int
+    is_overdue: bool
+
+
+class CreateDraftRequest(BaseModel):
+    return_type: str = Field(..., description="FIN060 | BREACH_REPORT")
+    return_period: str = Field(..., description="ISO period: YYYY-MM or YYYY-MM-DD")
+    validated_by: str = Field(default="SYSTEM")
+    source_recon_id: str | None = None
+
+
+class ApproveRequest(BaseModel):
+    approved_by: str = Field(..., description="Identity of MLRO / CFO approving submission")
+
+
+class RejectRequest(BaseModel):
+    rejected_by: str = Field(..., description="Identity of MLRO / CFO rejecting submission")
+    reason: str = Field(..., description="Reason for rejection")

--- a/api/routers/gabriel.py
+++ b/api/routers/gabriel.py
@@ -1,0 +1,203 @@
+"""
+api/routers/gabriel.py — K-gabriel FCA Returns Governance API
+IL-CBS-GABRIEL-API-2026-06-26 | K-gabriel spec §5
+
+Endpoints:
+  GET  /v1/gabriel/returns                       — list all submission records
+  GET  /v1/gabriel/returns/{submission_id}       — get by submission_id
+  POST /v1/gabriel/returns                       — create or get idempotent draft
+  POST /v1/gabriel/returns/{id}/approve          — HITL: approve → submit to FCA
+  POST /v1/gabriel/returns/{id}/reject           — HITL: reject draft
+  GET  /v1/gabriel/deadline/{return_type}/{period} — deadline status
+
+FCA compliance:
+  - I-27: approve endpoint is the ONLY path to GabrielSubmissionPort.submit()
+  - I-24: all transitions audit-logged via GabrielAuditPort
+  - I-08: audit TTL ≥ 5 years (enforced at persistence layer)
+  - All amounts Decimal strings (none at this layer — structural data only)
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, status
+
+from api.models.gabriel import (
+    ApproveRequest,
+    CreateDraftRequest,
+    DeadlineStatusResponse,
+    RejectRequest,
+    SubmissionRecordResponse,
+)
+from services.gabriel.gabriel_models import (
+    GabrielReturnType,
+    InMemoryGabrielAuditPort,
+    InMemoryGabrielSubmissionPort,
+    SubmissionRecord,
+)
+from services.gabriel.returns_governor import ReturnsGovernor
+
+logger = logging.getLogger("banxe.api.gabriel")
+
+router = APIRouter(tags=["Gabriel Returns (K-gabriel)"])
+
+# ── Singletons (sandbox InMemory; swap for real adapters in production) ───────
+
+_governor = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+_submission_port = InMemoryGabrielSubmissionPort()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _to_response(record: SubmissionRecord) -> SubmissionRecordResponse:
+    return SubmissionRecordResponse(
+        submission_id=record.submission_id,
+        return_type=record.return_type.value,
+        return_period=record.return_period,
+        fca_item_code=record.fca_item_code,
+        prepared_at=record.prepared_at,
+        validated_by=record.validated_by,
+        status=record.status.value,
+        idempotency_key=record.idempotency_key,
+        submitted_at=record.submitted_at,
+        submission_ref=record.submission_ref,
+        source_recon_id=record.source_recon_id,
+    )
+
+
+def _parse_return_type(raw: str) -> GabrielReturnType:
+    try:
+        return GabrielReturnType(raw.upper())
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown return_type {raw!r}. Valid values: FIN060, BREACH_REPORT",
+        )
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/gabriel/returns", response_model=list[SubmissionRecordResponse])
+async def list_gabriel_returns() -> list[SubmissionRecordResponse]:
+    """List all K-gabriel submission records."""
+    return [_to_response(r) for r in _governor.list_records()]
+
+
+@router.get(
+    "/gabriel/returns/{submission_id}", response_model=SubmissionRecordResponse
+)
+async def get_gabriel_return(submission_id: str) -> SubmissionRecordResponse:
+    """Get a single submission record by submission_id."""
+    record = _governor.get_by_id(submission_id)
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No submission record with id={submission_id!r}",
+        )
+    return _to_response(record)
+
+
+@router.post(
+    "/gabriel/returns",
+    response_model=SubmissionRecordResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def create_gabriel_draft(body: CreateDraftRequest) -> SubmissionRecordResponse:
+    """Create or retrieve an idempotent DRAFT submission record.
+
+    Repeating the same (return_type, return_period) returns the existing record.
+    """
+    return_type = _parse_return_type(body.return_type)
+    record = _governor.get_or_create(
+        return_type=return_type,
+        return_period=body.return_period,
+        validated_by=body.validated_by,
+        source_recon_id=body.source_recon_id,
+    )
+    return _to_response(record)
+
+
+@router.post(
+    "/gabriel/returns/{submission_id}/approve",
+    response_model=SubmissionRecordResponse,
+)
+async def approve_gabriel_return(
+    submission_id: str, body: ApproveRequest
+) -> SubmissionRecordResponse:
+    """HITL gate: approve a DRAFT and submit to FCA Gabriel.
+
+    I-27: The ONLY endpoint that calls GabrielSubmissionPort.submit().
+    Requires an explicit human decision (approved_by must identify the MLRO/CFO).
+    Returns 422 if the record fails pre-submission validation.
+    """
+    try:
+        submitted = _governor.approve(
+            submission_id=submission_id,
+            approved_by=body.approved_by,
+            submission_port=_submission_port,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    logger.info(
+        "Gabriel HITL approve: submission_id=%s by=%s ref=%s",
+        submitted.submission_id,
+        body.approved_by,
+        submitted.submission_ref,
+    )
+    return _to_response(submitted)
+
+
+@router.post(
+    "/gabriel/returns/{submission_id}/reject",
+    response_model=SubmissionRecordResponse,
+)
+async def reject_gabriel_return(
+    submission_id: str, body: RejectRequest
+) -> SubmissionRecordResponse:
+    """HITL gate: reject a DRAFT submission record.
+
+    Returns 404 if the record does not exist.
+    """
+    try:
+        rejected = _governor.reject(
+            submission_id=submission_id,
+            rejected_by=body.rejected_by,
+            reason=body.reason,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    logger.info(
+        "Gabriel HITL reject: submission_id=%s by=%s",
+        rejected.submission_id,
+        body.rejected_by,
+    )
+    return _to_response(rejected)
+
+
+@router.get(
+    "/gabriel/deadline/{return_type}/{return_period}",
+    response_model=DeadlineStatusResponse,
+)
+async def get_gabriel_deadline(
+    return_type: str, return_period: str
+) -> DeadlineStatusResponse:
+    """Return the FCA Gabriel filing deadline for a given return type and period."""
+    rt = _parse_return_type(return_type)
+    try:
+        ds = _governor.get_deadline_status(rt, return_period)
+    except (ValueError, KeyError) as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    return DeadlineStatusResponse(
+        return_type=ds.return_type.value,
+        return_period=ds.return_period,
+        deadline_date=ds.deadline_date,
+        days_remaining=ds.days_remaining,
+        is_overdue=ds.is_overdue,
+    )

--- a/services/gabriel/returns_governor.py
+++ b/services/gabriel/returns_governor.py
@@ -26,6 +26,7 @@ from services.gabriel.gabriel_models import (
     GabrielAuditPort,
     GabrielReturnStatus,
     GabrielReturnType,
+    GabrielSubmissionPort,
     InMemoryGabrielAuditPort,
     ReturnSchedule,
     SubmissionRecord,
@@ -192,3 +193,76 @@ class ReturnsGovernor:
         if not record.fca_item_code:
             errors.append("fca_item_code is required")
         return errors
+
+    # ── Public: query ─────────────────────────────────────────────────────────
+
+    def list_records(self) -> list[SubmissionRecord]:
+        """Return all records in creation order."""
+        return list(self._records.values())
+
+    def get_by_id(self, submission_id: str) -> SubmissionRecord | None:
+        """Lookup a record by submission_id (linear scan — records are small)."""
+        for record in self._records.values():
+            if record.submission_id == submission_id:
+                return record
+        return None
+
+    # ── Public: HITL transitions ──────────────────────────────────────────────
+
+    def approve(
+        self,
+        submission_id: str,
+        approved_by: str,
+        submission_port: GabrielSubmissionPort,
+    ) -> SubmissionRecord:
+        """HITL gate: validate record, call submission_port.submit(), audit.
+
+        I-27: The ONLY path that calls GabrielSubmissionPort.submit().
+              Requires an explicit human-initiated POST /approve request.
+        """
+        from dataclasses import replace as _replace
+
+        record = self.get_by_id(submission_id)
+        if record is None:
+            raise KeyError(f"No record with submission_id={submission_id!r}")
+        errors = self.validate_for_submission(record)
+        if errors:
+            raise ValueError(f"Invalid for submission: {'; '.join(errors)}")
+        approved = _replace(record, status=GabrielReturnStatus.APPROVED)
+        submitted = submission_port.submit(approved)
+        self._records[record.idempotency_key] = submitted
+        self._audit.record(
+            GabrielAuditEntry(
+                submission_id=submitted.submission_id,
+                action="APPROVED_SUBMITTED",
+                actor=approved_by,
+                occurred_at=datetime.now(UTC).isoformat(),
+                details=f"submitted_at={submitted.submitted_at} ref={submitted.submission_ref}",
+            )
+        )
+        return submitted
+
+    def reject(
+        self,
+        submission_id: str,
+        rejected_by: str,
+        reason: str,
+    ) -> SubmissionRecord:
+        """HITL gate: mark record REJECTED, audit the decision."""
+        from dataclasses import replace as _replace
+
+        record = self.get_by_id(submission_id)
+        if record is None:
+            raise KeyError(f"No record with submission_id={submission_id!r}")
+        rejected = _replace(record, status=GabrielReturnStatus.REJECTED)
+        self._records[record.idempotency_key] = rejected
+        self._audit.record(
+            GabrielAuditEntry(
+                submission_id=rejected.submission_id,
+                action="REJECTED",
+                actor=rejected_by,
+                occurred_at=datetime.now(UTC).isoformat(),
+                details=reason,
+            )
+        )
+        return rejected

--- a/tests/test_gabriel_api.py
+++ b/tests/test_gabriel_api.py
@@ -1,0 +1,308 @@
+"""
+tests/test_gabriel_api.py
+K-gabriel API layer tests (IL-CBS-GABRIEL-API-2026-06-26).
+
+Tests governor extensions (list/get_by_id/approve/reject) and
+FastAPI router endpoints via TestClient.
+
+Coverage:
+  - ReturnsGovernor.list_records / get_by_id
+  - ReturnsGovernor.approve — happy path, not-found, validation-blocked
+  - ReturnsGovernor.reject — happy path, not-found
+  - GET /v1/gabriel/returns (empty and populated)
+  - GET /v1/gabriel/returns/{id} (found / not-found)
+  - POST /v1/gabriel/returns (create draft)
+  - POST /v1/gabriel/returns/{id}/approve (happy + errors)
+  - POST /v1/gabriel/returns/{id}/reject (happy + not-found)
+  - GET /v1/gabriel/deadline/{type}/{period}
+  - 422 on unknown return_type
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import pytest
+
+from services.gabriel.gabriel_models import (
+    GabrielReturnStatus,
+    GabrielReturnType,
+    InMemoryGabrielAuditPort,
+    InMemoryGabrielSubmissionPort,
+)
+from services.gabriel.returns_governor import ReturnsGovernor
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+PERIOD_MAY = "2026-05"
+PERIOD_BREACH = "2026-06-20"
+
+
+def _governor_with_audit() -> tuple[ReturnsGovernor, InMemoryGabrielAuditPort]:
+    audit = InMemoryGabrielAuditPort()
+    return ReturnsGovernor(audit=audit), audit
+
+
+def _governor() -> ReturnsGovernor:
+    return ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+
+
+# ── ReturnsGovernor: list_records / get_by_id ─────────────────────────────────
+
+
+class TestGovernorQuery:
+    def test_list_empty_initially(self) -> None:
+        gov = _governor()
+        assert gov.list_records() == []
+
+    def test_list_returns_all_records(self) -> None:
+        gov = _governor()
+        gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        gov.get_or_create(GabrielReturnType.BREACH_REPORT, PERIOD_BREACH)
+        assert len(gov.list_records()) == 2
+
+    def test_get_by_id_found(self) -> None:
+        gov = _governor()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        found = gov.get_by_id(record.submission_id)
+        assert found is not None
+        assert found.submission_id == record.submission_id
+
+    def test_get_by_id_not_found_returns_none(self) -> None:
+        gov = _governor()
+        assert gov.get_by_id("nonexistent-id") is None
+
+    def test_list_idempotent_no_duplicates(self) -> None:
+        gov = _governor()
+        gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)  # same key
+        assert len(gov.list_records()) == 1
+
+
+# ── ReturnsGovernor.approve ───────────────────────────────────────────────────
+
+
+class TestGovernorApprove:
+    def test_approve_happy_path_returns_submitted(self) -> None:
+        gov, audit = _governor_with_audit()
+        port = InMemoryGabrielSubmissionPort()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        submitted = gov.approve(record.submission_id, "MLRO-Alice", port)
+        assert submitted.status == GabrielReturnStatus.SUBMITTED
+        assert submitted.submitted_at is not None
+        assert submitted.submission_ref is not None
+
+    def test_approve_audit_action_is_approved_submitted(self) -> None:
+        gov, audit = _governor_with_audit()
+        port = InMemoryGabrielSubmissionPort()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        gov.approve(record.submission_id, "MLRO-Alice", port)
+        actions = [e.action for e in audit.entries]
+        assert "APPROVED_SUBMITTED" in actions
+
+    def test_approve_not_found_raises_key_error(self) -> None:
+        gov = _governor()
+        port = InMemoryGabrielSubmissionPort()
+        with pytest.raises(KeyError):
+            gov.approve("bad-id", "MLRO-Alice", port)
+
+    def test_approve_already_submitted_raises_value_error(self) -> None:
+        gov = _governor()
+        port = InMemoryGabrielSubmissionPort()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        gov.approve(record.submission_id, "MLRO-Alice", port)  # first submit
+        refetched = gov.get_by_id(record.submission_id)
+        assert refetched is not None
+        with pytest.raises(ValueError):
+            gov.approve(refetched.submission_id, "MLRO-Alice", port)
+
+    def test_approve_updates_record_in_governor(self) -> None:
+        gov = _governor()
+        port = InMemoryGabrielSubmissionPort()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        gov.approve(record.submission_id, "MLRO-Alice", port)
+        updated = gov.get_by_id(record.submission_id)
+        assert updated is not None
+        assert updated.status == GabrielReturnStatus.SUBMITTED
+
+    def test_approve_delegates_to_port(self) -> None:
+        gov = _governor()
+        port = InMemoryGabrielSubmissionPort()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        gov.approve(record.submission_id, "MLRO-Alice", port)
+        assert len(port.submitted) == 1
+        assert port.submitted[0].submission_id == record.submission_id
+
+
+# ── ReturnsGovernor.reject ────────────────────────────────────────────────────
+
+
+class TestGovernorReject:
+    def test_reject_happy_path_returns_rejected(self) -> None:
+        gov = _governor()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        rejected = gov.reject(record.submission_id, "MLRO-Alice", "Incorrect period")
+        assert rejected.status == GabrielReturnStatus.REJECTED
+
+    def test_reject_audit_action_is_rejected(self) -> None:
+        gov, audit = _governor_with_audit()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        gov.reject(record.submission_id, "MLRO-Alice", "Wrong data")
+        actions = [e.action for e in audit.entries]
+        assert "REJECTED" in actions
+
+    def test_reject_not_found_raises_key_error(self) -> None:
+        gov = _governor()
+        with pytest.raises(KeyError):
+            gov.reject("bad-id", "MLRO-Alice", "reason")
+
+    def test_reject_updates_record_in_governor(self) -> None:
+        gov = _governor()
+        record = gov.get_or_create(GabrielReturnType.FIN060, PERIOD_MAY)
+        gov.reject(record.submission_id, "MLRO-Alice", "reason")
+        updated = gov.get_by_id(record.submission_id)
+        assert updated is not None
+        assert updated.status == GabrielReturnStatus.REJECTED
+
+
+# ── API layer via TestClient ───────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    """Fresh governor state per test — reset module singleton."""
+    from api.main import app
+    import api.routers.gabriel as gabriel_router
+
+    gabriel_router._governor = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+    gabriel_router._submission_port = InMemoryGabrielSubmissionPort()
+    return TestClient(app)
+
+
+class TestGabrielApiListCreate:
+    def test_list_empty(self, client: TestClient) -> None:
+        resp = client.get("/v1/gabriel/returns")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_create_draft_returns_200(self, client: TestClient) -> None:
+        resp = client.post(
+            "/v1/gabriel/returns",
+            json={"return_type": "FIN060", "return_period": PERIOD_MAY},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["return_type"] == "FIN060"
+        assert data["status"] == "DRAFT"
+        assert data["idempotency_key"] == "FIN060:2026-05"
+
+    def test_create_draft_idempotent(self, client: TestClient) -> None:
+        payload = {"return_type": "FIN060", "return_period": PERIOD_MAY}
+        r1 = client.post("/v1/gabriel/returns", json=payload)
+        r2 = client.post("/v1/gabriel/returns", json=payload)
+        assert r1.json()["submission_id"] == r2.json()["submission_id"]
+
+    def test_list_shows_created_record(self, client: TestClient) -> None:
+        client.post(
+            "/v1/gabriel/returns",
+            json={"return_type": "FIN060", "return_period": PERIOD_MAY},
+        )
+        resp = client.get("/v1/gabriel/returns")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_create_unknown_return_type_422(self, client: TestClient) -> None:
+        resp = client.post(
+            "/v1/gabriel/returns",
+            json={"return_type": "BOGUS_TYPE", "return_period": PERIOD_MAY},
+        )
+        assert resp.status_code == 422
+
+
+class TestGabrielApiGetById:
+    def test_get_found(self, client: TestClient) -> None:
+        created = client.post(
+            "/v1/gabriel/returns",
+            json={"return_type": "FIN060", "return_period": PERIOD_MAY},
+        ).json()
+        resp = client.get(f"/v1/gabriel/returns/{created['submission_id']}")
+        assert resp.status_code == 200
+        assert resp.json()["submission_id"] == created["submission_id"]
+
+    def test_get_not_found_404(self, client: TestClient) -> None:
+        resp = client.get("/v1/gabriel/returns/nonexistent-id")
+        assert resp.status_code == 404
+
+
+class TestGabrielApiApprove:
+    def test_approve_returns_submitted(self, client: TestClient) -> None:
+        created = client.post(
+            "/v1/gabriel/returns",
+            json={"return_type": "FIN060", "return_period": PERIOD_MAY},
+        ).json()
+        resp = client.post(
+            f"/v1/gabriel/returns/{created['submission_id']}/approve",
+            json={"approved_by": "MLRO-Alice"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "SUBMITTED"
+        assert data["submitted_at"] is not None
+        assert data["submission_ref"] is not None
+
+    def test_approve_not_found_404(self, client: TestClient) -> None:
+        resp = client.post(
+            "/v1/gabriel/returns/bad-id/approve",
+            json={"approved_by": "MLRO-Alice"},
+        )
+        assert resp.status_code == 404
+
+    def test_approve_already_submitted_422(self, client: TestClient) -> None:
+        created = client.post(
+            "/v1/gabriel/returns",
+            json={"return_type": "FIN060", "return_period": PERIOD_MAY},
+        ).json()
+        sid = created["submission_id"]
+        client.post(f"/v1/gabriel/returns/{sid}/approve", json={"approved_by": "MLRO"})
+        resp = client.post(
+            f"/v1/gabriel/returns/{sid}/approve", json={"approved_by": "MLRO"}
+        )
+        assert resp.status_code == 422
+
+
+class TestGabrielApiReject:
+    def test_reject_returns_rejected_status(self, client: TestClient) -> None:
+        created = client.post(
+            "/v1/gabriel/returns",
+            json={"return_type": "FIN060", "return_period": PERIOD_MAY},
+        ).json()
+        resp = client.post(
+            f"/v1/gabriel/returns/{created['submission_id']}/reject",
+            json={"rejected_by": "MLRO-Bob", "reason": "Incorrect amounts"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "REJECTED"
+
+    def test_reject_not_found_404(self, client: TestClient) -> None:
+        resp = client.post(
+            "/v1/gabriel/returns/bad-id/reject",
+            json={"rejected_by": "MLRO-Bob", "reason": "reason"},
+        )
+        assert resp.status_code == 404
+
+
+class TestGabrielApiDeadline:
+    def test_deadline_fin060_returns_15th_next_month(self, client: TestClient) -> None:
+        resp = client.get("/v1/gabriel/deadline/FIN060/2026-05")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["deadline_date"] == "2026-06-15"
+        assert data["return_type"] == "FIN060"
+
+    def test_deadline_breach_report_two_days(self, client: TestClient) -> None:
+        resp = client.get("/v1/gabriel/deadline/BREACH_REPORT/2026-06-20")
+        assert resp.status_code == 200
+        assert resp.json()["deadline_date"] == "2026-06-22"
+
+    def test_deadline_unknown_type_422(self, client: TestClient) -> None:
+        resp = client.get("/v1/gabriel/deadline/BOGUS/2026-05")
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Extends `ReturnsGovernor` with `list_records()`, `get_by_id()`, `approve()`, `reject()` 
- `approve()` is the **sole path** to `GabrielSubmissionPort.submit()` (I-27 HITL gate enforced)
- New `api/models/gabriel.py` — Pydantic request/response models
- New `api/routers/gabriel.py` — 6 endpoints under `/v1/gabriel/`
- Registered in `api/main.py`

## Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | /v1/gabriel/returns | List all submission records |
| GET | /v1/gabriel/returns/{id} | Get by submission_id (404 if missing) |
| POST | /v1/gabriel/returns | Idempotent draft create |
| POST | /v1/gabriel/returns/{id}/approve | **HITL gate** → submit to FCA Gabriel |
| POST | /v1/gabriel/returns/{id}/reject | HITL reject |
| GET | /v1/gabriel/deadline/{type}/{period} | Deadline status |

## Compliance

- I-27: `approve` endpoint is the ONLY path that calls `GabrielSubmissionPort.submit()`
- I-24: every state transition audit-logged via `GabrielAuditPort`
- I-01: no monetary amounts at this layer (structural data only)
- Returns 422 on already-submitted record (duplicate guard)

## Test plan

- [x] 30 new tests in `tests/test_gabriel_api.py`
- [x] All 11,585 tests pass
- [x] `ruff check` — 0 issues
- [x] `semgrep` — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)