### PR TITLE
docs(gap-register): Add GAP-089 crypto-ledger Wave E deferral

### DIFF
--- a/GAP-REGISTER.md
+++ b/GAP-REGISTER.md
@@ -59,6 +59,7 @@
 | Gap ID | Title | Severity | Owner | Target | Notes |
 |--------|-------|----------|-------|--------|-------|
 | GAP-088 | BT-010 — FCA RegData API key + FCA_FRN + API spec | P0 | CEO/CFO | TBD | FCA CASS 15.12.4R — monthly FIN060 submission by 15th. LiveRegDataClient.submit() fail-closed pending BT-010. Draft mode (FIN060 PDF generation, CFO offline review) works. Code-complete via `feat/gap088-regdata-fail-closed` with typed `RegDataNotConfiguredError` exception. |
+| GAP-089 | Crypto-ledger Midaz production adapter wiring (Wave E) | P3 | CTIO/future team | TBD | S-PROD-3 scope: D-gl (fiat double-entry GL) = DONE (2026-06-20, banxe-emi-stack/services/ledger/); D-crypto deferred to Wave E. Crypto ledger port frozen (PORT-CONTRACTS-FREEZE-2026-05-08, ADR-031 + ADR-025 §15-16). `services/ledger/production/midaz_crypto_stub.py` raises `NotImplementedError` on all network methods (get_balance, create_wallet_address, create_tx, get_fee_estimate, health) with explicit Wave E deferral note in module docstring. Not a P0/P1 blocker for fiat core banking. Implement in dedicated production PR tagged [IL-CRYPTO-PROD-01]. |
 
 ---
 


### PR DESCRIPTION
## S-PROD-3 Status Sync — GAP-089 Crypto-ledger

### Problem

`docs/ROADMAP-STATUS-2026-06-23.md:71` said "D-gl ~5% = largest core gap" — **stale** as of 2026-06-20.
Predates S-PROD-3 fiat core banking completion. Caused confusion about P0 readiness.

### Actual Status (verified 2026-06-27)

**S-PROD-3 Fiat Core Banking: COMPLETE**

| Component | Status | Evidence |
|-----------|--------|---------|
| D-gl (fiat double-entry GL) | **DONE** | banxe-emi-stack/services/ledger/ — gl_service.py, ledger_port.py, midaz_adapter.py, inmemory_ledger.py, test_*.py (unit + integration tests green) |
| D-recon (Reconciliation) | **DONE** | services/recon/ |
| D-fee (Fee Management) | **DONE** | services/fee_management/ |
| D-fin (FIN060 Reporting) | **DONE** | services/reporting/ |
| Crypto-ledger Midaz adapter | **DEFERRED (Wave E, P3)** | services/ledger/production/midaz_crypto_stub.py → `NotImplementedError`; Port frozen (ADR-031, ADR-025 §15-16); explicit future-track |

### Changes Made

1. **banxe-architecture/docs/ROADMAP-STATUS-2026-06-23.md** (line 71–72):
   - Stale line preserved (history non-destructive)
   - Correction block added: D-gl = DONE; crypto = Wave E (P3, not a blocker)

2. **banxe-emi-stack/GAP-REGISTER.md**:
   - **GAP-089 added** — Crypto-ledger Midaz adapter (Wave E, P3, CTIO/future)
   - Code marker: `services/ledger/production/midaz_crypto_stub.py` NotImplementedError
   - Clear Wave E deferral note in module docstring

### Verdict

**Fiat core banking ready for S-PROD-4 (Onboarding) and downstream phases.**
Crypto-ledger: explicit Wave E future-track, not a P0/P1 blocker for 7 May 2026 deadline.

---

🤖 Generated with Claude Code | Docs only, no code changes