### PR TITLE
feat(ci): O-11 — advisory quality-gate step (KPI-1/2/4, non-blocking) [IL-CBS-CI-QUALITYGATE-2026-06-26]

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -205,3 +205,46 @@ jobs:
       - name: Run Vitest
         run: npm run test
         continue-on-error: true
+
+  # -- O-11: Advisory quality gates (KPI-1, KPI-2, KPI-4)
+  # O-11: advisory — promote-to-required is operator-gate (not autonomous)
+  # Measures coverage ≥85%, security hotspot, tech-debt proxy.
+  # All steps continue-on-error: true (green main preserved; non-blocking).
+  quality-gate-advisory:
+    name: "Quality Gate (advisory) [O-11]"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: [test, semgrep]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-cov pytest-asyncio semgrep
+      - name: "KPI-1: Coverage ≥ 85% (advisory)"
+        # O-11: advisory — non-blocking until promoted by operator
+        # Current gate is 80% (test job); advisory targets 85% for future.
+        run: |
+          python -m pytest tests/ \
+            --cov=services --cov=api --cov=src \
+            --cov-fail-under=85 \
+            --cov-report=term-missing \
+            -q --tb=no 2>&1 | tail -30
+        continue-on-error: true
+      - name: "KPI-4: Semgrep security hotspot ≥ 95% (advisory)"
+        # O-11: proxy for security-hotspot ≥ 95% — 0 semgrep findings = pass
+        run: |
+          semgrep --config .semgrep/banxe-rules.yml --error --quiet 2>&1 | tail -15
+        continue-on-error: true
+      - name: "KPI-2: Tech-debt proxy (advisory, ⚪ DELEGATED)"
+        # O-11: ruff statistics as tech-debt proxy; replace with SonarQube when configured
+        # Per banxe-architecture/scripts/quality-gate.sh, tech-debt <5% is DELEGATED to project SonarQube
+        run: |
+          echo "⚪ DELEGATED: tech-debt <5% requires SonarQube or equivalent — not yet configured in banxe-emi-stack"
+          echo "  Proxy signal (ruff lint count):"
+          ruff check . --statistics 2>&1 | tail -10 || true
+        continue-on-error: true

--- a/INSTRUCTION-LEDGER.md
+++ b/INSTRUCTION-LEDGER.md
@@ -539,3 +539,23 @@
   returns empty after this errata lands (the collision exists only in the pre-errata
   history; this entry documents and closes it).
 - This errata PR own key: `IL-CBS-LEDGER-ERRATA-DRECON3LEG-2026-06-26` (unique).
+
+### IL-CBS-CI-QUALITYGATE-2026-06-26
+
+**Task:** O-11 — wire quality-gate advisory step into banxe-emi-stack CI
+**Status:** OPEN (pending operator review / promote-to-required)
+**Scope:** `.github/workflows/quality-gate.yml` (advisory job `quality-gate-advisory`, continue-on-error: true)
+**KPIs:**
+  - KPI-1: coverage ≥85% (pytest --cov-fail-under=85, advisory, non-blocking)
+  - KPI-2: tech-debt ⚪ DELEGATED (SonarQube not yet configured; ruff statistics as proxy only)
+  - KPI-4: security hotspot ≥95% (semgrep 0 findings, advisory, non-blocking)
+**Design:** All sub-steps `continue-on-error: true` — green main preserved; non-blocking. Advisory job depends on [test, semgrep] baseline gates (required). Comment in YAML: "promote-to-required is operator-gate".
+**Invariants:** I-27 (HITL), ADR-102 (no duplication — extends existing quality-gate.yml rather than creating new), I-28 (audit trail via IL), I-24 (append-only).
+**Operator gates pending:**
+  - [ ] Promote advisory → required (separate operator decision, not autonomous)
+  - [ ] KPI-2 tech-debt: configure SonarQube or equivalent when ready
+  - [ ] Coverage baseline: confirm 85% threshold is achievable against current test suite
+**Proof:**
+  - YAML parses: ✅
+  - ADR-102: extends existing quality-gate.yml (lines 209–253), no new workflow file ✅
+  - IL key unique: `grep 'IL-CBS-CI-QUALITYGATE-2026-06-26' INSTRUCTION-LEDGER.md | wc -l` = 1 ✅


### PR DESCRIPTION
## O-11 — Quality Gate Advisory Step

Wires repo-local quality-gate KPIs into banxe-emi-stack CI as a **non-blocking advisory job** (`continue-on-error: true`).

### Changes
- `.github/workflows/quality-gate.yml`: new `quality-gate-advisory` job (lines 209–253)
  - **KPI-1:** coverage ≥ 85% (`pytest --cov-fail-under=85`, `continue-on-error: true`)
  - **KPI-4:** security hotspot (`semgrep banxe-rules --error`, `continue-on-error: true`)
  - **KPI-2:** tech-debt proxy (ruff statistics + `⚪ DELEGATED` note, `continue-on-error: true`)
  - All sub-steps `continue-on-error: true` — green main is preserved (non-blocking)
  - Job comment: "promote-to-required is operator-gate"
- `INSTRUCTION-LEDGER.md`: appended `IL-CBS-CI-QUALITYGATE-2026-06-26`

### Advisory-first Design
- Depends on `[test, semgrep]` baseline gates (required)
- No dependent job gates on this advisory job — subsequent jobs proceed regardless
- SonarQube: not required — graceful degradation to advisory-only note

### Operator Gates Pending
- [ ] Promote advisory → required (separate operator decision, not autonomous)
- [ ] KPI-2 tech-debt: configure SonarQube or equivalent when ready
- [ ] Coverage baseline: confirm 85% threshold is achievable against current test suite

### Proof
- ✅ YAML parses: `python3 -c "import yaml; yaml.safe_load(open(...))"`
- ✅ ADR-102: no duplicate quality steps created — extends existing workflow (not new file)
- ✅ IL key unique: `IL-CBS-CI-QUALITYGATE-2026-06-26` appears once in append entry
- ✅ Guardian/semgrep: zero findings
- ✅ Production guards untouched

### Test Plan
1. Merge PR when CI passes
2. PR CI runs new `quality-gate-advisory` job (advisory, continues on fail)
3. Baseline jobs (ruff, test, semgrep) still required; PR blocks if they fail
4. PR merges green

⚠️ **DO NOT AUTO-MERGE** — pending operator review (promote-to-required is a separate operator-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)