### PR TITLE
feat(safeguarding): GAP-087 Step 3 — systemd unit + timer + operator runbook

### DIFF
--- a/deploy/systemd/banxe-recon.service
+++ b/deploy/systemd/banxe-recon.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Banxe CASS 15 Daily Safeguarding Reconciliation
+Documentation=https://github.com/CarmiBanxe/banxe-emi-stack/blob/main/docs/runbooks/banxe-recon-service-activation.md
+After=network.target postgresql.service clickhouse-server.service
+Wants=network.target
+
+[Service]
+Type=oneshot
+# Run as the banxe service account (not root, not the current user)
+User=mmber
+Group=mmber
+WorkingDirectory=/home/mmber/banxe-emi-stack
+# Load secrets and config without hardcoding (CASS 15 compliance, BANXE security rule)
+EnvironmentFile=/home/mmber/banxe-emi-stack/.env
+# Activate venv and run via Python module path (keeps relative imports working)
+ExecStart=/opt/banxe/compliance/venv/bin/python -m services.recon.cron_daily_recon
+# systemd-native output: journal captures both stdout and stderr
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=banxe-recon
+# Restart policy: oneshot timers should NOT auto-restart (timer re-triggers daily)
+Restart=no
+# 10 minute timeout: reconciliation should complete well within this window
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/banxe-recon.timer
+++ b/deploy/systemd/banxe-recon.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Daily CASS 15 Safeguarding Reconciliation Timer (07:00 UTC Mon-Fri)
+Requires=banxe-recon.service
+
+[Timer]
+# Fire at 07:00 UTC Mon-Fri (bank statements available post-overnight batch)
+OnCalendar=Mon-Fri 07:00:00 UTC
+# If system was off at fire time, run when it starts up (within 15 minutes)
+AccuracySec=1min
+Persistent=true
+Unit=banxe-recon.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/runbooks/banxe-recon-service-activation.md
+++ b/docs/runbooks/banxe-recon-service-activation.md
@@ -1,0 +1,117 @@
+# Operator Runbook: banxe-recon Systemd Activation (GAP-087 Step 3)
+
+**Status:** RED-ZONE — factory prepares, operator + HITL activates  
+**FCA:** CASS 15 §7.15, CASS 7.15.29G, PS23/3 §3.49  
+**HITL gate:** CTIO + CFO sign-off required before activation  
+
+---
+
+## Prerequisites
+
+- [ ] GAP-087 Step 1 PR merged (ClickHouseStreakCounter wired)
+- [ ] GAP-087 Step 2 PR merged (N8nFcaBreachNotifier wired)
+- [ ] This PR merged (systemd unit + timer files)
+- [ ] `N8N_FCA_WEBHOOK_URL` set in `/home/mmber/banxe-emi-stack/.env`
+- [ ] Midaz CBS reachable from evo1 (`MIDAZ_BASE_URL`, `MIDAZ_API_KEY` in `.env`)
+- [ ] ClickHouse reachable (`CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`)
+- [ ] n8n FCA breach workflow active and tested
+
+---
+
+## Step 1 — Pre-activation dry run
+
+Run on evo1 as mmber:
+
+```bash
+cd /home/mmber/banxe-emi-stack
+python -m services.recon.cron_daily_recon --dry-run
+```
+
+Expected exit code: `0` (MATCHED) or `2` (PENDING — bank statement not yet received).  
+If exit code `3` (FATAL): stop — fix infrastructure before activating.  
+If exit code `1` (DISCREPANCY): stop — investigate before activating.
+
+---
+
+## Step 2 — Install systemd unit files
+
+```bash
+sudo cp deploy/systemd/banxe-recon.service /etc/systemd/system/
+sudo cp deploy/systemd/banxe-recon.timer   /etc/systemd/system/
+sudo systemd-analyze verify /etc/systemd/system/banxe-recon.service
+sudo systemd-analyze verify /etc/systemd/system/banxe-recon.timer
+```
+
+---
+
+## Step 3 — Enable and test
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable banxe-recon.timer
+sudo systemctl start banxe-recon.timer
+# Verify timer active
+sudo systemctl status banxe-recon.timer
+# One-shot manual trigger to verify service
+sudo systemctl start banxe-recon.service
+sudo systemctl status banxe-recon.service
+sudo journalctl -u banxe-recon.service -n 50
+```
+
+Expected: `Active: inactive (dead)` with `Result: exit-code` 0 (MATCHED) or 2 (PENDING).  
+NOT expected: `failed` status.
+
+---
+
+## Common Failure Modes and Fixes
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| `EnvironmentFile not found` | `.env` missing | Create `/home/mmber/banxe-emi-stack/.env` with required vars |
+| `python: No such file` | Wrong venv path | Verify `/opt/banxe/compliance/venv/bin/python` exists; update `ExecStart=` if different |
+| `ModuleNotFoundError` | Wrong `WorkingDirectory` | Confirm `WorkingDirectory=/home/mmber/banxe-emi-stack` |
+| `Permission denied` | Wrong `User=` | Confirm `mmber` owns the repo; update `User=/Group=` |
+| Exit code `3` (FATAL) | Midaz/ClickHouse unreachable | Check `.env` URLs and network; test with `--dry-run` |
+
+---
+
+## HITL Gate
+
+This activation is CASS 15 production critical. The following **humans** must sign off before enabling the timer:
+
+| Role | Sign-off required |
+|------|-----------------|
+| CTIO | Confirms infra (Midaz, ClickHouse, n8n) are production-ready |
+| CFO  | Confirms FCA notification path tested and MLRO notified |
+
+Do NOT enable the timer without both sign-offs. Log sign-offs in the INSTRUCTION-LEDGER.md.
+
+---
+
+## Post-activation verification
+
+The day after first run, confirm:
+
+```bash
+sudo journalctl -u banxe-recon.service --since yesterday
+# Should show: STATUS=MATCHED or STATUS=PENDING, exit code 0 or 2
+```
+
+Check ClickHouse audit trail:
+
+```sql
+SELECT event_type, entity_id, occurred_at, severity
+FROM banxe.safeguarding_audit
+WHERE toDate(occurred_at) = today() - 1
+AND actor = 'SafeguardingAgent'
+ORDER BY occurred_at DESC
+LIMIT 5;
+```
+
+---
+
+## ADR references
+
+- ADR-013: Midaz as primary CBS (no direct HTTP bypass)
+- ADR-117/Hermes: RED-ZONE — factory prepares, operator activates
+- GAP-087: S-PROD-1 Safeguarding Engine production delivery (ADR-140 Amendment 1)


### PR DESCRIPTION
## GAP-087 Step 3 of 3 — CASS 15 Recon Service Stabilisation

Resolves: banxe-recon.service 'failed' status (was never activated; unit files were missing from repo).

### Root cause of prior failure

systemd service was in 'failed' state because:
- `EnvironmentFile=` not set → secrets/config not loaded → Midaz/ClickHouse connections fail
- `WorkingDirectory=` missing → Python relative imports fail (ModuleNotFoundError)
- `ExecStart=` likely used system Python, not venv → missing dependencies

### What's in this PR

| File | What it does |
|------|-------------|
| `deploy/systemd/banxe-recon.service` | oneshot service: correct EnvironmentFile, WorkingDirectory, User, venv ExecStart |
| `deploy/systemd/banxe-recon.timer` | Mon-Fri 07:00 UTC, Persistent=true (catches missed runs) |
| `docs/runbooks/banxe-recon-service-activation.md` | Operator HITL runbook: dry-run, install, verify, failure modes |

### HITL Gate

Activation requires CTIO + CFO sign-off (see runbook).  
Factory DOES NOT run `systemctl` commands.

### Merge order

Steps 1, 2, and 3 can be merged in any order (Step 3 is independent).  
Merge Steps 1 and 2 before first operator activation.

### RED-ZONE

ADR-117 (Hermes) boundary: factory prepares only.
Operator copies files to `/etc/systemd/system/` after HITL approval.