### PR TITLE
feat(safeguarding): GAP-087 Step 2 — wire N8nFcaBreachNotifier (immutable FCA shortfall path)

### DIFF
--- a/services/recon/cron_daily_recon.py
+++ b/services/recon/cron_daily_recon.py
@@ -105,6 +105,7 @@ def _run_safeguarding_agent(recon_date: date, dry_run: bool) -> int:
         from src.safeguarding.clickhouse_streak_counter import (  # noqa: PLC0415
             ClickHouseStreakCounter,
         )
+        from src.safeguarding.fca_notifier import N8nFcaBreachNotifier  # noqa: PLC0415
         from src.safeguarding.three_leg import InMemoryRailBalancePort  # noqa: PLC0415
 
         from services.recon.safeguarding_adapters import (  # noqa: PLC0415
@@ -126,6 +127,7 @@ def _run_safeguarding_agent(recon_date: date, dry_run: bool) -> int:
             # Leg C rail: starts as InMemoryRailBalancePort (PENDING path).
             # Wire a real RailBalancePort when the payment-rail adapter is ready.
             rail=InMemoryRailBalancePort(),
+            fca_notifier=N8nFcaBreachNotifier() if not dry_run else None,
         )
         agent = SafeguardingAgent(ports, fca_notify=not dry_run)
         result = agent.run(recon_date)

--- a/tests/test_recon/test_safeguarding_adapters.py
+++ b/tests/test_recon/test_safeguarding_adapters.py
@@ -215,6 +215,7 @@ class TestRunSafeguardingAgent:
             m.audit = kwargs.get("audit")
             m.streak_counter = kwargs.get("streak_counter")
             m.rail = kwargs.get("rail")
+            m.fca_notifier = kwargs.get("fca_notifier")
             return m
 
         with (
@@ -234,10 +235,10 @@ class TestRunSafeguardingAgent:
 
         assert isinstance(captured_ports.get("streak_counter"), ClickHouseStreakCounter)
 
-    def test_midaz_leg_a_wired_not_stub(self):
-        """ledger port must be MidazClientFundsPort (real Midaz adapter)."""
+    def test_fca_notifier_is_n8n_in_production(self):
+        """_run_safeguarding_agent must wire N8nFcaBreachNotifier when not dry_run."""
         from services.recon.cron_daily_recon import _run_safeguarding_agent
-        from services.recon.safeguarding_adapters import MidazClientFundsPort as RealPort
+        from src.safeguarding.fca_notifier import N8nFcaBreachNotifier
 
         captured_ports = {}
 
@@ -249,12 +250,44 @@ class TestRunSafeguardingAgent:
             return m
 
         with (
+            patch(self._MIDAZ_PORT),
             patch(self._STMT_PORT),
+            patch(self._STREAK),
             patch(self._SA_AUDIT),
             patch(self._SA_RAIL),
             patch(self._SA_PORTS, side_effect=capture_ports),
             patch(self._SA_AGENT) as mock_agent_cls,
-            patch("services.ledger.midaz_adapter.MidazLedgerAdapter"),
+        ):
+            mock_result = MagicMock()
+            mock_result.exit_code = 0
+            mock_result.status_label = "MATCHED"
+            mock_result.three_leg_result = None
+            mock_agent_cls.return_value.run.return_value = mock_result
+            _run_safeguarding_agent(D, dry_run=False)
+
+        assert isinstance(captured_ports.get("fca_notifier"), N8nFcaBreachNotifier)
+
+    def test_fca_notifier_none_in_dry_run(self):
+        """_run_safeguarding_agent must NOT wire notifier in dry_run (sandbox safety)."""
+        from services.recon.cron_daily_recon import _run_safeguarding_agent
+
+        captured_ports = {}
+
+        def capture_ports(**kwargs):
+            captured_ports.update(kwargs)
+            m = MagicMock()
+            for k, v in kwargs.items():
+                setattr(m, k, v)
+            return m
+
+        with (
+            patch(self._MIDAZ_PORT),
+            patch(self._STMT_PORT),
+            patch(self._STREAK),
+            patch(self._SA_AUDIT),
+            patch(self._SA_RAIL),
+            patch(self._SA_PORTS, side_effect=capture_ports),
+            patch(self._SA_AGENT) as mock_agent_cls,
         ):
             mock_result = MagicMock()
             mock_result.exit_code = 0
@@ -263,4 +296,4 @@ class TestRunSafeguardingAgent:
             mock_agent_cls.return_value.run.return_value = mock_result
             _run_safeguarding_agent(D, dry_run=True)
 
-        assert isinstance(captured_ports.get("ledger"), RealPort)
+        assert captured_ports.get("fca_notifier") is None


### PR DESCRIPTION
## GAP-087 Step 2 of 3 — FCA Shortfall Notification Pipeline

**CASS 7.15.29G:** Breach must be notified to FCA within 1 business day.  
**PS23/3 §3.49:** Enhanced breach notification from 7 May 2026.

### What changed

- `services/recon/cron_daily_recon.py`: Wire `N8nFcaBreachNotifier` as `fca_notifier` in `SafeguardingAgentPorts`
- Production (not dry_run): notifier fires on CRITICAL breach → n8n webhook → MLRO + CEO Telegram/email
- Dry-run / sandbox: `fca_notifier=None` (safe, I-27 gate preserved)
- FCA Connect portal submission remains HITL-only (human CFO step)

### Constraints met

- **I-24**: Audit trail still written before notifier fires (append-only)
- **I-27**: HITL gate preserved — factory proposes, operator+CFO activates and files FCA portal
- **No-suppress**: `BreachDetector.notify_fca()` always fires when `fca_notification_required=True`
- **Immutable path**: shortfall ≥ £0 → CRITICAL → FCA mandatory (hardcoded in BreachDetector)

### Tests added

- `test_fca_notifier_is_n8n_in_production` — verifies N8nFcaBreachNotifier instance wired when not dry_run
- `test_fca_notifier_none_in_dry_run` — verifies None in dry_run (sandbox safety)

### Env var required on evo1

\`\`\`
N8N_FCA_WEBHOOK_URL=<n8n webhook URL>  # operator sets this — NEVER hardcoded
\`\`\`

### Merge order

1. Merge Step 1 (\`gap087step1-streak-wire\`) first (ClickHouseStreakCounter)
2. Merge this PR (Step 2) second
3. Step 3 (\`gap087step3-systemd\`) is independent

### RED-ZONE

Factory DOES NOT activate this. Operator + HITL only.
ADR-117 (Hermes) boundary: no AI write to safeguarding/payment-core production.