### PR TITLE
feat(payment): SEPA scheme validation on live Modulr rail (ADR-102 de-dup)

### DIFF
--- a/services/payment/legacy/legacy_sepa_adapter.py
+++ b/services/payment/legacy/legacy_sepa_adapter.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 from enum import Enum
-import re
 import secrets
 from typing import Literal
 
@@ -44,35 +43,27 @@ from services.payment.payment_port import (
     PaymentResult,
     PaymentStatus,
 )
+from services.payment.sepa_validation import (
+    SCT_INSTANT_MAX_EUR,
+    validate_bic,
+    validate_iban,
+)
 from services.shared.errors import BanxeLegacyAdapterError
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 _SEPA_RAILS: frozenset[PaymentRail] = frozenset({PaymentRail.SEPA_CT, PaymentRail.SEPA_INSTANT})
-_SCT_INST_MAX_EUR: Decimal = Decimal("100000.00")
 _SEPA_REFERENCE_MAX_LEN: int = 140
 _CREDITOR_NAME_MAX_LEN: int = 70
 
 _SepaEventType = Literal["CREATED", "SUBMITTED", "SETTLED", "REJECTED", "CANCELLED"]
 
-
 # ── Validation helpers ────────────────────────────────────────────────────────
-
-
-def _validate_iban(iban: str) -> bool:
-    """Return True if IBAN passes ISO 13616 mod-97 check."""
-    clean = iban.replace(" ", "").upper()
-    if not re.fullmatch(r"[A-Z]{2}\d{2}[A-Z0-9]{10,30}", clean):
-        return False
-    rearranged = clean[4:] + clean[:4]
-    numeric = "".join(str(ord(c) - 55) if c.isalpha() else c for c in rearranged)
-    return int(numeric) % 97 == 1
-
-
-def _validate_bic(bic: str) -> bool:
-    """Return True if BIC matches SWIFT/RFC-9362 (8 or 11 chars)."""
-    clean = bic.strip().upper()
-    return bool(re.fullmatch(r"[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?", clean))
+# Canonical source is services.payment.sepa_validation (ADR-102 single source of truth).
+# Back-compat aliases below preserve existing `_validate_*` / `_SCT_INST_MAX_EUR` references.
+_validate_iban = validate_iban
+_validate_bic = validate_bic
+_SCT_INST_MAX_EUR = SCT_INSTANT_MAX_EUR
 
 
 # ── State machine ─────────────────────────────────────────────────────────────

--- a/services/payment/modulr_client.py
+++ b/services/payment/modulr_client.py
@@ -46,6 +46,12 @@ from services.payment.payment_port import (
     PaymentStatus,
     PaymentStatusUpdate,
 )
