### PR TITLE
feat(gabriel): GabrielBreachHandler — BreachNotifyPort bridge to K-gabriel [IL-CBS-GABRIEL-BREACH-HANDLER-2026-06-26]

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 if TYPE_CHECKING:
     from src.safeguarding.buffered_audit_port import BufferedAuditPort
 
+    from services.gabriel.breach_handler import GabrielBreachHandler
     from services.recon.recon_engine import ReconciliationEngine
 
 from services.customer.customer_service import InMemoryCustomerService
@@ -231,14 +232,46 @@ def get_crypto_application_service():  # type: ignore[return]
 
 
 @lru_cache(maxsize=1)
+def get_gabriel_breach_handler() -> GabrielBreachHandler:
+    """GabrielBreachHandler singleton — bridges D-recon breaches to K-gabriel DRAFTs.
+
+    D-recon spec §4: wired into ReconciliationEngine.breach_notifier so that every
+    CASS 15 shortfall creates a DRAFT in ReturnsGovernor (I-27: HITL-gated, no
+    autonomous FCA submission).
+
+    GABRIEL_ADAPTER=stub    → InMemoryBreachRegistrar (default, no FCA calls)
+    GABRIEL_ADAPTER=regdata → RegDataGabrielAdapter (production, requires FCA env vars)
+    """
+    from services.gabriel.breach_handler import GabrielBreachHandler, InMemoryBreachRegistrar
+    from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
+    from services.gabriel.returns_governor import ReturnsGovernor
+
+    governor = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+    adapter_name = os.environ.get("GABRIEL_ADAPTER", "stub")
+    if adapter_name == "regdata":
+        from services.gabriel.regdata_gabriel_adapter import RegDataGabrielAdapter
+        from services.recon.fca_regdata_client import FCARegDataClient
+        from services.reporting.regdata_return import LiveRegDataClient, MockFIN060Generator
+
+        registrar = RegDataGabrielAdapter(
+            breach_client=FCARegDataClient(),
+            fin060_client=LiveRegDataClient(),
+            fin060_generator=MockFIN060Generator(),
+        )
+    else:
+        registrar = InMemoryBreachRegistrar()
+    return GabrielBreachHandler(governor=governor, registrar=registrar)
+
+
+@lru_cache(maxsize=1)
 def get_recon_engine() -> ReconciliationEngine:
     """Production ReconciliationEngine with durable audit sink (ADR-027 step 2).
 
     LEDGER_ADAPTER=stub  → StubLedgerAdapter (default, in-memory)
     LEDGER_ADAPTER=midaz → MidazLedgerAdapter (requires MIDAZ_BASE_URL)
 
-    NOTE: ReconciliationEngine (CASS 15) was previously only instantiated in tests.
-    This provider creates the first production wiring per ADR-027 step 2.
+    K-gabriel breach handler is always wired (GABRIEL_ADAPTER=stub|regdata).
+    D-recon spec §4: every CASS 15 shortfall creates a DRAFT in ReturnsGovernor.
     """
     from services.recon.recon_engine import ReconciliationEngine
 
@@ -248,7 +281,11 @@ def get_recon_engine() -> ReconciliationEngine:
     else:
         ledger = StubLedgerAdapter()
 
-    return ReconciliationEngine(ledger=ledger, audit=get_buffered_audit_port())
+    return ReconciliationEngine(
+        ledger=ledger,
+        audit=get_buffered_audit_port(),
+        breach_notifier=get_gabriel_breach_handler(),
+    )
 
 
 # ── ADR-034: Webhook delivery reliability (WebhookReliabilityPort) ───────────

--- a/api/deps.py
+++ b/api/deps.py
@@ -251,12 +251,15 @@ def get_gabriel_breach_handler() -> GabrielBreachHandler:
     if adapter_name == "regdata":
         from services.gabriel.regdata_gabriel_adapter import RegDataGabrielAdapter
         from services.recon.fca_regdata_client import FCARegDataClient
-        from services.reporting.regdata_return import LiveRegDataClient, MockFIN060Generator
+        from services.reporting.regdata_return import (
+            LiveRegDataClient,
+            RealFIN060Generator,
+        )
 
         registrar = RegDataGabrielAdapter(
             breach_client=FCARegDataClient(),
             fin060_client=LiveRegDataClient(),
-            fin060_generator=MockFIN060Generator(),
+            fin060_generator=RealFIN060Generator(),
         )
     else:
         registrar = InMemoryBreachRegistrar()

