### PR TITLE
chore(semgrep): add banxe-no-bittrex-reintroduction guard

### DIFF
--- a/.semgrep/banxe-rules.yml
+++ b/.semgrep/banxe-rules.yml
@@ -206,3 +206,24 @@ rules:
         - "**/tests/**"
         - "**/docs/**"
         - "**/.semgrep/**"
+
+  # NOTE: distinct from banxe-no-bitrix-reintroduction above — that guards Bitrix (CMS, "битрикс");
+  # this guards Bittrex (the retired crypto exchange). The bitrix regex does NOT match "bittrex".
+  - id: banxe-no-bittrex-reintroduction
+    pattern-regex: '(?i)bittrex'
+    message: |
+      Bittrex must not be reintroduced. PAYBIS is the sole external crypto provider.
+      Bittrex is fully removed from EMI; rollback must never re-route to Bittrex.
+    languages: [generic]
+    severity: ERROR
+    paths:
+      include:
+        - "**/services/**"
+        - "**/app/**"
+        - "**/src/**"
+        - "**/api/**"
+        - "**/config/**"
+      exclude:
+        - "**/tests/**"
+        - "**/docs/**"
+        - "**/.semgrep/**"


### PR DESCRIPTION
## Summary
HEAD `3f418d1`: repo-wide `git grep -il bittrex` = **0** — Bittrex is already fully absent from EMI. But the forward-guard was **missing**: `banxe-no-bitrix-reintroduction` guards **Bitrix** (CMS / `битрикс`) and does **not** match **Bittrex** (the crypto exchange) — verified `re.search(r'(?i)(bitrix|битрикс)','bittrex')` → False.

## New rule
- `id: banxe-no-bittrex-reintroduction` · `pattern-regex: '(?i)bittrex'` · `languages: [generic]` · `severity: ERROR`.
- `paths.include`: `services/** app/** src/** api/** config/**`; `exclude`: `tests/** docs/** .semgrep/**` (educational/historical refs in docs/tests not flagged).
- Mirrors the existing `banxe-no-{bitrix,neuronext}-reintroduction` guards; **does not duplicate or weaken** them (ADR-102 dup-audit: no existing bittrex rule; distinct semantics from the bitrix rule).

## Verification (read-only / local, no network)
YAML parses (16 rules, no dup ids); `semgrep --config .semgrep/banxe-rules.yml --error` = **0 findings** on HEAD; positive self-test = rule **fires** (1 blocking) on a `Bittrex` token under `services/`.

**Sandbox-only change; no runtime logic affected.** CI semgrep gate will now fail on any future Bittrex reintroduction. **Ready for review — DO NOT MERGE (operator decides, §71).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)