### PR TITLE
feat(kyb): BT-002 Companies House live adapter — httpx + injectable mock

### DIFF
--- a/services/kyb_onboarding/companies_house_adapter.py
+++ b/services/kyb_onboarding/companies_house_adapter.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from typing import Protocol
+from collections.abc import Callable
+import os
+from typing import Any, Protocol
+
+import httpx
 
 
 class CompaniesHousePort(Protocol):
@@ -60,19 +64,67 @@ class InMemoryCompaniesHouseAdapter:
 
 
 class CompaniesHouseAdapter:
-    """Live API client stub — BT-002 BLOCKED in prod."""
+    """Live Companies House REST API adapter — BT-002 resolved.
 
-    def __init__(self, api_key: str = "PLACEHOLDER_BT002") -> None:
-        self._api_key = api_key
+    Auth: HTTP Basic with COMPANIES_HOUSE_API_KEY env var (empty password).
+    Base: https://api.company-information.service.gov.uk
+    http_get is injectable for testing (defaults to httpx.get in production).
+    """
+
+    _BASE_URL = "https://api.company-information.service.gov.uk"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        http_get: Callable[..., Any] | None = None,
+    ) -> None:
+        self._api_key = api_key or os.environ.get("COMPANIES_HOUSE_API_KEY", "")
+        self._http_get = http_get
+
+    def _do_get(self, path: str) -> dict:
+        fn: Callable[..., Any] = self._http_get or httpx.get  # pragma: no cover
+        response = fn(
+            f"{self._BASE_URL}{path}",
+            auth=(self._api_key, ""),
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
 
     def lookup_company(self, company_number: str) -> dict | None:
-        raise NotImplementedError("BT-002: Companies House live API not yet integrated")
+        try:
+            data = self._do_get(f"/company/{company_number}")
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return None
+            raise
+        return {
+            "name": data.get("company_name"),
+            "status": data.get("company_status"),
+            "type": data.get("type"),
+            "incorporated": data.get("date_of_creation"),
+        }
 
     def verify_officers(self, company_number: str) -> list[dict]:
-        raise NotImplementedError("BT-002: Companies House live API not yet integrated")
+        data = self._do_get(f"/company/{company_number}/officers")
+        return [
+            {"name": item.get("name"), "role": item.get("officer_role")}
+            for item in data.get("items", [])
+        ]
 
     def get_filing_history(self, company_number: str) -> list[dict]:
-        raise NotImplementedError("BT-002: Companies House live API not yet integrated")
+        data = self._do_get(f"/company/{company_number}/filing-history")
+        return [
+            {
+                "date": item.get("date"),
+                "type": item.get("type"),
+                "description": item.get("description"),
+            }
+            for item in data.get("items", [])
+        ]
 
     def check_company_status(self, company_number: str) -> str:
-        raise NotImplementedError("BT-002: Companies House live API not yet integrated")
+        result = self.lookup_company(company_number)
+        if result is None:
+            return "unknown"
+        return result.get("status") or "unknown"

--- a/tests/test_kyb_onboarding/test_companies_house.py
+++ b/tests/test_kyb_onboarding/test_companies_house.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-import pytest
+from unittest.mock import MagicMock
+
+import httpx
 
 from services.kyb_onboarding.companies_house_adapter import (
     SEEDED,
@@ -87,28 +89,126 @@ def test_seeded_has_three_companies():
     assert len(SEEDED) == 3
 
 
-# --- CompaniesHouseAdapter live stub (BT-002) ---
+# --- CompaniesHouseAdapter live (BT-002 resolved) ---
 
 
-def test_live_adapter_lookup_raises_not_implemented():
-    adapter = CompaniesHouseAdapter()
-    with pytest.raises(NotImplementedError, match="BT-002"):
-        adapter.lookup_company("12345678")
+def _ok_http_get(json_body: dict) -> MagicMock:
+    """Return a mock http_get that returns a 200 response with the given body."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = json_body
+    mock_resp.raise_for_status.return_value = None
+    return MagicMock(return_value=mock_resp)
 
 
-def test_live_adapter_verify_officers_raises():
-    adapter = CompaniesHouseAdapter()
-    with pytest.raises(NotImplementedError, match="BT-002"):
-        adapter.verify_officers("12345678")
+def _err_http_get(status_code: int) -> MagicMock:
+    """Return a mock http_get that raises HTTPStatusError."""
+    mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.status_code = status_code
+    error = httpx.HTTPStatusError(
+        f"HTTP {status_code}",
+        request=httpx.Request("GET", "https://api.company-information.service.gov.uk/company/x"),
+        response=mock_resp,
+    )
+    mock = MagicMock()
+    mock.return_value.raise_for_status.side_effect = error
+    return mock
 
 
-def test_live_adapter_filing_history_raises():
-    adapter = CompaniesHouseAdapter()
-    with pytest.raises(NotImplementedError, match="BT-002"):
-        adapter.get_filing_history("12345678")
+def test_live_adapter_lookup_company_returns_dict():
+    adapter = CompaniesHouseAdapter(
+        api_key="test-key",
+        http_get=_ok_http_get(
+            {
+                "company_name": "Banxe Ltd",
+                "company_status": "active",
+                "type": "ltd",
+                "date_of_creation": "2021-03-10",
+            }
+        ),
+    )
+    result = adapter.lookup_company("12345678")
+    assert result is not None
+    assert result["name"] == "Banxe Ltd"
+    assert result["status"] == "active"
+    assert result["type"] == "ltd"
+    assert result["incorporated"] == "2021-03-10"
 
 
-def test_live_adapter_check_status_raises():
-    adapter = CompaniesHouseAdapter()
-    with pytest.raises(NotImplementedError, match="BT-002"):
-        adapter.check_company_status("12345678")
+def test_live_adapter_lookup_company_not_found_returns_none():
+    adapter = CompaniesHouseAdapter(api_key="test-key", http_get=_err_http_get(404))
+    assert adapter.lookup_company("NOTFOUND") is None
+
+
+def test_live_adapter_verify_officers_returns_list():
+    adapter = CompaniesHouseAdapter(
+        api_key="test-key",
+        http_get=_ok_http_get({"items": [{"name": "Jane Director", "officer_role": "director"}]}),
+    )
+    officers = adapter.verify_officers("12345678")
+    assert len(officers) == 1
+    assert officers[0]["name"] == "Jane Director"
+    assert officers[0]["role"] == "director"
+
+
+def test_live_adapter_verify_officers_empty_items():
+    adapter = CompaniesHouseAdapter(api_key="test-key", http_get=_ok_http_get({"items": []}))
+    assert adapter.verify_officers("12345678") == []
+
+
+def test_live_adapter_filing_history_returns_list():
+    adapter = CompaniesHouseAdapter(
+        api_key="test-key",
+        http_get=_ok_http_get(
+            {
+                "items": [
+                    {"date": "2025-01-15", "type": "CS01", "description": "Confirmation statement"}
+                ]
+            }
+        ),
+    )
+    history = adapter.get_filing_history("12345678")
+    assert len(history) == 1
+    assert history[0]["type"] == "CS01"
+    assert history[0]["date"] == "2025-01-15"
+
+
+def test_live_adapter_filing_history_empty():
+    adapter = CompaniesHouseAdapter(api_key="test-key", http_get=_ok_http_get({"items": []}))
+    assert adapter.get_filing_history("12345678") == []
+
+
+def test_live_adapter_check_status_active():
+    adapter = CompaniesHouseAdapter(
+        api_key="test-key",
+        http_get=_ok_http_get({"company_name": "X", "company_status": "active"}),
+    )
+    assert adapter.check_company_status("12345678") == "active"
+
+
+def test_live_adapter_check_status_dissolved():
+    adapter = CompaniesHouseAdapter(
+        api_key="test-key",
+        http_get=_ok_http_get({"company_name": "X", "company_status": "dissolved"}),
+    )
+    assert adapter.check_company_status("12345678") == "dissolved"
+
+
+def test_live_adapter_check_status_not_found_returns_unknown():
+    adapter = CompaniesHouseAdapter(api_key="test-key", http_get=_err_http_get(404))
+    assert adapter.check_company_status("NOTFOUND") == "unknown"
+
+
+def test_live_adapter_uses_auth_header():
+    captured: list[dict] = []
+
+    def capturing_http_get(url: str, **kwargs: object) -> MagicMock:
+        captured.append({"url": url, "auth": kwargs.get("auth")})
+        resp = MagicMock()
+        resp.json.return_value = {"company_name": "X", "company_status": "active"}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    adapter = CompaniesHouseAdapter(api_key="my-secret-key", http_get=capturing_http_get)
+    adapter.lookup_company("12345678")
+    assert captured[0]["auth"] == ("my-secret-key", "")
+    assert "12345678" in captured[0]["url"]


### PR DESCRIPTION
## Summary

- **BT-002 resolved**: `CompaniesHouseAdapter` 4× `NotImplementedError` stubs replaced with working httpx calls
- HTTP Basic auth via `COMPANIES_HOUSE_API_KEY` env var (empty password) — no secrets in code
- `http_get` injectable via constructor → all 4 methods tested without network calls (mock-based)
- `lookup_company` returns `None` on 404 (company not found); re-raises other HTTP errors
- 10 new behavioral tests replace the 4 `raises NotImplementedError` tests (net +6 tests, 22 total)

## Files Changed

- `services/kyb_onboarding/companies_house_adapter.py` — live adapter implementation
- `tests/test_kyb_onboarding/test_companies_house.py` — behavioral tests replacing stubs

## Test plan

- [x] 22 tests pass (`test_companies_house.py`)
- [x] 11691 full suite green, 0 failures
- [x] `ruff check` + `ruff format` clean
- [x] `semgrep banxe-rules` — 0 findings
- [x] No secrets hardcoded (`COMPANIES_HOUSE_API_KEY` from env)
- [x] `Decimal` not applicable (no monetary values here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)