--- a/api/deps.py
+++ b/api/deps.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from src.safeguarding.buffered_audit_port import BufferedAuditPort
 
     from services.gabriel.breach_handler import GabrielBreachHandler
+    from services.gabriel.returns_governor import ReturnsGovernor
     from services.recon.recon_engine import ReconciliationEngine
 
 from services.customer.customer_service import InMemoryCustomerService
@@ -232,6 +233,20 @@ def get_crypto_application_service():  # type: ignore[return]
 
 
 @lru_cache(maxsize=1)
+def get_gabriel_governor() -> ReturnsGovernor:
+    """Shared ReturnsGovernor singleton — used by both the API layer and GabrielBreachHandler.
+
+    Single instance ensures breach DRAFTs created by ReconciliationEngine via
+    GabrielBreachHandler.notify() are immediately visible to GET /v1/gabriel/returns
+    and POST /v1/gabriel/returns/{id}/approve (HITL gate).
+    """
+    from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
+    from services.gabriel.returns_governor import ReturnsGovernor
+
+    return ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+
+
+@lru_cache(maxsize=1)
 def get_gabriel_breach_handler() -> GabrielBreachHandler:
     """GabrielBreachHandler singleton — bridges D-recon breaches to K-gabriel DRAFTs.
 
@@ -243,10 +258,8 @@ def get_gabriel_breach_handler() -> GabrielBreachHandler:
     GABRIEL_ADAPTER=regdata → RegDataGabrielAdapter (production, requires FCA env vars)
     """
     from services.gabriel.breach_handler import GabrielBreachHandler, InMemoryBreachRegistrar
-    from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
-    from services.gabriel.returns_governor import ReturnsGovernor
 
-    governor = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+    governor = get_gabriel_governor()
     adapter_name = os.environ.get("GABRIEL_ADAPTER", "stub")
     if adapter_name == "regdata":
         from services.gabriel.regdata_gabriel_adapter import RegDataGabrielAdapter

--- a/api/routers/gabriel.py
+++ b/api/routers/gabriel.py
@@ -23,6 +23,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException, status
 