+from services.payment.sepa_validation import (
+    SCT_INSTANT_MAX_EUR,
+    exceeds_sct_instant_cap,
+    validate_bic,
+    validate_iban,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +109,10 @@ class ModulrPaymentAdapter:
         Returns PaymentResult immediately (status = PROCESSING).
         Final status arrives via webhook.
         """
+        if intent.rail in (PaymentRail.SEPA_CT, PaymentRail.SEPA_INSTANT):
+            rejected = self._validate_sepa(intent)
+            if rejected is not None:
+                return rejected
         source_account_id = self._resolve_source_account(intent)
         payload = self._build_payment_payload(intent)
 
@@ -143,6 +153,41 @@ class ModulrPaymentAdapter:
             amount=intent.amount,
             currency=intent.currency,
             submitted_at=datetime.now(UTC),
+        )
+
+    def _validate_sepa(self, intent: PaymentIntent) -> PaymentResult | None:
+        """SEPA scheme input-validation (ADR-102 shared validators) — pure, no network.
+
+        Returns a FAILED PaymentResult (rejected before any API call) on a bad IBAN/BIC or an
+        over-cap SCT Instant; None when the SEPA input is valid. FPS/Bacs are not routed here.
+        """
+        dest = intent.creditor_account
+        iban = dest.iban or ""
+        bic = dest.bic or ""
+        error_code: str | None = None
+        error_message = ""
+        if not validate_iban(iban):
+            error_code, error_message = "invalid_iban", f"Invalid IBAN: {iban!r}"
+        elif bic and not validate_bic(bic):
+            error_code, error_message = "invalid_bic", f"Invalid BIC: {bic!r}"
+        elif exceeds_sct_instant_cap(
+            intent.amount, is_instant=intent.rail == PaymentRail.SEPA_INSTANT
+        ):
+            error_code = "amount_exceeds_sct_inst_max"
+            error_message = f"SEPA Instant max €{SCT_INSTANT_MAX_EUR}, got €{intent.amount}"
+        if error_code is None:
+            return None
+        logger.warning("ModulrAdapter SEPA validation rejected payment: %s", error_message)
+        return PaymentResult(
+            idempotency_key=intent.idempotency_key,
+            provider_payment_id="",
+            status=PaymentStatus.FAILED,
+            rail=intent.rail,
+            amount=intent.amount,
+            currency=intent.currency,
+            submitted_at=datetime.now(UTC),
+            error_code=error_code,
+            error_message=error_message,
         )
 
     def get_payment_status(self, provider_payment_id: str) -> PaymentResult:

--- a/services/payment/production/modulr_sepa_adapter.py
+++ b/services/payment/production/modulr_sepa_adapter.py
@@ -27,19 +27,23 @@ from typing import Any
 
 import httpx
 
-from services.payment.legacy.legacy_sepa_adapter import (
-    _validate_bic,
-    _validate_iban,
-)
 from services.payment.payment_port import (
     PaymentIntent,
     PaymentRail,
     PaymentResult,
     PaymentStatus,
 )
+from services.payment.sepa_validation import (
+    SCT_INSTANT_MAX_EUR as _SCT_INST_MAX_EUR,
+)
+from services.payment.sepa_validation import (
+    validate_bic as _validate_bic,
+)
+from services.payment.sepa_validation import (
+    validate_iban as _validate_iban,
+)
 
 _SEPA_RAILS: frozenset[PaymentRail] = frozenset({PaymentRail.SEPA_CT, PaymentRail.SEPA_INSTANT})
-_SCT_INST_MAX_EUR: Decimal = Decimal("100000.00")
 _SANDBOX_BASE_URL: str = "https://api-sandbox.modulrfinance.com"
 _PROD_BASE_URL: str = "https://api.modulrfinance.com"
 

--- a/services/payment/sepa_validation.py
+++ b/services/payment/sepa_validation.py
@@ -1,0 +1,45 @@
+"""SEPA scheme-compliance validators — single source of truth (ADR-102).
+
+Pure input validation: no network, no secrets, no side effects. Consumed by the live Modulr
+rail (`ModulrPaymentAdapter`) and the SEPA adapters. Previously these lived in
+`services/payment/legacy/legacy_sepa_adapter.py` (a legacy module) and were partially duplicated;
+consolidated here so production code no longer imports validation from a legacy adapter.
+
+References:
+  - IBAN: ISO 13616 — mod-97 check digit (EPC SCT / SCT Inst rulebooks).
+  - BIC:  ISO 9362 — SWIFT format (8 or 11 chars).
+  - SCT Instant value cap: EPC SCT Inst rulebook — €100,000 per transaction.
+
+I-01: monetary values are Decimal (never float).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import re
+
+#: EPC SCT Instant per-transaction value cap (EUR).
+SCT_INSTANT_MAX_EUR: Decimal = Decimal("100000.00")
+
+_IBAN_RE = re.compile(r"[A-Z]{2}\d{2}[A-Z0-9]{10,30}")
+_BIC_RE = re.compile(r"[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?")
+
+
+def validate_iban(iban: str) -> bool:
+    """Return True iff `iban` passes the ISO 13616 mod-97 check (whitespace-insensitive)."""
+    clean = iban.replace(" ", "").upper()
+    if not _IBAN_RE.fullmatch(clean):
+        return False
+    rearranged = clean[4:] + clean[:4]
+    numeric = "".join(str(ord(c) - 55) if c.isalpha() else c for c in rearranged)
+    return int(numeric) % 97 == 1
+
+
+def validate_bic(bic: str) -> bool:
+    """Return True iff `bic` matches ISO 9362 / SWIFT format (8 or 11 chars)."""
+    return bool(_BIC_RE.fullmatch(bic.strip().upper()))
+
+
+def exceeds_sct_instant_cap(amount: Decimal, *, is_instant: bool) -> bool:
+    """Return True iff `amount` exceeds the SCT Instant €100k cap (only when `is_instant`)."""
+    return is_instant and amount > SCT_INSTANT_MAX_EUR

--- a/tests/test_modulr_payment_adapter_sepa.py
+++ b/tests/test_modulr_payment_adapter_sepa.py
@@ -1,0 +1,75 @@
+"""SEPA input-validation tests for the LIVE Modulr rail (ModulrPaymentAdapter).
+
+Validation runs BEFORE any network call, so invalid SEPA input returns a FAILED PaymentResult
+with no HTTP request. No live API calls; no secrets.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from services.payment.modulr_client import ModulrPaymentAdapter
+from services.payment.payment_port import (
+    BankAccount,
+    PaymentDirection,
+    PaymentIntent,
+    PaymentRail,
+    PaymentStatus,
+)
+
+
+def _intent(
+    *,
+    rail: PaymentRail = PaymentRail.SEPA_CT,
+    iban: str = "DE89370400440532013000",
+    bic: str = "DEUTDEFF",
+    amount: str = "100.00",
+) -> PaymentIntent:
+    return PaymentIntent(
+        idempotency_key="idem-1",
+        rail=rail,
+        direction=PaymentDirection.OUTBOUND,
+        amount=Decimal(amount),
+        currency="EUR",
+        debtor_account=BankAccount(account_holder_name="Banxe EUR", iban="DE89370400440532013000"),
+        creditor_account=BankAccount(account_holder_name="Jane Doe", iban=iban, bic=bic),
+        reference="ref",
+        end_to_end_id="e2e-1",
+        requested_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def adapter() -> ModulrPaymentAdapter:
+    return ModulrPaymentAdapter()
+
+
+def test_sepa_invalid_iban_rejected_before_network(adapter: ModulrPaymentAdapter) -> None:
+    result = adapter.submit_payment(_intent(iban="DE00INVALID0000000000"))
+    assert result.status is PaymentStatus.FAILED
+    assert result.error_code == "invalid_iban"
+    assert result.provider_payment_id == ""
+
+
+def test_sepa_invalid_bic_rejected(adapter: ModulrPaymentAdapter) -> None:
+    result = adapter.submit_payment(_intent(bic="BAD"))
+    assert result.status is PaymentStatus.FAILED
+    assert result.error_code == "invalid_bic"
+
+
+def test_sepa_instant_over_cap_rejected(adapter: ModulrPaymentAdapter) -> None:
+    result = adapter.submit_payment(_intent(rail=PaymentRail.SEPA_INSTANT, amount="100000.01"))
+    assert result.status is PaymentStatus.FAILED
+    assert result.error_code == "amount_exceeds_sct_inst_max"
+
+
+def test_valid_sepa_input_passes_validation_gate(adapter: ModulrPaymentAdapter) -> None:
+    # SCT (non-instant) has no €100k cap and the IBAN/BIC are valid → the validation gate
+    # returns None (would proceed to the network call, which we do not exercise here).
+    assert adapter._validate_sepa(_intent(rail=PaymentRail.SEPA_CT, amount="250000.00")) is None
+    assert (
+        adapter._validate_sepa(_intent(rail=PaymentRail.SEPA_INSTANT, amount="100000.00")) is None
+    )

--- a/tests/test_sepa_validation.py
+++ b/tests/test_sepa_validation.py
@@ -1,0 +1,72 @@
+"""Unit tests for services.payment.sepa_validation (ADR-102 single source of truth).
+
+Pure validators — no network. Covers IBAN mod-97, BIC SWIFT format, SCT Instant €100k cap.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from services.payment.sepa_validation import (
+    SCT_INSTANT_MAX_EUR,
+    exceeds_sct_instant_cap,
+    validate_bic,
+    validate_iban,
+)
+
+
+@pytest.mark.parametrize(
+    "iban",
+    [
+        "DE89370400440532013000",  # valid DE
+        "GB29NWBK60161331926819",  # valid GB
+        "FR1420041010050500013M02606",  # valid FR (alpha in BBAN)
+        "de89 3704 0044 0532 0130 00",  # lowercase + spaces tolerated
+    ],
+)
+def test_validate_iban_accepts_valid(iban):
+    assert validate_iban(iban) is True
+
+
+@pytest.mark.parametrize(
+    "iban",
+    [
+        "DE89370400440532013001",  # wrong check digits
+        "XX00",  # too short / bad format
+        "GB29NWBK6016133192681",  # one digit short
+        "",  # empty
+        "1234567890",  # no country code
+    ],
+)
+def test_validate_iban_rejects_invalid(iban):
+    assert validate_iban(iban) is False
+
+
+@pytest.mark.parametrize("bic", ["NWBKGB2L", "NWBKGB2LXXX", "deutdeff", "DEUTDEFF500"])
+def test_validate_bic_accepts_valid(bic):
+    assert validate_bic(bic) is True
+
+
+@pytest.mark.parametrize("bic", ["NWBK", "NWBKGB2", "NWBKGB2LXX", "12BKGB2L", ""])
+def test_validate_bic_rejects_invalid(bic):
+    assert validate_bic(bic) is False
+
+
+def test_sct_instant_cap_value():
+    assert Decimal("100000.00") == SCT_INSTANT_MAX_EUR
+
+
+@pytest.mark.parametrize(
+    ("amount", "is_instant", "expected"),
+    [
+        (Decimal("100000.00"), True, False),  # exactly at cap → allowed
+        (Decimal("100000.01"), True, True),  # over cap → exceeds
+        (Decimal("250000.00"), True, True),  # well over → exceeds
+        (Decimal("250000.00"), False, False),  # SCT (non-instant) → cap does not apply
+        (Decimal("0.01"), True, False),  # tiny instant → fine
+    ],
+)
+def test_exceeds_sct_instant_cap(amount, is_instant, expected):
+    assert exceeds_sct_instant_cap(amount, is_instant=is_instant) is expected


### PR DESCRIPTION
## Verified gap
The wired SEPA rail — `ModulrPaymentAdapter` (`PAYMENT_ADAPTER=modulr` → `/v1/payments`) — accepted SEPA payments with **no** IBAN mod-97, **no** BIC regex, **no** SCT Instant €100k cap. Those validations existed only in the **unwired** `ModulrSepaAdapter` (which imported them from `legacy_sepa_adapter`). ADR-102 audit on EMI `4f93870`.

## Change (validation-only; no live network behavior changed)
- **New `services/payment/sepa_validation.py`** = single source of truth: `validate_iban` (ISO 13616 mod-97), `validate_bic` (ISO 9362), `SCT_INSTANT_MAX_EUR` + `exceeds_sct_instant_cap`. Pure functions — no network, no secrets.
- **`ModulrPaymentAdapter._validate_sepa()`** runs **before** any API call on `SEPA_CT`/`SEPA_INSTANT`: rejects bad IBAN/BIC + over-cap SCT Instant → FAILED `PaymentResult` (no HTTP). FPS/Bacs untouched. Live submission stays gated on Wave C + `MODULR_API_KEY`.
- **ADR-102 de-dup:** `legacy_sepa_adapter.py` + `modulr_sepa_adapter.py` now import the validators from `sepa_validation` (legacy keeps back-compat `_validate_*`/`_SCT_INST_MAX_EUR` aliases). The **duplicated `_SCT_INST_MAX_EUR` constant is removed** → defined once. Production no longer imports validation from a legacy module.

## Tests
- `tests/test_sepa_validation.py` — validators (valid/invalid IBAN, BIC, SCT cap at/over/under).
- `tests/test_modulr_payment_adapter_sepa.py` — live rail rejects bad IBAN/BIC + over-cap SCT Instant **before network**; valid input passes the gate.

## Gates (all GREEN, local)
ruff 0.15.20 `check .` + `format --check .` clean · semgrep banxe-rules exit 0 · pytest **cov 91.96% (≥80)** · 168 targeted + full suite green.

## Scope / safety
FROZEN `PaymentRailPort` contract **unchanged**. The `health_check → health` conformance fix is **DEFERRED** to a separate one-line PR (flagged). No live Twilio/Modulr calls; no secrets; no BANXE.RAR. **DO NOT MERGE** — operator decides (§71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
