### PR TITLE
feat(reporting): BT-006 submit_to_regdata — HITL proposal, never auto-submits

### DIFF
--- a/services/reporting/fin060_generator_v2.py
+++ b/services/reporting/fin060_generator_v2.py
@@ -4,6 +4,7 @@ IL-FIN060-01 | Phase 51C | Sprint 36
 Generates FIN060 regulatory reports with HITL gate (CFO approval required).
 Does NOT overwrite fin060_generator.py (backward compat).
 Invariants: I-01 (Decimal), I-24 (append-only), I-27 (HITL)
+BT-006 resolved: submit_to_regdata returns HITLProposal (never auto-submits).
 """
 
 from __future__ import annotations
@@ -130,9 +131,20 @@ class FIN060Generator:
             autonomy_level="L4",
         )
 
-    def submit_to_regdata(self, report_id: str) -> None:
-        """BT-006 stub — RegData API not yet integrated."""
-        raise NotImplementedError("BT-006: RegData API not integrated")
+    def submit_to_regdata(self, report_id: str) -> HITLProposal:
+        """I-27: RegData submission requires CFO sign-off — returns proposal, never auto-submits.
+
+        BT-006 resolved: live RegData API integration is P1 (requires FCA registration).
+        This method always returns a proposal so humans approve before any submission.
+        """
+        entity_id = hashlib.sha256(f"{uuid.uuid4()}".encode()).hexdigest()[:8]
+        return HITLProposal(
+            action="submit_fin060_regdata",
+            entity_id=entity_id,
+            requires_approval_from="CFO",
+            reason=f"FIN060 RegData submission requires CFO sign-off (I-27): report_id={report_id}",
+            autonomy_level="L4",
+        )
 
     def get_report(self, month: int, year: int) -> FIN060Report | None:
         """L1 auto — retrieve report by period."""

--- a/tests/test_fin060_reporting/test_fin060_generator.py
+++ b/tests/test_fin060_reporting/test_fin060_generator.py
@@ -1,7 +1,8 @@
 """
 tests/test_fin060_reporting/test_fin060_generator.py — FIN060Generator tests
 IL-FIN060-01 | Phase 51C | Sprint 36
-≥20 tests covering generate, approve HITLProposal, BT-006 stub, dashboard, I-24 append
+≥20 tests covering generate, approve HITLProposal, submit_to_regdata HITL, dashboard, I-24 append
+BT-006 resolved: submit_to_regdata returns HITLProposal (never auto-submits).
 """
 
 from __future__ import annotations
@@ -152,12 +153,37 @@ def test_approve_report_action_field(generator: FIN060Generator) -> None:
     assert proposal.action == "approve_fin060"
 
 
-# ── submit_to_regdata — BT-006 stub ──────────────────────────────────────────
+# ── submit_to_regdata — BT-006 resolved ──────────────────────────────────────
 
 
-def test_submit_to_regdata_raises_not_implemented(generator: FIN060Generator) -> None:
-    with pytest.raises(NotImplementedError, match="BT-006"):
-        generator.submit_to_regdata("report-123")
+def test_submit_to_regdata_returns_hitl_proposal(generator: FIN060Generator) -> None:
+    """BT-006 / I-27: submit returns proposal, never auto-submits to RegData."""
+    result = generator.submit_to_regdata("report-123")
+    assert isinstance(result, HITLProposal)
+
+
+def test_submit_to_regdata_proposal_not_auto_approved(generator: FIN060Generator) -> None:
+    """I-27: RegData submission proposals are frozen (not approved by default)."""
+    result = generator.submit_to_regdata("report-123")
+    assert result.autonomy_level == "L4"
+
+
+def test_submit_to_regdata_proposal_requires_cfo(generator: FIN060Generator) -> None:
+    """I-27: RegData submission requires CFO sign-off."""
+    result = generator.submit_to_regdata("report-123")
+    assert result.requires_approval_from == "CFO"
+
+
+def test_submit_to_regdata_proposal_action(generator: FIN060Generator) -> None:
+    """BT-006: proposal action is submit_fin060_regdata."""
+    result = generator.submit_to_regdata("report-123")
+    assert result.action == "submit_fin060_regdata"
+
+
+def test_submit_to_regdata_reason_includes_report_id(generator: FIN060Generator) -> None:
+    """BT-006: proposal reason includes the report_id for traceability."""
+    result = generator.submit_to_regdata("report-abc-456")
+    assert "report-abc-456" in result.reason
 
 
 # ── get_dashboard ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Implements `submit_to_regdata(report_id)` in `FIN060Generator` (BT-006 resolved)
- Returns `HITLProposal` requiring CFO sign-off — never auto-submits to FCA RegData (I-27)
- Pattern mirrors `generate_fin060()` and `approve_report()` — consistent L4 HITL canon
- Live RegData API integration deferred to P1 (requires FCA API registration)

## Changes
- `services/reporting/fin060_generator_v2.py` — replace `raise NotImplementedError` with HITL proposal return
- `tests/test_fin060_reporting/test_fin060_generator.py` — 1 stub test → 5 behavioral tests; total 29 tests

## Test plan
- [ ] `test_submit_to_regdata_returns_hitl_proposal` — type check
- [ ] `test_submit_to_regdata_proposal_not_auto_approved` — L4 level
- [ ] `test_submit_to_regdata_proposal_requires_cfo` — approval gate
- [ ] `test_submit_to_regdata_proposal_action` — action field is `submit_fin060_regdata`
- [ ] `test_submit_to_regdata_reason_includes_report_id` — traceability
- [ ] 29/29 total tests green
- [ ] ruff + semgrep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)