### PR TITLE
fix(recon): recon_date must be datetime.date obj for clickhouse-driver (supersedes #252)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,11 @@ secrets/
 .openclaw/skills/SKILL.md
 records/
 tools/
+
+# Accidental editor/tool backups (added 2026-06-27)
+*.bak
+*.bak.*
+.claude/settings.json.bak*
+
+# Stray nested checkout artifacts (added 2026-06-27)
+/banxe-emi-stack

--- a/services/recon/reconciliation_engine.py
+++ b/services/recon/reconciliation_engine.py
@@ -207,12 +207,13 @@ class ReconciliationEngine:
         amounts passed as str → ClickHouse driver casts to Decimal(18,2) correctly.
         """
         # Guard: recon_date may be str (from external sources) or date object (from reconcile())
-        # Normalize to str ISO format for ClickHouse insertion
-        recon_date_str: str
+        # Normalize to datetime.date object for ClickHouse insertion
+        # clickhouse-driver calls .year/.month/.day on Date column values internally
+        recon_date_obj: date
         if isinstance(r.recon_date, str):
-            recon_date_str = r.recon_date
+            recon_date_obj = date.fromisoformat(r.recon_date)
         else:
-            recon_date_str = r.recon_date.isoformat()
+            recon_date_obj = r.recon_date
 
         self._ch.execute(
             """
@@ -223,7 +224,7 @@ class ReconciliationEngine:
             VALUES
             """,
             {
-                "recon_date": recon_date_str,
+                "recon_date": recon_date_obj,
                 "account_id": r.account_id,
                 "account_type": r.account_type,
                 "currency": r.currency,

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -334,7 +334,7 @@ class TestStringDateHandling:
     """
 
     def test_write_to_clickhouse_accepts_string_date(self):
-        """Regression: str recon_date must not crash with AttributeError."""
+        """Regression: str recon_date must be parsed to datetime.date for clickhouse-driver."""
         from dataclasses import replace
 
         engine, ch = make_engine(
@@ -353,12 +353,17 @@ class TestStringDateHandling:
             "Setup: recon_date should be string"
         )
 
-        # This should NOT raise AttributeError: 'str' object has no attribute 'isoformat'
-        # because _write_to_clickhouse guards against it
+        # _write_to_clickhouse must parse str → datetime.date before passing to execute
         engine._write_to_clickhouse(result_with_str_date)
 
-        # Verify the event was captured (without crashing)
+        # Verify the event was captured and recon_date was converted to datetime.date
         assert ch.call_count >= 2  # at least the original 2 + this new write
+        # The params dict passed to execute should have recon_date as a datetime.date object
+        latest_event = ch.events[-1]
+        assert isinstance(latest_event["recon_date"], date), (
+            f"recon_date in params must be datetime.date, got {type(latest_event['recon_date'])}"
+        )
+        assert latest_event["recon_date"] == TEST_DATE
 
     def test_write_to_clickhouse_accepts_date_object(self):
         """Sanity: date objects (normal case) still work."""


### PR DESCRIPTION
## Root cause (confirmed)

`clickhouse-driver` internally calls `.year` on values for `Date`/`DateTime` columns.
PR #252 (merged) normalized `recon_date` to a **string** — wrong direction.
String still crashes with `'str' object has no attribute 'year'`.

The correct fix: normalize to `datetime.date` OBJECT.

## Fix

```python
recon_date_obj: date = (
    date.fromisoformat(r.recon_date)
    if isinstance(r.recon_date, str)
    else r.recon_date
)
```

Pass `recon_date_obj` (a `datetime.date`) to the INSERT params dict.

## Why str breaks, date works

`banxe.safeguarding_events.recon_date` is ClickHouse `Date` type.
`clickhouse-driver` formatter: `value.year, value.month, value.day` → crashes on str.
A `datetime.date` object satisfies `.year/.month/.day` → inserts correctly.

## Tests

- `test_write_to_clickhouse_accepts_string_date` — updated: now asserts params contain `datetime.date`, not str
- `test_write_to_clickhouse_accepts_date_object` — unchanged, still passes

## Supersedes

PR #252 (merged, wrong direction). This is the correct fix.

## Constraints

- I-01: Decimal for money — not touched
- I-24: Audit trail — not modified
- RED-ZONE: factory prepares, operator merges