+from api.deps import get_gabriel_governor
 from api.models.gabriel import (
     ApproveRequest,
     CreateDraftRequest,
@@ -32,19 +33,19 @@ from api.models.gabriel import (
 )
 from services.gabriel.gabriel_models import (
     GabrielReturnType,
-    InMemoryGabrielAuditPort,
     InMemoryGabrielSubmissionPort,
     SubmissionRecord,
 )
-from services.gabriel.returns_governor import ReturnsGovernor
 
 logger = logging.getLogger("banxe.api.gabriel")
 
 router = APIRouter(tags=["Gabriel Returns (K-gabriel)"])
 
 # ── Singletons (sandbox InMemory; swap for real adapters in production) ───────
+# _governor shared with GabrielBreachHandler via get_gabriel_governor() so that
+# DRAFTs created by ReconciliationEngine.breach_notifier are visible to the API.
 
-_governor = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+_governor = get_gabriel_governor()
 _submission_port = InMemoryGabrielSubmissionPort()
 
 

--- a/services/gabriel/breach_handler.py
+++ b/services/gabriel/breach_handler.py
@@ -40,6 +40,22 @@ class _ReturnsGovernorPort(Protocol):
     def create_breach_draft(self, breach_event: BreachEvent) -> object: ...
 
 
+# ── Stubs ─────────────────────────────────────────────────────────────────────
+
+
+class InMemoryBreachRegistrar:
+    """Stub BreachRegistrarPort — stores events in memory (no FCA calls).
+
+    Use in sandbox / test composition roots where RegDataGabrielAdapter is not wired.
+    """
+
+    def __init__(self) -> None:
+        self.registered: list[BreachEvent] = []
+
+    def register_breach_event(self, event: BreachEvent) -> None:
+        self.registered.append(event)
+
+
 # ── Handler ───────────────────────────────────────────────────────────────────
 
 

--- a/services/gabriel/breach_handler.py
+++ b/services/gabriel/breach_handler.py
@@ -1,0 +1,99 @@
+"""
+services/gabriel/breach_handler.py
+GabrielBreachHandler — BreachNotifyPort bridge to K-gabriel workflow.
+
+D-recon spec §4: when ReconciliationEngine emits `safeguarding.breach.detected`
+it fires this handler, which:
+  1. Pre-registers the BreachEvent in the adapter (needed for BREACH_REPORT submit)
+  2. Creates a DRAFT SubmissionRecord in ReturnsGovernor (HITL-gated; I-27)
+
+HITL invariant (I-27): this handler only PROPOSES — no FCA submission is ever
+made autonomously. The DRAFT must be approved by MLRO/CFO via ReturnsGovernor.approve().
+
+Fail-open (per BreachNotifyPort spec): exceptions are logged, never raised,
+so a notification failure never breaks the upstream reconciliation audit trail.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+from services.recon.breach_notify_port import BreachEvent
+
+logger = logging.getLogger(__name__)
+
+
+# ── Minimal DI protocols ──────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class BreachRegistrarPort(Protocol):
+    """Minimal port for pre-registering a BreachEvent before BREACH_REPORT submit."""
+
+    def register_breach_event(self, event: BreachEvent) -> None: ...
+
+
+class _ReturnsGovernorPort(Protocol):
+    """Minimal port for creating a breach DRAFT in the governor."""
+
+    def create_breach_draft(self, breach_event: BreachEvent) -> object: ...
+
+
+# ── Handler ───────────────────────────────────────────────────────────────────
+
+
+class GabrielBreachHandler:
+    """Implements BreachNotifyPort — bridges D-recon to K-gabriel (HITL-gated).
+
+    On notify(event):
+      1. Calls registrar.register_breach_event(event) so that if the draft is later
+         approved, RegDataGabrielAdapter can build the FCA BreachRecord payload.
+      2. Calls governor.create_breach_draft(event) to create a DRAFT in the
+         ReturnsGovernor, awaiting HITL approval from MLRO/CFO.
+
+    Errors from either call are logged and swallowed (fail-open), so a governor
+    or adapter failure never aborts the parent reconciliation cycle.
+
+    Args:
+        governor: ReturnsGovernor instance (or any _ReturnsGovernorPort).
+        registrar: Adapter that pre-registers events (BreachRegistrarPort).
+    """
+
+    def __init__(
+        self,
+        governor: _ReturnsGovernorPort,
+        registrar: BreachRegistrarPort,
+    ) -> None:
+        self._governor = governor
+        self._registrar = registrar
+
+    def notify(self, event: BreachEvent) -> None:
+        """Emit safeguarding.breach.detected into K-gabriel workflow.
+
+        Fail-open: logs and returns on any error — never raises.
+        """
+        try:
+            self._registrar.register_breach_event(event)
+        except Exception as exc:
+            logger.error(
+                "GabrielBreachHandler: register_breach_event failed (recon_id=%s): %s",
+                event.recon_id,
+                exc,
+            )
+            return
+
+        try:
+            self._governor.create_breach_draft(event)
+            logger.info(
+                "GabrielBreachHandler: DRAFT created for recon_id=%s shortfall=%s %s",
+                event.recon_id,
+                event.shortfall,
+                event.currency,
+            )
+        except Exception as exc:
+            logger.error(
+                "GabrielBreachHandler: create_breach_draft failed (recon_id=%s): %s",
+                event.recon_id,
+                exc,
+            )

--- a/tests/test_gabriel_breach_handler.py
+++ b/tests/test_gabriel_breach_handler.py
@@ -266,3 +266,28 @@ class TestIntegrationChain:
         submitted = gov.approve(draft.submission_id, "MLRO-Alice", sub_port)
         assert submitted.status == GabrielReturnStatus.SUBMITTED
         assert len(sub_port.submitted) == 1
+
+    def test_shared_governor_draft_visible_via_api_layer(self) -> None:
+        """Regression: shared-state fix — DRAFTs from GabrielBreachHandler must be
+        visible through the same governor instance the API layer uses.
+
+        Simulates the composition root sharing: api/deps.get_gabriel_governor() is
+        used by both GabrielBreachHandler AND the router's _governor.
+        """
+        # Shared governor — mirrors how get_gabriel_governor() wires both sides
+        shared_audit = InMemoryGabrielAuditPort()
+        shared_gov = ReturnsGovernor(audit=shared_audit)
+
+        # Breach handler uses shared_gov (as wired via get_gabriel_breach_handler())
+        reg = _InMemoryRegistrar()
+        handler = GabrielBreachHandler(governor=shared_gov, registrar=reg)
+
+        # Simulate ReconciliationEngine firing a breach event
+        event = _event(recon_id="RECON-SHARED-TEST")
+        handler.notify(event)
+
+        # API layer queries the same shared_gov (as wired via get_gabriel_governor())
+        api_side_records = shared_gov.list_records()
+        assert len(api_side_records) == 1
+        assert api_side_records[0].source_recon_id == "RECON-SHARED-TEST"
+        assert api_side_records[0].status == GabrielReturnStatus.DRAFT

--- a/tests/test_gabriel_breach_handler.py
+++ b/tests/test_gabriel_breach_handler.py
@@ -1,0 +1,268 @@
+"""
+tests/test_gabriel_breach_handler.py
+GabrielBreachHandler tests (IL-CBS-GABRIEL-BREACH-HANDLER-2026-06-26).
+
+Covers:
+  - notify() registers breach event in registrar
+  - notify() creates DRAFT in governor
+  - notify() is idempotent on duplicate recon_id (governor deduplicates)
+  - notify() is fail-open: registrar error → logged, no raise, governor not called
+  - notify() is fail-open: governor error → logged, no raise
+  - notify() records audit trail (via InMemoryGabrielAuditPort)
+  - BreachRegistrarPort structural check (runtime_checkable)
+  - Wiring: ReconEngine + GabrielBreachHandler + ReturnsGovernor integration
+  - InMemoryBreachNotifyPort still works independently (regression guard)
+  - notify() on multiple distinct breaches creates distinct drafts
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from services.gabriel.breach_handler import BreachRegistrarPort, GabrielBreachHandler
+from services.gabriel.gabriel_models import (
+    GabrielReturnStatus,
+    GabrielReturnType,
+    InMemoryGabrielAuditPort,
+    InMemoryGabrielSubmissionPort,
+)
+from services.gabriel.returns_governor import ReturnsGovernor
+from services.recon.breach_notify_port import BreachEvent, InMemoryBreachNotifyPort
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _event(
+    recon_id: str = "RECON-2026-06-25-ABC",
+    shortfall: Decimal = Decimal("1000.00"),
+    currency: str = "GBP",
+    recon_date: str = "2026-06-25",
+) -> BreachEvent:
+    return BreachEvent(
+        event_type="safeguarding.breach.detected",
+        recon_id=recon_id,
+        recon_date=recon_date,
+        currency=currency,
+        client_funds_total=Decimal("50000.00"),
+        safeguarding_total=Decimal("50000.00") - shortfall,
+        shortfall=shortfall,
+        detected_at=datetime.now().isoformat(),
+        requires_approval_from="MLRO",
+    )
+
+
+class _InMemoryRegistrar:
+    """Minimal BreachRegistrarPort stub for unit tests."""
+
+    def __init__(self) -> None:
+        self.registered: list[BreachEvent] = []
+        self.raise_on_register: Exception | None = None
+
+    def register_breach_event(self, event: BreachEvent) -> None:
+        if self.raise_on_register:
+            raise self.raise_on_register
+        self.registered.append(event)
+
+
+class _InMemoryGovernorStub:
+    """Minimal _ReturnsGovernorPort stub for unit tests."""
+
+    def __init__(self) -> None:
+        self.drafts: list[BreachEvent] = []
+        self.raise_on_draft: Exception | None = None
+
+    def create_breach_draft(self, breach_event: BreachEvent) -> None:
+        if self.raise_on_draft:
+            raise self.raise_on_draft
+        self.drafts.append(breach_event)
+
+
+def _handler(
+    governor: _InMemoryGovernorStub | None = None,
+    registrar: _InMemoryRegistrar | None = None,
+) -> tuple[GabrielBreachHandler, _InMemoryGovernorStub, _InMemoryRegistrar]:
+    gov = governor or _InMemoryGovernorStub()
+    reg = registrar or _InMemoryRegistrar()
+    return GabrielBreachHandler(governor=gov, registrar=reg), gov, reg
+
+
+# ── Core notify behaviour ─────────────────────────────────────────────────────
+
+
+class TestNotifyCore:
+    def test_notify_registers_event_in_registrar(self) -> None:
+        handler, _, reg = _handler()
+        event = _event()
+        handler.notify(event)
+        assert len(reg.registered) == 1
+        assert reg.registered[0].recon_id == event.recon_id
+
+    def test_notify_creates_draft_in_governor(self) -> None:
+        handler, gov, _ = _handler()
+        event = _event()
+        handler.notify(event)
+        assert len(gov.drafts) == 1
+        assert gov.drafts[0].recon_id == event.recon_id
+
+    def test_notify_registers_before_governor(self) -> None:
+        """registrar is always called before governor (ordering invariant)."""
+        call_order: list[str] = []
+
+        class _OrdReg:
+            def register_breach_event(self, event: BreachEvent) -> None:
+                call_order.append("registrar")
+
+        class _OrdGov:
+            def create_breach_draft(self, breach_event: BreachEvent) -> None:
+                call_order.append("governor")
+
+        handler = GabrielBreachHandler(governor=_OrdGov(), registrar=_OrdReg())
+        handler.notify(_event())
+        assert call_order == ["registrar", "governor"]
+
+    def test_notify_shortfall_preserved_in_registered_event(self) -> None:
+        handler, _, reg = _handler()
+        event = _event(shortfall=Decimal("12345.67"))
+        handler.notify(event)
+        assert reg.registered[0].shortfall == Decimal("12345.67")
+
+    def test_notify_currency_preserved_in_registered_event(self) -> None:
+        handler, _, reg = _handler()
+        event = _event(currency="EUR")
+        handler.notify(event)
+        assert reg.registered[0].currency == "EUR"
+
+
+# ── Idempotency ───────────────────────────────────────────────────────────────
+
+
+class TestIdempotency:
+    def test_duplicate_notify_stores_two_registrar_entries(self) -> None:
+        """Handler itself doesn't deduplicate — registrar/governor do."""
+        handler, _, reg = _handler()
+        event = _event()
+        handler.notify(event)
+        handler.notify(event)
+        assert len(reg.registered) == 2
+
+    def test_governor_deduplicates_via_real_returns_governor(self) -> None:
+        """ReturnsGovernor.create_breach_draft is idempotent per recon_id."""
+        audit = InMemoryGabrielAuditPort()
+        gov = ReturnsGovernor(audit=audit)
+        reg = _InMemoryRegistrar()
+        handler = GabrielBreachHandler(governor=gov, registrar=reg)
+        event = _event()
+        handler.notify(event)
+        handler.notify(event)
+        # Same idempotency_key → only one record in governor
+        records = gov.list_records()
+        assert len(records) == 1
+
+    def test_distinct_recon_ids_create_distinct_drafts(self) -> None:
+        audit = InMemoryGabrielAuditPort()
+        gov = ReturnsGovernor(audit=audit)
+        reg = _InMemoryRegistrar()
+        handler = GabrielBreachHandler(governor=gov, registrar=reg)
+        handler.notify(_event(recon_id="R-001", recon_date="2026-06-01"))
+        handler.notify(_event(recon_id="R-002", recon_date="2026-06-02"))
+        assert len(gov.list_records()) == 2
+
+
+# ── Fail-open behaviour ───────────────────────────────────────────────────────
+
+
+class TestFailOpen:
+    def test_registrar_error_does_not_raise(self) -> None:
+        handler, gov, reg = _handler()
+        reg.raise_on_register = RuntimeError("registrar boom")
+        # Must not raise
+        handler.notify(_event())
+
+    def test_registrar_error_skips_governor(self) -> None:
+        handler, gov, reg = _handler()
+        reg.raise_on_register = RuntimeError("registrar boom")
+        handler.notify(_event())
+        assert gov.drafts == []  # governor never called
+
+    def test_governor_error_does_not_raise(self) -> None:
+        handler, gov, reg = _handler()
+        gov.raise_on_draft = RuntimeError("governor boom")
+        handler.notify(_event())
+
+    def test_governor_error_still_registers_event(self) -> None:
+        handler, gov, reg = _handler()
+        gov.raise_on_draft = RuntimeError("governor boom")
+        handler.notify(_event())
+        assert len(reg.registered) == 1
+
+
+# ── Protocol structural check ─────────────────────────────────────────────────
+
+
+class TestProtocolCheck:
+    def test_in_memory_registrar_is_breach_registrar_port(self) -> None:
+        reg = _InMemoryRegistrar()
+        assert isinstance(reg, BreachRegistrarPort)
+
+    def test_real_regdata_adapter_is_breach_registrar_port(self) -> None:
+        from services.gabriel.regdata_gabriel_adapter import RegDataGabrielAdapter
+        from services.recon.fca_regdata_client import MockFCARegDataClient
+        from services.reporting.regdata_return import MockFIN060Generator, StubRegDataClient
+
+        adapter = RegDataGabrielAdapter(
+            breach_client=MockFCARegDataClient(),
+            fin060_client=StubRegDataClient(),
+            fin060_generator=MockFIN060Generator(),
+        )
+        assert isinstance(adapter, BreachRegistrarPort)
+
+
+# ── Integration: full D-recon → K-gabriel chain ───────────────────────────────
+
+
+class TestIntegrationChain:
+    def test_breach_draft_status_is_draft(self) -> None:
+        """Draft created by handler should be in DRAFT status (HITL not yet approved)."""
+        audit = InMemoryGabrielAuditPort()
+        gov = ReturnsGovernor(audit=audit)
+        reg = _InMemoryRegistrar()
+        handler = GabrielBreachHandler(governor=gov, registrar=reg)
+        event = _event()
+        handler.notify(event)
+        records = gov.list_records()
+        assert len(records) == 1
+        assert records[0].status == GabrielReturnStatus.DRAFT
+        assert records[0].return_type == GabrielReturnType.BREACH_REPORT
+
+    def test_breach_draft_source_recon_id_matches_event(self) -> None:
+        audit = InMemoryGabrielAuditPort()
+        gov = ReturnsGovernor(audit=audit)
+        reg = _InMemoryRegistrar()
+        handler = GabrielBreachHandler(governor=gov, registrar=reg)
+        event = _event(recon_id="RECON-9999")
+        handler.notify(event)
+        records = gov.list_records()
+        assert records[0].source_recon_id == "RECON-9999"
+
+    def test_inmemory_breach_notify_port_still_works(self) -> None:
+        """Regression: InMemoryBreachNotifyPort unchanged by this change."""
+        port = InMemoryBreachNotifyPort()
+        port.notify(_event())
+        assert len(port.events) == 1
+
+    def test_handler_approve_end_to_end(self) -> None:
+        """Full chain: notify → DRAFT → approve via InMemoryGabrielSubmissionPort."""
+        audit = InMemoryGabrielAuditPort()
+        gov = ReturnsGovernor(audit=audit)
+        sub_port = InMemoryGabrielSubmissionPort()
+        reg = _InMemoryRegistrar()
+        handler = GabrielBreachHandler(governor=gov, registrar=reg)
+        event = _event()
+        handler.notify(event)
+        records = gov.list_records()
+        assert len(records) == 1
+        draft = records[0]
+        submitted = gov.approve(draft.submission_id, "MLRO-Alice", sub_port)
+        assert submitted.status == GabrielReturnStatus.SUBMITTED
+        assert len(sub_port.submitted) == 1

--- a/tests/test_recon_breach_notify.py
+++ b/tests/test_recon_breach_notify.py
@@ -358,8 +358,8 @@ class TestReconToGabrielChain:
         return ReconciliationEngine(ledger=ledger, breach_notifier=handler)
 
     def test_shortfall_creates_draft_in_governor(self) -> None:
-        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
         from services.gabriel.breach_handler import InMemoryBreachRegistrar
+        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
         from services.gabriel.returns_governor import ReturnsGovernor
 
         gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
@@ -370,11 +370,11 @@ class TestReconToGabrielChain:
         assert len(records) == 1
 
     def test_draft_return_type_is_breach_report(self) -> None:
+        from services.gabriel.breach_handler import InMemoryBreachRegistrar
         from services.gabriel.gabriel_models import (
             GabrielReturnType,
             InMemoryGabrielAuditPort,
         )
-        from services.gabriel.breach_handler import InMemoryBreachRegistrar
         from services.gabriel.returns_governor import ReturnsGovernor
 
         gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
@@ -384,11 +384,11 @@ class TestReconToGabrielChain:
         assert gov.list_records()[0].return_type == GabrielReturnType.BREACH_REPORT
 
     def test_draft_status_is_draft(self) -> None:
+        from services.gabriel.breach_handler import InMemoryBreachRegistrar
         from services.gabriel.gabriel_models import (
             GabrielReturnStatus,
             InMemoryGabrielAuditPort,
         )
-        from services.gabriel.breach_handler import InMemoryBreachRegistrar
         from services.gabriel.returns_governor import ReturnsGovernor
 
         gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
@@ -398,8 +398,8 @@ class TestReconToGabrielChain:
         assert gov.list_records()[0].status == GabrielReturnStatus.DRAFT
 
     def test_draft_source_recon_id_set(self) -> None:
-        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
         from services.gabriel.breach_handler import InMemoryBreachRegistrar
+        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
         from services.gabriel.returns_governor import ReturnsGovernor
 
         gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
@@ -411,11 +411,11 @@ class TestReconToGabrielChain:
         assert len(record.source_recon_id) > 0
 
     def test_no_shortfall_no_draft(self) -> None:
-        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
         from services.gabriel.breach_handler import (
             GabrielBreachHandler,
             InMemoryBreachRegistrar,
         )
+        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
         from services.gabriel.returns_governor import ReturnsGovernor
 
         gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
@@ -430,12 +430,12 @@ class TestReconToGabrielChain:
 
     def test_mlro_can_approve_draft(self) -> None:
         """Full HITL path: shortfall → DRAFT → MLRO approves → SUBMITTED (I-27)."""
+        from services.gabriel.breach_handler import InMemoryBreachRegistrar
         from services.gabriel.gabriel_models import (
             GabrielReturnStatus,
             InMemoryGabrielAuditPort,
             InMemoryGabrielSubmissionPort,
         )
-        from services.gabriel.breach_handler import InMemoryBreachRegistrar
         from services.gabriel.returns_governor import ReturnsGovernor
 
         gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
@@ -449,8 +449,8 @@ class TestReconToGabrielChain:
         assert len(sub_port.submitted) == 1
 
     def test_registrar_receives_breach_event(self) -> None:
-        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
         from services.gabriel.breach_handler import InMemoryBreachRegistrar
+        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
         from services.gabriel.returns_governor import ReturnsGovernor
 
         gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())

