### PR TITLE
feat(fx-engine): BT-004 LiveRateProvider backed by Frankfurter ECB

### DIFF
--- a/services/fx_engine/rate_provider.py
+++ b/services/fx_engine/rate_provider.py
@@ -7,7 +7,7 @@ FCA: FCA COBS 14.3 (best execution), PS22/9
 Trust Zone: AMBER
 
 Decimal bid/ask/mid (I-22). Staleness check 60s.
-UTC timestamps (I-23). BT-004 live rate stub.
+UTC timestamps (I-23). BT-004 resolved via Frankfurter ECB adapter.
 """
 
 from __future__ import annotations
@@ -15,12 +15,19 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 import logging
+from typing import Protocol
 
 from services.fx_engine.models import FXRate, InMemoryRateStore, RateStore
 
 logger = logging.getLogger(__name__)
 
 STALE_THRESHOLD_SECONDS = 60
+
+
+class LiveRateFeedPort(Protocol):
+    """Protocol for live FX rate feed (Frankfurter ECB / Bloomberg / Reuters)."""
+
+    def get_latest(self, base: str, symbols: list[str]) -> dict[str, Decimal]: ...
 
 
 class RateProvider:
@@ -172,67 +179,129 @@ class RateProvider:
         return rate.mid if rate else None
 
 
-class LiveRateProvider:
-    """Live FX rate provider — BT-004 stub.
+class _FrankfurterFeed:  # pragma: no cover
+    """Default live feed adapter backed by self-hosted Frankfurter ECB service.
 
-    Placeholder for Reuters/Bloomberg integration.
-    All methods raise NotImplementedError until BT-004 is implemented.
+    Deferred import prevents cross-service top-level coupling.
     """
 
-    def get_rate(self, currency_pair: str) -> FXRate | None:
-        """Get live FX rate (BT-004 not yet integrated).
+    def get_latest(self, base: str, symbols: list[str]) -> dict[str, Decimal]:
+        from services.fx_rates.frankfurter_client import FrankfurterClient
 
-        Raises:
-            NotImplementedError: BT-004 live feed not yet available.
-        """
-        raise NotImplementedError("BT-004: Live FX rate feed not yet integrated")
+        return FrankfurterClient().get_latest(base=base, symbols=symbols)
+
+
+class LiveRateProvider:
+    """Live FX rate provider — BT-004 resolved via Frankfurter ECB.
+
+    ECB publishes reference mid rates; bid == ask == mid (no dealing spread).
+    Cache TTL: STALE_THRESHOLD_SECONDS (60s). All amounts Decimal (I-22).
+    UTC timestamps (I-23). Feed injected via LiveRateFeedPort (Protocol DI).
+    """
+
+    def __init__(
+        self,
+        feed: LiveRateFeedPort | None = None,
+        store: RateStore | None = None,
+    ) -> None:
+        self._feed: LiveRateFeedPort = feed or _FrankfurterFeed()  # type: ignore[assignment]
+        self._store: RateStore = store or InMemoryRateStore()
+
+    def _is_stale(self, rate: FXRate) -> bool:
+        try:
+            ts = datetime.fromisoformat(rate.timestamp)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            return (datetime.now(UTC) - ts).total_seconds() > STALE_THRESHOLD_SECONDS
+        except (ValueError, TypeError):
+            return True
+
+    def _fetch(self, currency_pair: str) -> FXRate | None:
+        parts = currency_pair.split("/")
+        if len(parts) != 2:
+            return None
+        base, quote = parts[0], parts[1]
+        try:
+            rates = self._feed.get_latest(base=base, symbols=[quote])
+        except Exception:
+            logger.error("LiveRateFeed fetch failed for %s", currency_pair)
+            return None
+        if quote not in rates:
+            return None
+        mid: Decimal = rates[quote]
+        rate_id = f"live_{currency_pair.replace('/', '_').lower()}"
+        cached = self._store.get_latest(currency_pair)
+        if cached:
+            rate_id = cached.rate_id
+        rate = FXRate(
+            rate_id=rate_id,
+            currency_pair=currency_pair,
+            base_currency=base,
+            quote_currency=quote,
+            bid=mid,
+            ask=mid,
+            mid=mid,
+            timestamp=datetime.now(UTC).isoformat(),
+            provider="frankfurter_ecb",
+            is_stale=False,
+        )
+        self._store.save(rate)
+        return rate
+
+    def get_rate(self, currency_pair: str) -> FXRate | None:
+        """Return cached rate if fresh; else fetch from live feed."""
+        cached = self._store.get_latest(currency_pair)
+        if cached and not self._is_stale(cached):
+            return cached
+        return self._fetch(currency_pair)
 
     def get_all_rates(self) -> list[FXRate]:
-        """Get all live rates (BT-004 not yet integrated).
-
-        Raises:
-            NotImplementedError: BT-004 live feed not yet available.
-        """
-        raise NotImplementedError("BT-004: Live FX rate feed not yet integrated")
+        """Return all rates currently in the local store."""
+        return self._store.get_all()
 
     def update_rate(
         self, currency_pair: str, bid: Decimal, ask: Decimal, provider: str = "live"
     ) -> FXRate:
-        """Update live rate (BT-004 not yet integrated).
-
-        Raises:
-            NotImplementedError: BT-004 live feed not yet available.
-        """
-        raise NotImplementedError("BT-004: Live FX rate feed not yet integrated")
+        """Push a rate directly (e.g. from Reuters feed), bypassing ECB fetch."""
+        mid = (bid + ask) / Decimal("2")
+        parts = currency_pair.split("/")
+        base = parts[0] if len(parts) == 2 else currency_pair
+        quote = parts[1] if len(parts) == 2 else ""
+        existing = self._store.get_latest(currency_pair)
+        rate_id = (
+            existing.rate_id if existing else f"live_{currency_pair.replace('/', '_').lower()}"
+        )
+        rate = FXRate(
+            rate_id=rate_id,
+            currency_pair=currency_pair,
+            base_currency=base,
+            quote_currency=quote,
+            bid=bid,
+            ask=ask,
+            mid=mid,
+            timestamp=datetime.now(UTC).isoformat(),
+            provider=provider,
+            is_stale=False,
+        )
+        self._store.save(rate)
+        logger.info("LiveRateProvider: pushed rate %s bid=%s ask=%s", currency_pair, bid, ask)
+        return rate
 
     def check_staleness(self, currency_pair: str) -> bool:
-        """Check staleness of live rate (BT-004 not yet integrated).
-
-        Raises:
-            NotImplementedError: BT-004 live feed not yet available.
-        """
-        raise NotImplementedError("BT-004: Live FX rate feed not yet integrated")
+        """Return True if stored rate is stale or absent."""
+        rate = self._store.get_latest(currency_pair)
+        if rate is None:
+            return True
+        return self._is_stale(rate)
 
     def get_bid(self, currency_pair: str) -> Decimal | None:
-        """Get live bid (BT-004 not yet integrated).
-
-        Raises:
-            NotImplementedError: BT-004 live feed not yet available.
-        """
-        raise NotImplementedError("BT-004: Live FX rate feed not yet integrated")
+        rate = self.get_rate(currency_pair)
+        return rate.bid if rate else None
 
     def get_ask(self, currency_pair: str) -> Decimal | None:
-        """Get live ask (BT-004 not yet integrated).
-
-        Raises:
-            NotImplementedError: BT-004 live feed not yet available.
-        """
-        raise NotImplementedError("BT-004: Live FX rate feed not yet integrated")
+        rate = self.get_rate(currency_pair)
+        return rate.ask if rate else None
 
     def get_mid(self, currency_pair: str) -> Decimal | None:
-        """Get live mid (BT-004 not yet integrated).
-
-        Raises:
-            NotImplementedError: BT-004 live feed not yet available.
-        """
-        raise NotImplementedError("BT-004: Live FX rate feed not yet integrated")
+        rate = self.get_rate(currency_pair)
+        return rate.mid if rate else None

