### PR TITLE
chore(ruff): fix pre-existing I001 in test_safeguarding_adapters.py (unblock repo-wide Ruff gate)

### DIFF
--- a/tests/test_recon/test_safeguarding_adapters.py
+++ b/tests/test_recon/test_safeguarding_adapters.py
@@ -202,8 +202,9 @@ class TestRunSafeguardingAgent:
 
     def test_clickhouse_streak_counter_wired_not_zero(self):
         """_run_safeguarding_agent must wire ClickHouseStreakCounter (real, not stub)."""
-        from services.recon.cron_daily_recon import _run_safeguarding_agent
         from src.safeguarding.clickhouse_streak_counter import ClickHouseStreakCounter
+
+        from services.recon.cron_daily_recon import _run_safeguarding_agent
 
         captured_ports = {}
 
@@ -237,8 +238,9 @@ class TestRunSafeguardingAgent:
 
     def test_fca_notifier_is_n8n_in_production(self):
         """_run_safeguarding_agent must wire N8nFcaBreachNotifier when not dry_run."""
-        from services.recon.cron_daily_recon import _run_safeguarding_agent
         from src.safeguarding.fca_notifier import N8nFcaBreachNotifier
+
+        from services.recon.cron_daily_recon import _run_safeguarding_agent
 
         captured_ports = {}
 


### PR DESCRIPTION
Single-file, import-sort-only fix to unblock the repo-wide Ruff gate. CI's unpinned `ruff-action@v3` (now 0.15.20, runs `ruff check .`) flags a **pre-existing** I001 (unsorted function-local imports) in `tests/test_recon/test_safeguarding_adapters.py` → RED on every PR. Applied `ruff check --fix --select I` to that one file only: 2 import blocks reordered (import/blank lines only, **zero logic lines**). Verified ruff 0.15.20: `ruff check .` exit 0 (whole repo), format clean, collect-only exit 0, 98 recon tests pass, semgrep banxe-rules exit 0. Ruff version-pinning deferred to a separate governance PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)