### PR TITLE
chore(ci): pin ruff to 0.15.20 across CI + pre-commit (stop unpinned drift)

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -65,11 +65,13 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.20"
           args: "check --output-format=github"
       - name: Ruff format (check only)
         if: needs.changes.outputs.docs_only != 'true'
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.20"
           args: "format --check"
       - name: Docs-only PR — Ruff not required
         if: needs.changes.outputs.docs_only == 'true'

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -75,10 +75,12 @@ jobs:
       - name: Ruff lint (GitHub annotations)
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.20"
           args: "check --output-format=github"
       - name: Ruff format check
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.20"
           args: "format --check"
 
   # -- Frontend: Biome

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
 repos:
   # ── Python: Ruff (upstream) ─────────────────────────────────────────────
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.15.20
     hooks:
       - id: ruff
         name: Ruff lint (Python)


### PR DESCRIPTION
Config/CI-only — pins ruff to the **current** CI version 0.15.20 so floating `ruff-action@v3` can't silently re-block the repo-wide Ruff gate (as it did pre-#257). 4× `version: "0.15.20"` added to the ruff-action steps in lint-python.yml + quality-gate.yml (args preserved); `.pre-commit-config.yaml` ruff rev v0.11.6→v0.15.20. **No source/test change.** Validated: ruff 0.15.20 `check .` exit 0, format clean, YAML parses. Not bumped past 0.15.20 (avoids new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)