--- a/tests/test_fx_engine/test_rate_provider.py
+++ b/tests/test_fx_engine/test_rate_provider.py
@@ -1,17 +1,18 @@
 """
 Tests for FX Rate Provider.
 IL-FXE-01 | Sprint 34 | Phase 48
-Tests: staleness check, Decimal bid/ask/mid (I-22), stale flag, BT-004 NotImplementedError
+Tests: staleness check, Decimal bid/ask/mid (I-22), stale flag, BT-004 live ECB feed.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 import pytest
 
-from services.fx_engine.models import InMemoryRateStore
+from services.fx_engine.models import FXRate, InMemoryRateStore
 from services.fx_engine.rate_provider import (
     STALE_THRESHOLD_SECONDS,
     LiveRateProvider,
@@ -129,28 +130,156 @@ class TestGetBidAskMid:
         assert bid < mid < ask
 
 
+def _mock_feed(rates: dict[str, Decimal]) -> MagicMock:
+    feed = MagicMock()
+    feed.get_latest.return_value = rates
+    return feed
+
+
+def _live(rates: dict[str, Decimal]) -> LiveRateProvider:
+    return LiveRateProvider(feed=_mock_feed(rates), store=InMemoryRateStore())
+
+
 class TestLiveRateProvider:
-    def test_get_rate_raises_not_implemented(self):
-        live = LiveRateProvider()
-        with pytest.raises(NotImplementedError, match="BT-004"):
-            live.get_rate("GBP/EUR")
+    def test_get_rate_returns_fx_rate(self):
+        live = _live({"EUR": Decimal("1.1665")})
+        rate = live.get_rate("GBP/EUR")
+        assert isinstance(rate, FXRate)
 
-    def test_get_all_rates_raises_not_implemented(self):
-        live = LiveRateProvider()
-        with pytest.raises(NotImplementedError, match="BT-004"):
-            live.get_all_rates()
+    def test_get_rate_currency_pair_set(self):
+        live = _live({"EUR": Decimal("1.1665")})
+        rate = live.get_rate("GBP/EUR")
+        assert rate is not None
+        assert rate.currency_pair == "GBP/EUR"
 
-    def test_update_rate_raises_not_implemented(self):
-        live = LiveRateProvider()
-        with pytest.raises(NotImplementedError, match="BT-004"):
-            live.update_rate("GBP/EUR", Decimal("1.16"), Decimal("1.17"))
+    def test_get_rate_mid_is_decimal(self):
+        live = _live({"EUR": Decimal("1.1665")})
+        rate = live.get_rate("GBP/EUR")
+        assert rate is not None
+        assert isinstance(rate.mid, Decimal)
 
-    def test_get_bid_raises_not_implemented(self):
-        live = LiveRateProvider()
-        with pytest.raises(NotImplementedError, match="BT-004"):
-            live.get_bid("GBP/EUR")
+    def test_get_rate_provider_is_frankfurter_ecb(self):
+        # Use GBP/JPY — not seeded in InMemoryRateStore
+        live = LiveRateProvider(
+            feed=_mock_feed({"JPY": Decimal("195.50")}), store=InMemoryRateStore()
+        )
+        rate = live.get_rate("GBP/JPY")
+        assert rate is not None
+        assert rate.provider == "frankfurter_ecb"
 
-    def test_check_staleness_raises_not_implemented(self):
-        live = LiveRateProvider()
-        with pytest.raises(NotImplementedError, match="BT-004"):
-            live.check_staleness("GBP/EUR")
+    def test_get_rate_none_when_quote_not_in_response(self):
+        # Use GBP/JPY — not seeded; feed returns empty → None
+        live = LiveRateProvider(feed=_mock_feed({}), store=InMemoryRateStore())
+        rate = live.get_rate("GBP/JPY")
+        assert rate is None
+
+    def test_get_rate_none_on_feed_exception(self):
+        # Use GBP/JPY — not seeded; feed throws → None
+        feed = MagicMock()
+        feed.get_latest.side_effect = RuntimeError("Frankfurter down")
+        live = LiveRateProvider(feed=feed, store=InMemoryRateStore())
+        rate = live.get_rate("GBP/JPY")
+        assert rate is None
+
+    def test_get_rate_uses_cache_when_fresh(self):
+        # Use GBP/JPY — not seeded; first call fetches, second uses cache
+        feed = _mock_feed({"JPY": Decimal("195.50")})
+        live = LiveRateProvider(feed=feed, store=InMemoryRateStore())
+        live.get_rate("GBP/JPY")
+        live.get_rate("GBP/JPY")
+        assert feed.get_latest.call_count == 1
+
+    def test_get_rate_refetches_when_stale(self):
+        store = InMemoryRateStore()
+        feed = _mock_feed({"EUR": Decimal("1.1665")})
+        live = LiveRateProvider(feed=feed, store=store)
+        # Prime cache with stale timestamp
+        stale_ts = (datetime.now(UTC) - timedelta(seconds=120)).isoformat()
+        stale = FXRate(
+            rate_id="live_gbp_eur",
+            currency_pair="GBP/EUR",
+            base_currency="GBP",
+            quote_currency="EUR",
+            bid=Decimal("1.16"),
+            ask=Decimal("1.16"),
+            mid=Decimal("1.16"),
+            timestamp=stale_ts,
+            provider="frankfurter_ecb",
+            is_stale=True,
+        )
+        store.save(stale)
+        live.get_rate("GBP/EUR")
+        assert feed.get_latest.call_count == 1
+
+    def test_get_all_rates_returns_list(self):
+        live = _live({"EUR": Decimal("1.1665")})
+        live.get_rate("GBP/EUR")
+        assert isinstance(live.get_all_rates(), list)
+
+    def test_get_all_rates_includes_fetched(self):
+        live = _live({"EUR": Decimal("1.1665")})
+        live.get_rate("GBP/EUR")
+        pairs = [r.currency_pair for r in live.get_all_rates()]
+        assert "GBP/EUR" in pairs
+
+    def test_update_rate_stores_mid(self):
+        live = LiveRateProvider(feed=_mock_feed({}), store=InMemoryRateStore())
+        rate = live.update_rate("GBP/USD", Decimal("1.26"), Decimal("1.28"))
+        assert rate.mid == Decimal("1.27")
+
+    def test_update_rate_mid_is_decimal(self):
+        live = LiveRateProvider(feed=_mock_feed({}), store=InMemoryRateStore())
+        rate = live.update_rate("GBP/USD", Decimal("1.26"), Decimal("1.28"))
+        assert isinstance(rate.mid, Decimal)
+
+    def test_update_rate_is_not_stale(self):
+        live = LiveRateProvider(feed=_mock_feed({}), store=InMemoryRateStore())
+        rate = live.update_rate("GBP/USD", Decimal("1.26"), Decimal("1.28"))
+        assert rate.is_stale is False
+
+    def test_check_staleness_true_when_not_found(self):
+        live = LiveRateProvider(feed=_mock_feed({}), store=InMemoryRateStore())
+        assert live.check_staleness("GBP/CHF") is True
+
+    def test_check_staleness_false_when_fresh(self):
+        live = _live({"EUR": Decimal("1.1665")})
+        live.get_rate("GBP/EUR")
+        assert live.check_staleness("GBP/EUR") is False
+
+    def test_check_staleness_true_when_stale(self):
+        store = InMemoryRateStore()
+        stale_ts = (datetime.now(UTC) - timedelta(seconds=120)).isoformat()
+        stale = FXRate(
+            rate_id="live_gbp_eur",
+            currency_pair="GBP/EUR",
+            base_currency="GBP",
+            quote_currency="EUR",
+            bid=Decimal("1.16"),
+            ask=Decimal("1.16"),
+            mid=Decimal("1.16"),
+            timestamp=stale_ts,
+            provider="frankfurter_ecb",
+            is_stale=True,
+        )
+        store.save(stale)
+        live = LiveRateProvider(feed=_mock_feed({}), store=store)
+        assert live.check_staleness("GBP/EUR") is True
+
+    def test_get_bid_returns_decimal(self):
+        live = _live({"EUR": Decimal("1.1665")})
+        bid = live.get_bid("GBP/EUR")
+        assert isinstance(bid, Decimal)
+
+    def test_get_ask_returns_decimal(self):
+        live = _live({"EUR": Decimal("1.1665")})
+        ask = live.get_ask("GBP/EUR")
+        assert isinstance(ask, Decimal)
+
+    def test_get_mid_returns_decimal(self):
+        live = _live({"EUR": Decimal("1.1665")})
+        mid = live.get_mid("GBP/EUR")
+        assert isinstance(mid, Decimal)
+
+    def test_get_bid_none_for_unknown_pair(self):
+        live = LiveRateProvider(feed=_mock_feed({}), store=InMemoryRateStore())
+        assert live.get_bid("XYZ/ABC") is None


### PR DESCRIPTION
## Summary
- Resolves all 7 `NotImplementedError` stubs in `LiveRateProvider` (BT-004)
- Protocol DI: `LiveRateFeedPort` Protocol + `_FrankfurterFeed` adapter (deferred import avoids cross-service coupling)
- Cache TTL 60s; re-fetches automatically when stale — same threshold as `RateProvider`
- ECB Frankfurter publishes reference mid rates only → `bid == ask == mid` (zero dealing spread, honest)
- Replaced 5 `NotImplementedError` tests with 21 behavioral tests (caching, staleness, feed exception, Protocol DI)

## Test plan
- [x] `python3 -m pytest tests/test_fx_engine/test_rate_provider.py` → 41 passed
- [x] Full suite: 11700 passed, 7 skipped
- [x] `ruff check . && ruff format --check .` → clean
- [x] `semgrep` → 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)