### PR TITLE
feat(fatca): BT-012 submit_to_hmrc_gateway — I-27 HITL proposal

### DIFF
--- a/services/fatca_crs/hmrc_reporter.py
+++ b/services/fatca_crs/hmrc_reporter.py
@@ -5,7 +5,7 @@ Integrates with SelfCertEngine (Phase 55A) to collect certifications.
 I-01: all amounts Decimal strings.
 I-24: ReportLog append-only.
 I-27: generate + submit require CFO + MLRO dual sign-off (L4).
-BT-012: submit_to_hmrc_gateway() raises NotImplementedError.
+BT-012: submit_to_hmrc_gateway() resolved — returns HMRCHITLProposal (I-27 HITL, never auto-submits).
 """
 
 from __future__ import annotations
@@ -72,7 +72,7 @@ class HMRCReporter:
     I-01: all amounts as Decimal strings.
     I-24: report_log is append-only.
     I-27: generation and submission require CFO + MLRO.
-    BT-012: submit_to_hmrc_gateway() raises NotImplementedError.
+    BT-012: submit_to_hmrc_gateway() resolved — returns HMRCHITLProposal (never auto-submits).
     """
 
     def __init__(
@@ -192,12 +192,20 @@ class HMRCReporter:
             errors=errors,
         )
 
-    def submit_to_hmrc_gateway(self, report: HMRCReport) -> HMRCSubmissionResult:
-        """BT-012 stub: HMRC API submission requires registration."""
-        raise NotImplementedError(
-            "BT-012: HMRC Gateway submission not yet implemented. "
-            "Requires HMRC API registration and credentials (P1 item)."
+    def submit_to_hmrc_gateway(self, report: HMRCReport) -> HMRCSubmissionResult | HMRCHITLProposal:
+        """I-27: submission requires CFO + MLRO dual sign-off — returns proposal, never auto-submits.
+
+        BT-012 resolved: live HMRC Gateway integration is P1 (requires API registration).
+        This method always returns a proposal so humans approve before any gateway call.
+        """
+        pid = f"HMRC_SUBMIT_{hashlib.sha256(f'{report.report_id}submit'.encode()).hexdigest()[:8]}"
+        proposal = HMRCHITLProposal(
+            proposal_id=pid,
+            action=f"submit_to_hmrc_gateway_{report.tax_year}",
+            tax_year=report.tax_year,
         )
+        self._proposals.append(proposal)
+        return proposal
 
     @property
     def report_log(self) -> list[dict]:

--- a/tests/test_fatca_crs/test_hmrc_reporter.py
+++ b/tests/test_fatca_crs/test_hmrc_reporter.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-import pytest
-
 from services.fatca_crs.hmrc_models import (
     AccountHolder,
     HMRCReport,
@@ -131,12 +129,36 @@ class TestHMRCReporterGeneration:
         assert "RU" in BLOCKED_JURISDICTIONS
         assert "GB" not in BLOCKED_JURISDICTIONS
 
-    def test_bt012_submit_raises(self):
-        """BT-012: HMRC gateway is a stub."""
+    def test_bt012_submit_returns_hitl_proposal(self):
+        """BT-012 / I-27: submit returns proposal, never auto-submits to HMRC."""
         reporter = _make_reporter()
         report = reporter._do_generate(2025)
-        with pytest.raises(NotImplementedError, match="BT-012"):
-            reporter.submit_to_hmrc_gateway(report)
+        result = reporter.submit_to_hmrc_gateway(report)
+        assert isinstance(result, HMRCHITLProposal)
+
+    def test_bt012_submit_proposal_not_auto_approved(self):
+        """I-27: HMRC submission proposals start unapproved."""
+        reporter = _make_reporter()
+        report = reporter._do_generate(2025)
+        proposal = reporter.submit_to_hmrc_gateway(report)
+        assert isinstance(proposal, HMRCHITLProposal)
+        assert proposal.approved is False
+
+    def test_bt012_submit_proposal_requires_cfo_mlro(self):
+        """I-27: HMRC submission requires CFO + MLRO dual sign-off."""
+        reporter = _make_reporter()
+        report = reporter._do_generate(2025)
+        proposal = reporter.submit_to_hmrc_gateway(report)
+        assert isinstance(proposal, HMRCHITLProposal)
+        assert "CFO" in proposal.requires_approval_from
+        assert "MLRO" in proposal.requires_approval_from
+
+    def test_bt012_submit_appended_to_proposals(self):
+        """Proposal is registered in reporter.proposals (I-24 append)."""
+        reporter = _make_reporter()
+        report = reporter._do_generate(2025)
+        reporter.submit_to_hmrc_gateway(report)
+        assert any("submit" in p.action for p in reporter.proposals)
 
 
 class TestHMRCValidation:


### PR DESCRIPTION
## Summary

- **BT-012 resolved**: `submit_to_hmrc_gateway()` `NotImplementedError` stub replaced with I-27 HITL pattern
- Method now mirrors `generate_annual_report()` — returns `HMRCHITLProposal` requiring CFO + MLRO dual sign-off
- Never auto-submits to HMRC Gateway; humans must approve before any gateway call
- Live HMRC API integration remains P1 (requires HMRC API registration/credentials)
- 4 new behavioral tests replace 1 `raises NotImplementedError` test (net +3)

## Files Changed

- `services/fatca_crs/hmrc_reporter.py` — BT-012 stub → HMRCHITLProposal pattern
- `tests/test_fatca_crs/test_hmrc_reporter.py` — 4 I-27 HITL behavioral tests

## Test plan

- [x] 23 tests pass (`test_hmrc_reporter.py`)
- [x] 11688 full suite green, 0 failures
- [x] `ruff check` + `ruff format` clean
- [x] `semgrep banxe-rules` — 0 findings
- [x] I-27 HITL: proposal not auto-approved, requires CFO + MLRO

🤖 Generated with [Claude Code](https://claude.com/claude-code)