### PR TITLE
refactor(consumer_duty): rename models_v2.py → models.py (rename-debt cleanup)

### DIFF
--- a/api/routers/consumer_duty_v2.py
+++ b/api/routers/consumer_duty_v2.py
@@ -27,7 +27,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel, field_validator
 
 from services.consumer_duty.consumer_duty_reporter import ConsumerDutyReporter
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     HITLProposal,
     InMemoryOutcomeStore,
     InMemoryProductGovernance,

--- a/services/consumer_duty/__init__.py
+++ b/services/consumer_duty/__init__.py
@@ -23,7 +23,7 @@ from services.consumer_duty.consumer_duty_port import (
 from services.consumer_duty.consumer_duty_reporter import ConsumerDutyReporter
 from services.consumer_duty.consumer_duty_service import ConsumerDutyService
 from services.consumer_duty.consumer_support_tracker import ConsumerSupportTracker
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     AssessmentStatus,
     ConsumerProfile,
     HITLProposal,

--- a/services/consumer_duty/consumer_duty_agent.py
+++ b/services/consumer_duty/consumer_duty_agent.py
@@ -18,7 +18,7 @@ import logging
 
 from services.consumer_duty.consumer_duty_reporter import ConsumerDutyReporter
 from services.consumer_duty.consumer_support_tracker import ConsumerSupportTracker
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     HITLProposal,
     InMemoryOutcomeStore,
     InMemoryProductGovernance,

--- a/services/consumer_duty/consumer_duty_reporter.py
+++ b/services/consumer_duty/consumer_duty_reporter.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 import logging
 
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     AssessmentStatus,
     HITLProposal,
     InMemoryOutcomeStore,

--- a/services/consumer_duty/models.py
+++ b/services/consumer_duty/models.py
@@ -1,5 +1,5 @@
 """
-services/consumer_duty/models_v2.py
+services/consumer_duty/models.py
 Consumer Duty Outcome Monitoring — Domain Models (Phase 50)
 IL-CDO-01 | Phase 50 | Sprint 35
 

--- a/services/consumer_duty/outcome_assessor.py
+++ b/services/consumer_duty/outcome_assessor.py
@@ -19,7 +19,7 @@ from decimal import Decimal
 import hashlib
 import logging
 
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     AssessmentStatus,
     InMemoryOutcomeStore,
     OutcomeAssessment,

--- a/services/consumer_duty/product_governance.py
+++ b/services/consumer_duty/product_governance.py
@@ -19,7 +19,7 @@ from decimal import Decimal
 import hashlib
 import logging
 
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     HITLProposal,
     InMemoryProductGovernance,
     InterventionType,

--- a/services/consumer_duty/vulnerability_detector.py
+++ b/services/consumer_duty/vulnerability_detector.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime
 import hashlib
 import logging
 
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     HITLProposal,
     InMemoryVulnerabilityAlertStore,
     VulnerabilityAlert,

--- a/tests/test_consumer_duty/test_consumer_duty_reporter.py
+++ b/tests/test_consumer_duty/test_consumer_duty_reporter.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 
 from services.consumer_duty.consumer_duty_reporter import ConsumerDutyReporter
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     HITLProposal,
     InMemoryOutcomeStore,
     InMemoryProductGovernance,

--- a/tests/test_consumer_duty/test_models.py
+++ b/tests/test_consumer_duty/test_models.py
@@ -1,5 +1,5 @@
 """
-tests/test_consumer_duty/test_models_v2.py
+tests/test_consumer_duty/test_models.py
 Tests for consumer duty Phase 50 models, frozen dataclasses, Decimal I-01.
 IL-CDO-01 | Phase 50 | Sprint 35
 
@@ -18,7 +18,7 @@ from decimal import Decimal
 
 import pytest
 
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     AssessmentStatus,
     ConsumerProfile,
     HITLProposal,

--- a/tests/test_consumer_duty/test_outcome_assessor.py
+++ b/tests/test_consumer_duty/test_outcome_assessor.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     AssessmentStatus,
     InMemoryOutcomeStore,
     OutcomeType,

--- a/tests/test_consumer_duty/test_product_governance.py
+++ b/tests/test_consumer_duty/test_product_governance.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     HITLProposal,
     InMemoryProductGovernance,
     InterventionType,

--- a/tests/test_consumer_duty/test_vulnerability_detector.py
+++ b/tests/test_consumer_duty/test_vulnerability_detector.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import pytest
 
-from services.consumer_duty.models_v2 import (
+from services.consumer_duty.models import (
     HITLProposal,
     InMemoryVulnerabilityAlertStore,
     VulnerabilityAlert,


### PR DESCRIPTION
Legacy/v2 rationalization batch #1 — **Part A only** (narrow, audit-driven).

**Part A — consumer_duty rename-debt:** `models_v2.py` was the sole implementation (no `models.py`). Renamed → `models.py` (+ `test_models_v2.py`→`test_models.py`, git mv R100), updated all 11 importers. Behavior preserved; 0 remaining `models_v2` refs.

**Part B — payment-legacy: NO removal.** Re-verified all 3 are LIVE/transitively-live (NOT orphan) → PARKED_REVIEW: bifrost (`to_minor_units` ← open_banking ×2), legacy_transactions (`TransactionRecord`→midaz_adapter, `TransactionApplicationError`→shared/errors), legacy_abs_payment (← bifrost intra-legacy, bifrost live).

**NOT touched:** consumer_duty_v2 router (/v1), crypto_legacy router (/v1/crypto-legacy), legacy_sepa, ledger/Neuronext/PAYBIS.
Verified: ruff clean · collect-only exit 0 · 126 consumer_duty tests pass · semgrep banxe-rules exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)