--- a/tests/test_recon_breach_notify.py
+++ b/tests/test_recon_breach_notify.py
@@ -334,3 +334,128 @@ class TestReconEngineBreachNotify:
         )
         engine.run_daily_recon(RECON_DATE)
         assert port.events[0].requires_approval_from == "MLRO"
+
+
+# ── E2E: ReconciliationEngine → GabrielBreachHandler → ReturnsGovernor ────────
+
+
+class TestReconToGabrielChain:
+    """Full D-recon → K-gabriel chain integration tests.
+
+    Verifies that a CASS 15 shortfall detected by ReconciliationEngine creates a
+    DRAFT SubmissionRecord in ReturnsGovernor via GabrielBreachHandler, and that
+    the MLRO can approve it (I-27 HITL gate).
+    """
+
+    @staticmethod
+    def _shortfall_engine(governor, registrar) -> ReconciliationEngine:
+        from services.gabriel.breach_handler import GabrielBreachHandler
+
+        handler = GabrielBreachHandler(governor=governor, registrar=registrar)
+        ledger = InMemoryLedgerPort()
+        ledger.add_client_fund("CLIENT-001", Decimal("50000.00"))
+        ledger.add_safeguarding("SAFEG-001", Decimal("49000.00"))  # 1 000 shortfall
+        return ReconciliationEngine(ledger=ledger, breach_notifier=handler)
+
+    def test_shortfall_creates_draft_in_governor(self) -> None:
+        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
+        from services.gabriel.breach_handler import InMemoryBreachRegistrar
+        from services.gabriel.returns_governor import ReturnsGovernor
+
+        gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+        reg = InMemoryBreachRegistrar()
+        engine = self._shortfall_engine(gov, reg)
+        engine.run_daily_recon(RECON_DATE)
+        records = gov.list_records()
+        assert len(records) == 1
+
+    def test_draft_return_type_is_breach_report(self) -> None:
+        from services.gabriel.gabriel_models import (
+            GabrielReturnType,
+            InMemoryGabrielAuditPort,
+        )
+        from services.gabriel.breach_handler import InMemoryBreachRegistrar
+        from services.gabriel.returns_governor import ReturnsGovernor
+
+        gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+        reg = InMemoryBreachRegistrar()
+        engine = self._shortfall_engine(gov, reg)
+        engine.run_daily_recon(RECON_DATE)
+        assert gov.list_records()[0].return_type == GabrielReturnType.BREACH_REPORT
+
+    def test_draft_status_is_draft(self) -> None:
+        from services.gabriel.gabriel_models import (
+            GabrielReturnStatus,
+            InMemoryGabrielAuditPort,
+        )
+        from services.gabriel.breach_handler import InMemoryBreachRegistrar
+        from services.gabriel.returns_governor import ReturnsGovernor
+
+        gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+        reg = InMemoryBreachRegistrar()
+        engine = self._shortfall_engine(gov, reg)
+        engine.run_daily_recon(RECON_DATE)
+        assert gov.list_records()[0].status == GabrielReturnStatus.DRAFT
+
+    def test_draft_source_recon_id_set(self) -> None:
+        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
+        from services.gabriel.breach_handler import InMemoryBreachRegistrar
+        from services.gabriel.returns_governor import ReturnsGovernor
+
+        gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+        reg = InMemoryBreachRegistrar()
+        engine = self._shortfall_engine(gov, reg)
+        engine.run_daily_recon(RECON_DATE)
+        record = gov.list_records()[0]
+        assert record.source_recon_id is not None
+        assert len(record.source_recon_id) > 0
+
+    def test_no_shortfall_no_draft(self) -> None:
+        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
+        from services.gabriel.breach_handler import (
+            GabrielBreachHandler,
+            InMemoryBreachRegistrar,
+        )
+        from services.gabriel.returns_governor import ReturnsGovernor
+
+        gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+        reg = InMemoryBreachRegistrar()
+        handler = GabrielBreachHandler(governor=gov, registrar=reg)
+        ledger = InMemoryLedgerPort()
+        ledger.add_client_fund("CLIENT-001", Decimal("50000.00"))
+        ledger.add_safeguarding("SAFEG-001", Decimal("50000.00"))  # balanced
+        engine = ReconciliationEngine(ledger=ledger, breach_notifier=handler)
+        engine.run_daily_recon(RECON_DATE)
+        assert gov.list_records() == []
+
+    def test_mlro_can_approve_draft(self) -> None:
+        """Full HITL path: shortfall → DRAFT → MLRO approves → SUBMITTED (I-27)."""
+        from services.gabriel.gabriel_models import (
+            GabrielReturnStatus,
+            InMemoryGabrielAuditPort,
+            InMemoryGabrielSubmissionPort,
+        )
+        from services.gabriel.breach_handler import InMemoryBreachRegistrar
+        from services.gabriel.returns_governor import ReturnsGovernor
+
+        gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+        reg = InMemoryBreachRegistrar()
+        engine = self._shortfall_engine(gov, reg)
+        engine.run_daily_recon(RECON_DATE)
+        draft = gov.list_records()[0]
+        sub_port = InMemoryGabrielSubmissionPort()
+        submitted = gov.approve(draft.submission_id, "MLRO-TestUser", sub_port)
+        assert submitted.status == GabrielReturnStatus.SUBMITTED
+        assert len(sub_port.submitted) == 1
+
+    def test_registrar_receives_breach_event(self) -> None:
+        from services.gabriel.gabriel_models import InMemoryGabrielAuditPort
+        from services.gabriel.breach_handler import InMemoryBreachRegistrar
+        from services.gabriel.returns_governor import ReturnsGovernor
+
+        gov = ReturnsGovernor(audit=InMemoryGabrielAuditPort())
+        reg = InMemoryBreachRegistrar()
+        engine = self._shortfall_engine(gov, reg)
+        engine.run_daily_recon(RECON_DATE)
+        assert len(reg.registered) == 1
+        assert reg.registered[0].shortfall == Decimal("1000.00")


### PR DESCRIPTION
## Summary

- `GabrielBreachHandler` — BreachNotifyPort bridge: ReconciliationEngine → K-gabriel
- Wire GabrielBreachHandler into ReconciliationEngine composition root
- Fix: use RealFIN060Generator in regdata production mode
- Fix: shared-state governor — DRAFTs from GabrielBreachHandler visible to API
- E2E chain tests: ReconciliationEngine → GabrielBreachHandler → ReturnsGovernor

## IL Reference

IL-CBS-GABRIEL-BREACH-HANDLER-2026-06-26

## Notes

Stacked PR (was #227). Rebased onto main after #228 (API layer) and #229 (RegDataGabrielAdapter) landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)