### PR TITLE
refactor(shared): de-duplicate to_minor_units into services/shared/money (ADR-102)

### DIFF
--- a/services/open_banking/m24_int_bridge.py
+++ b/services/open_banking/m24_int_bridge.py
@@ -17,24 +17,16 @@ float); I-01: amounts as Decimal upstream.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 from typing import Protocol, runtime_checkable
 
 from api.models.account_sot import SandboxAccountSoT
 
+# to_minor_units now lives in services.shared.money (ADR-102 de-dup); re-exported here so existing
+# `from services.open_banking.m24_int_bridge import to_minor_units` callers keep working.
+from services.shared.money import to_minor_units
+
 SANDBOX_SOURCE = "sandbox-mock"
-
-# ISO 4217 minor-unit exponents (config-as-data; default 2dp).
-_MINOR_UNITS: dict[str, int] = {"EUR": 2, "GBP": 2, "USD": 2, "CHF": 2}
-
-
-def to_minor_units(amount: Decimal, currency: str) -> int:
-    """Convert a Decimal amount to integer minor units (I-05; never float)."""
-    if not isinstance(amount, Decimal):  # I-01: Decimal upstream only
-        raise TypeError("amount must be Decimal")
-    dp = _MINOR_UNITS.get(currency.upper(), 2)
-    scaled = (amount * (Decimal(10) ** dp)).to_integral_value(rounding=ROUND_HALF_UP)
-    return int(scaled)
 
 
 @dataclass(frozen=True)

--- a/services/payment/legacy/bifrost_adapter.py
+++ b/services/payment/legacy/bifrost_adapter.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 import secrets
 
 from services.payment.legacy.legacy_abs_payment_adapter import AbsPaymentStatus
@@ -22,12 +22,10 @@ from services.payment.payment_port import (
     PaymentResult,
     PaymentStatus,
 )
+from services.shared.money import to_minor_units
 
 #: Sandbox guard — Wave-D live GCP transport is NOT wired in this scaffold.
 BIFROST_SANDBOX = True
-
-#: ISO 4217 minor-unit exponents (config-as-data; GBP/EUR = 2dp).
-_MINOR_UNITS: dict[str, int] = {"GBP": 2, "EUR": 2}
 
 #: Bifrost XML status code -> ABS state-machine (consume AbsPaymentStatus; descriptive).
 _BIFROST_TO_ABS: dict[str, AbsPaymentStatus] = {
@@ -47,13 +45,7 @@ _ABS_TO_PAYMENT: dict[AbsPaymentStatus, PaymentStatus] = {
     AbsPaymentStatus.CANCELLED: PaymentStatus.CANCELLED,
 }
 
-
-def to_minor_units(amount: Decimal, currency: str) -> int:
-    """Decimal major units -> int minor units for the XML descriptor (never float)."""
-    if not isinstance(amount, Decimal):  # I-24: Decimal only
-        raise TypeError("amount must be Decimal")
-    dp = _MINOR_UNITS.get(currency.upper(), 2)
-    return int((amount * (Decimal(10) ** dp)).to_integral_value(rounding=ROUND_HALF_UP))
+# to_minor_units now lives in services.shared.money (ADR-102 de-dup) — imported above.
 
 
 @dataclass(frozen=True)

--- a/services/shared/money.py
+++ b/services/shared/money.py
@@ -1,0 +1,29 @@
+"""Shared money utilities — single canonical minor-unit conversion (ADR-102 de-dup).
+
+Canonical home for `to_minor_units`, previously duplicated in
+`services/payment/legacy/bifrost_adapter.py` and `services/open_banking/m24_int_bridge.py`
+(identical logic; differing only in `_MINOR_UNITS` coverage — consolidated to the superset here).
+
+Money invariants:
+  - I-01: amounts are `Decimal` upstream — never `float`.
+  - I-05: minor units are `int` (the smallest currency unit), derived deterministically.
+"""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+# ISO 4217 minor-unit exponents (config-as-data; default 2dp for unlisted currencies).
+_MINOR_UNITS: dict[str, int] = {"EUR": 2, "GBP": 2, "USD": 2, "CHF": 2}
+
+
+def to_minor_units(amount: Decimal, currency: str) -> int:
+    """Convert a Decimal major-unit amount to integer minor units (I-01 in, I-05 out; never float).
+
+    Half-up rounding at the currency's minor-unit precision (default 2dp). Raises `TypeError`
+    if `amount` is not a `Decimal` (Decimal-only upstream, I-01).
+    """
+    if not isinstance(amount, Decimal):  # I-01: Decimal only
+        raise TypeError("amount must be Decimal")
+    dp = _MINOR_UNITS.get(currency.upper(), 2)
+    return int((amount * (Decimal(10) ** dp)).to_integral_value(rounding=ROUND_HALF_UP))

--- a/tests/test_shared_money.py
+++ b/tests/test_shared_money.py
@@ -1,0 +1,42 @@
+"""Unit tests for services.shared.money.to_minor_units (ADR-102 de-dup canonical impl).
+
+Covers: Decimal-only guard (I-01), all configured currencies + unlisted default (2dp),
+and ROUND_HALF_UP behaviour. No pragmas, no network.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.shared.money import to_minor_units
+
+
+@pytest.mark.parametrize(
+    ("amount", "currency", "expected"),
+    [
+        (Decimal("10.00"), "GBP", 1000),
+        (Decimal("10.00"), "EUR", 1000),
+        (Decimal("10.00"), "USD", 1000),
+        (Decimal("10.00"), "CHF", 1000),
+        (Decimal("0"), "GBP", 0),
+        (Decimal("1.005"), "GBP", 101),  # ROUND_HALF_UP at 2dp
+        (Decimal("1.004"), "GBP", 100),
+        (Decimal("99.99"), "eur", 9999),  # case-insensitive currency
+        (Decimal("5.50"), "JPY", 550),  # unlisted → default 2dp
+    ],
+)
+def test_to_minor_units_values(amount, currency, expected):
+    assert to_minor_units(amount, currency) == expected
+
+
+def test_to_minor_units_rejects_non_decimal():
+    """I-01: amount must be Decimal — float/int/str raise TypeError (never float money)."""
+    for bad in (10.0, 10, "10.00"):
+        with pytest.raises(TypeError):
+            to_minor_units(bad, "GBP")  # type: ignore[arg-type]
+
+
+def test_returns_int():
+    assert isinstance(to_minor_units(Decimal("1.23"), "USD"), int)


### PR DESCRIPTION
ADR-102 de-dup: `to_minor_units` was duplicated (identical logic) in `payment/legacy/bifrost_adapter.py` + `open_banking/m24_int_bridge.py`. Consolidated into **one** canonical `services/shared/money.py` (superset table {EUR,GBP,USD,CHF}=2dp = both callers' behavior; Decimal-only guard + ROUND_HALF_UP preserved). Both local defs removed; both files now import from shared (m24 re-exports for `intl_scheduled` back-compat). **bifrost FILE stays** (Wave-D scaffold, ADR-025 §15-16) — only its import source changed. New `tests/test_shared_money.py`. Verified: ruff 0.15.20 `check .` exit 0, bifrost char-tests + money = 18 passed, open_banking = 123 passed, collect-only exit 0, semgrep exit 0. Behavior-preserving; no RAR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)